### PR TITLE
[SPEC] Make metadata fields nullable for minting txs

### DIFF
--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2430,7 +2430,9 @@ components:
                       description: Payment credential
                       example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
                 stake_addr:
-                  $ref: "#/components/schemas/account_history/items/properties/stake_address"
+                  nullable: true
+                  allOf:
+                  - $ref: "#/components/schemas/account_history/items/properties/stake_address"
                 tx_hash:
                   type: string
                   description: Hash of transaction for UTxO

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2811,6 +2811,7 @@ components:
                   type: string
                   description: The metadata key
                   example: "721"
+                  nullable: true
                 json:
                   type: object
                   description: The minting Tx JSON payload if it can be decoded as JSON
@@ -2821,6 +2822,7 @@ components:
                       "collection": "ccvault.io - the mesmerizer 2021",
                       "description": "Thanks for supporting ccvault.io development!",
                     }
+                  nullable: true
           token_registry_metadata:
             type: object
             description: Asset metadata registered on the Cardano Token Registry

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2430,7 +2430,9 @@ components:
                       description: Payment credential
                       example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
                 stake_addr:
-                  $ref: "#/components/schemas/account_history/items/properties/stake_address"
+                  nullable: true
+                  allOf:
+                  - $ref: "#/components/schemas/account_history/items/properties/stake_address"
                 tx_hash:
                   type: string
                   description: Hash of transaction for UTxO

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2811,6 +2811,7 @@ components:
                   type: string
                   description: The metadata key
                   example: "721"
+                  nullable: true
                 json:
                   type: object
                   description: The minting Tx JSON payload if it can be decoded as JSON
@@ -2821,6 +2822,7 @@ components:
                       "collection": "ccvault.io - the mesmerizer 2021",
                       "description": "Thanks for supporting ccvault.io development!",
                     }
+                  nullable: true
           token_registry_metadata:
             type: object
             description: Asset metadata registered on the Cardano Token Registry

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2430,7 +2430,9 @@ components:
                       description: Payment credential
                       example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
                 stake_addr:
-                  $ref: "#/components/schemas/account_history/items/properties/stake_address"
+                  nullable: true
+                  allOf:
+                  - $ref: "#/components/schemas/account_history/items/properties/stake_address"
                 tx_hash:
                   type: string
                   description: Hash of transaction for UTxO

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2811,6 +2811,7 @@ components:
                   type: string
                   description: The metadata key
                   example: "721"
+                  nullable: true
                 json:
                   type: object
                   description: The minting Tx JSON payload if it can be decoded as JSON
@@ -2821,6 +2822,7 @@ components:
                       "collection": "ccvault.io - the mesmerizer 2021",
                       "description": "Thanks for supporting ccvault.io development!",
                     }
+                  nullable: true
           token_registry_metadata:
             type: object
             description: Asset metadata registered on the Cardano Token Registry

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1374,6 +1374,7 @@ schemas:
                   type: string
                   description: The metadata key
                   example: "721"
+                  nullable: true
                 json:
                   type: object
                   description: The minting Tx JSON payload if it can be decoded as JSON
@@ -1384,6 +1385,7 @@ schemas:
                       "collection": "ccvault.io - the mesmerizer 2021",
                       "description": "Thanks for supporting ccvault.io development!",
                     }
+                  nullable: true
           token_registry_metadata:
             type: object
             description: Asset metadata registered on the Cardano Token Registry

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -993,7 +993,9 @@ schemas:
                       description: Payment credential
                       example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
                 stake_addr:
-                  $ref: "#/components/schemas/account_history/items/properties/stake_address"
+                  nullable: true
+                  allOf:
+                  - $ref: "#/components/schemas/account_history/items/properties/stake_address"
                 tx_hash:
                   type: string
                   description: Hash of transaction for UTxO


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Schemathesis tests would fail for minting_txs that do not have any metadata attached.
Stake address can be null for non-account-related addresses.

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
