### PR TITLE
Change TTL values in tx_info to string

### DIFF
--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -47,7 +47,7 @@ BEGIN
         WHERE
           MTM.ident = _asset_id AND MTM.quantity > 0
         ORDER BY
-          MTM.tx_id ASC
+          MTM.tx_id DESC
         LIMIT 1
       ) AS tx_hash,
       minting_data.total_supply,
@@ -62,15 +62,15 @@ BEGIN
           ) as minting_tx_metadata
         FROM
           (
-            SELECT TM.key, TM.json, MAX(MTM.tx_id)
+            SELECT TM.key, TM.json, MTM.tx_id
               FROM tx_metadata TM
                 INNER JOIN ma_tx_mint MTM
                 ON TM.tx_id = MTM.tx_id
               WHERE
                 MTM.ident = _asset_id
+                AND MTM.tx_id = (SELECT max(tx_id) from ma_tx_mint where ident = _asset_id)
                 AND MTM.quantity > 0
                 AND TM.JSON IS NOT NULL
-              GROUP BY TM.key, TM.json
           ) x
       ) AS minting_tx_metadata,
       (

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -33,7 +33,7 @@ BEGIN
           MTM.ident = ANY(_policy_asset_ids) AND MTM.quantity > 0
         ORDER BY
           MTM.ident,
-          TM.tx_id ASC
+          TM.tx_id DESC
       ),
       token_registry_metadatas AS (
         SELECT DISTINCT ON (asset_policy, asset_name)

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -12,8 +12,8 @@ CREATE FUNCTION grest.tx_info (_tx_hashes text[])
     total_output text,
     fee text,
     deposit text,
-    invalid_before word64type,
-    invalid_after word64type,
+    invalid_before text,
+    invalid_after text,
     collateral_inputs jsonb,
     collateral_output jsonb,
     reference_inputs jsonb,
@@ -696,8 +696,8 @@ BEGIN
       ATX.total_output::text,
       ATX.fee::text,
       ATX.deposit::text,
-      ATX.invalid_before,
-      ATX.invalid_after,
+      ATX.invalid_before::text,
+      ATX.invalid_after::text,
       COALESCE((
         SELECT JSONB_AGG(tx_collateral_inputs)
         FROM (

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2723,11 +2723,11 @@ components:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -3107,7 +3107,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2723,11 +2723,11 @@ components:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -3107,7 +3107,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -2723,11 +2723,11 @@ components:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -3107,7 +3107,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -2723,11 +2723,11 @@ components:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -3107,7 +3107,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2723,11 +2723,11 @@ components:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -3107,7 +3107,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1085,11 +1085,11 @@ schemas:
             description: Total Deposits included in transaction (for example, if it is registering a pool/key)
             example: 0
           invalid_before:
-            type: integer
+            type: string
             description: Slot before which transaction cannot be validated (if supplied, else null)
             nullable: true
           invalid_after:
-            type: integer
+            type: string
             description: Slot after which transaction cannot be validated
             example: 42332172
             nullable: true
@@ -1469,7 +1469,7 @@ schemas:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the first mint transaction
+            description: Hash of the latest mint transaction
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           mint_cnt:
             type: integer


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
1. [Minor output (data-type) change] - Convert tx_info: TTL values to string (as some values are far beyond billion) - assists cardano-community/koios-java-client#100
2. [Non-breaking] - Fix asset_info/asset_policy_info to show latest mint tx data (was an error in change before intended to do the same), and update asset_info->tx_hash to show latest (instead of oldest) tx