### PR TITLE
Update tx_info schema for collateral_output

### DIFF
--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2410,6 +2410,7 @@ components:
           collateral_output:
             $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+            nullable: true
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2407,9 +2407,9 @@ components:
           collateral_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of collateral inputs needed for smart contracts in case of contract failure
-          collateral_outputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            description: An array of collateral outputs for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+          collateral_output:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
+            description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2410,6 +2410,7 @@ components:
           collateral_output:
             $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+            nullable: true
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2407,9 +2407,9 @@ components:
           collateral_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of collateral inputs needed for smart contracts in case of contract failure
-          collateral_outputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            description: An array of collateral outputs for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+          collateral_output:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
+            description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2410,6 +2410,7 @@ components:
           collateral_output:
             $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+            nullable: true
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2407,9 +2407,9 @@ components:
           collateral_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of collateral inputs needed for smart contracts in case of contract failure
-          collateral_outputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            description: An array of collateral outputs for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+          collateral_output:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
+            description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -973,6 +973,7 @@ schemas:
           collateral_output:
             $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+            nullable: true
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -970,9 +970,9 @@ schemas:
           collateral_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of collateral inputs needed for smart contracts in case of contract failure
-          collateral_outputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            description: An array of collateral outputs for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+          collateral_output:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items"
+            description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
           reference_inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)


### PR DESCRIPTION
## Description
Schema update due to change in tx_info endpoint to return a single output object, or null, for collateral_output

## Where should the reviewer start?

## Motivation and context

## Which issue it fixes?

## How has this been tested?
Unsure if ref is ok like this
