### PR TITLE
Add clarification for active_stake

### DIFF
--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -295,7 +295,8 @@ schemas:
             example: 8
           active_stake:
             type: string
-            description: Pool active stake
+            nullable: true
+            description: Pool active stake (will be null post epoch transition until dbsync calculation is complete)
             example: "64328627680963"
           block_count:
             type: integer

--- a/topology/topology-testnet.json
+++ b/topology/topology-testnet.json
@@ -3,7 +3,7 @@
     {"name":"olassl","addr":"koios-testnet.ahlnet.nu","port":2155,"ssl":"true"},
     {"name":"damjan","addr":"195.201.129.190","port":8053},
     {"name":"homer","addr":"95.216.173.194","port":8053},
-    {"name":"rdlrt","addr":"89.58.43.194","port":8453},
+    {"name":"rdlrt","addr":"89.58.43.194","port":8053},
     {"name":"HuthS0lo1-ssl","dbsync-testnet1.digitalsyndicate.io","port":8453,"ssl":"true"}
   ],
   "Consumers": []


### PR DESCRIPTION
## Description

Pool_info => active_stake will likely be null after an epoch transition (few seconds on guildnet, few minutes on testnet, and could be few hours on mainnet) while dbsync completes extracting-and-populating stake distribution
