### PR TITLE
New asset_info_cache table

### DIFF
--- a/files/grest/cron/jobs/asset-info-cache-update.sh
+++ b/files/grest/cron/jobs/asset-info-cache-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+DB_NAME=cexplorer
+
+echo "$(date +%F_%H:%M:%S) Running asset info cache update..."
+psql ${DB_NAME} -qbt -c "SELECT grest.asset_info_cache_update();" 2>&1 1>/dev/null
+echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -1,0 +1,177 @@
+CREATE TABLE IF NOT EXISTS grest.asset_info_cache (
+  asset_id bigint PRIMARY KEY NOT NULL,
+  creation_time date,
+  total_supply numeric,
+  decimals integer,
+  mint_cnt bigint,
+  burn_cnt bigint,
+  first_mint_tx_id bigint,
+  first_mint_keys text[],
+  last_mint_tx_id bigint,
+  last_mint_keys text[]
+);
+
+CREATE INDEX IF NOT EXISTS idx_first_mint_tx_id ON grest.asset_info_cache (first_mint_tx_id);
+CREATE INDEX IF NOT EXISTS idx_last_mint_tx_id ON grest.asset_info_cache (last_mint_tx_id);
+
+CREATE OR REPLACE FUNCTION grest.asset_info_cache_update ()
+  RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+DECLARE
+  _lastest_tx_id bigint;
+  _asset_info_cache_last_tx_id bigint;
+  _asset_id_list bigint[];
+BEGIN
+  -- Check previous cache update completed before running
+  IF (
+    SELECT
+      COUNT(pid) > 1
+    FROM
+      pg_stat_activity
+    WHERE
+      state = 'active' AND query ILIKE '%grest.asset_info_cache_update%'
+      AND datname = (SELECT current_database())
+  ) THEN 
+    RAISE EXCEPTION 'Previous asset_info_cache_update query still running but should have completed! Exiting...';
+  END IF;
+
+  SELECT
+    MAX(id) INTO _lastest_tx_id
+  FROM
+    public.tx;
+
+  SELECT
+    last_value::bigint INTO _asset_info_cache_last_tx_id
+  FROM
+    grest.control_table
+  WHERE
+    key = 'asset_info_cache_last_tx_id';
+
+  IF _asset_info_cache_last_tx_id IS NULL THEN
+    RAISE NOTICE 'Asset info cache table is empty, deleting all previous cache records and starting initial population...';
+    TRUNCATE TABLE grest.asset_info_cache;
+  ELSE
+    RAISE NOTICE 'Updating asset info based on data from transaction id in range % - % ...', _asset_info_cache_last_tx_id, _lastest_tx_id;
+    SELECT
+      ARRAY_AGG(DISTINCT ident) INTO _asset_id_list
+    FROM
+      ma_tx_mint
+    WHERE
+      tx_id > _asset_info_cache_last_tx_id;
+  END IF;
+
+  WITH
+
+    tx_mint_meta AS (
+      SELECT
+        mtm.ident,
+        MIN(mtm.tx_id) AS first_mint_tx_id, 
+        MAX(mtm.tx_id) AS last_mint_tx_id
+      FROM 
+        ma_tx_mint mtm
+        INNER JOIN tx_metadata tm ON tm.tx_id = mtm.tx_id
+      WHERE
+        CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
+          THEN
+            mtm.ident = any(_asset_id_list)
+          ELSE TRUE
+        END
+        AND mtm.quantity > 0
+        AND tm.json IS NOT NULL
+      GROUP BY mtm.ident
+    ),
+
+    tx_mint_nometa AS (
+      SELECT
+        mtm.ident,
+        MIN(mtm.tx_id) AS first_mint_tx_id, 
+        MAX(mtm.tx_id) AS last_mint_tx_id
+      FROM 
+        ma_tx_mint mtm
+        LEFT JOIN tx_mint_meta ON tx_mint_meta.ident = mtm.ident
+      WHERE
+        CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
+          THEN
+            mtm.id = any(_asset_id_list)
+          ELSE TRUE
+        END
+        AND tx_mint_meta IS NULL
+        AND mtm.quantity > 0
+      GROUP BY mtm.ident
+    ),
+    
+    tx_meta AS (
+      SELECT
+        tmm.ident,
+        tmm.first_mint_tx_id,
+        ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.first_mint_tx_id) AS first_mint_keys,
+        tmm.last_mint_tx_id,
+        ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.last_mint_tx_id) AS last_mint_keys
+      FROM
+        tx_mint_meta tmm
+        INNER JOIN tx_metadata tm ON tm.tx_id = tmm.first_mint_tx_id OR tm.tx_id = tmm.last_mint_tx_id
+      GROUP BY tmm.ident, tmm.first_mint_tx_id, tmm.last_mint_tx_id
+      --
+      UNION ALL
+      --
+      SELECT
+        tx_mint_nometa.ident,
+        tx_mint_nometa.first_mint_tx_id,
+        '{}',
+        tx_mint_nometa.last_mint_tx_id,
+        '{}'
+      FROM
+        tx_mint_nometa
+    )
+
+  INSERT INTO grest.asset_info_cache  
+    SELECT
+      ma.id,
+      MIN(B.time) AS creation_time,
+      SUM(mtm.quantity) AS total_supply,
+      COALESCE(arc.decimals, 0) AS decimals,
+      SUM(CASE WHEN mtm.quantity > 0 THEN 1 ELSE 0 END) AS mint_cnt,
+      SUM(CASE WHEN mtm.quantity < 0 THEN 1 ELSE 0 END) AS burn_cnt,
+      tm.first_mint_tx_id,
+      tm.first_mint_keys,
+      tm.last_mint_tx_id,
+      tm.last_mint_keys
+    FROM
+      multi_asset ma
+      INNER JOIN ma_tx_mint mtm ON mtm.ident = ma.id
+      INNER JOIN tx ON tx.id = mtm.tx_id
+      INNER JOIN block b ON b.id = tx.block_id
+      INNER JOIN tx_meta tm ON tm.ident = ma.id
+      LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
+    WHERE
+      CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
+        THEN
+          mtm.id = any(_asset_id_list)
+        ELSE TRUE
+      END
+    GROUP BY ma.id, arc.decimals, tm.first_mint_tx_id, tm.first_mint_keys, tm.last_mint_tx_id, tm.last_mint_keys
+  ON CONFLICT (asset_id)
+  DO UPDATE SET
+    creation_time     = excluded.creation_time,
+    total_supply      = excluded.total_supply,
+    decimals          = excluded.decimals,
+    mint_cnt          = excluded.mint_cnt,
+    burn_cnt          = excluded.burn_cnt,
+    first_mint_tx_id  = excluded.first_mint_tx_id,
+    first_mint_keys   = excluded.first_mint_keys,
+    last_mint_tx_id   = excluded.last_mint_tx_id,
+    last_mint_keys    = excluded.last_mint_keys;
+
+  IF _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL THEN
+    RAISE NOTICE '% assets added or updated', ARRAY_LENGTH(_asset_id_list, 1);
+  END IF;
+
+  -- GREST control table entry
+  PERFORM grest.update_control_table(
+    'asset_info_cache_last_tx_id',
+    _lastest_tx_id::text
+  );
+
+END;
+$$;

--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -42,7 +42,7 @@ BEGIN
     public.tx;
 
   SELECT
-    last_value::bigint INTO _asset_info_cache_last_tx_id
+    COALESCE(last_value::bigint,100) - 100 INTO _asset_info_cache_last_tx_id
   FROM
     grest.control_table
   WHERE
@@ -75,6 +75,7 @@ BEGIN
         CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
           THEN
             mtm.ident = any(_asset_id_list)
+            AND mtm.tx_id > _asset_info_cache_last_tx_id
           ELSE TRUE
         END
         AND mtm.quantity > 0
@@ -94,6 +95,7 @@ BEGIN
         CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
           THEN
             mtm.id = any(_asset_id_list)
+            AND mtm.tx_id > _asset_info_cache_last_tx_id
           ELSE TRUE
         END
         AND tx_mint_meta IS NULL
@@ -158,8 +160,6 @@ BEGIN
     decimals          = excluded.decimals,
     mint_cnt          = excluded.mint_cnt,
     burn_cnt          = excluded.burn_cnt,
-    first_mint_tx_id  = excluded.first_mint_tx_id,
-    first_mint_keys   = excluded.first_mint_keys,
     last_mint_tx_id   = excluded.last_mint_tx_id,
     last_mint_keys    = excluded.last_mint_keys;
 

--- a/files/grest/rpc/account/account_assets.sql
+++ b/files/grest/rpc/account/account_assets.sql
@@ -22,6 +22,7 @@ BEGIN
         ma.policy,
         ma.name,
         ma.fingerprint,
+        aic.decimals,
         SUM(mtx.quantity) as quantity
       FROM
         MA_TX_OUT MTX
@@ -30,6 +31,7 @@ BEGIN
         INNER JOIN STAKE_ADDRESS sa ON sa.id = TXO.stake_address_id
         LEFT JOIN TX_IN on TXO.TX_ID = TX_IN.TX_OUT_ID
           AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint
+        LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
       WHERE
         sa.id = ANY(sa_id_list)
         AND TX_IN.TX_IN_ID IS NULL
@@ -48,6 +50,7 @@ BEGIN
           'policy_id', ENCODE(aa.policy, 'hex'),
           'asset_name', ENCODE(aa.name, 'hex'),
           'fingerprint', aa.fingerprint,
+          'decimals', COALESCE(aa.decimals, 0),
           'quantity', aa.quantity::text
         )
       ) as assets

--- a/files/grest/rpc/account/account_assets.sql
+++ b/files/grest/rpc/account/account_assets.sql
@@ -29,9 +29,9 @@ BEGIN
         INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
         INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
         INNER JOIN STAKE_ADDRESS sa ON sa.id = TXO.stake_address_id
+        INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
         LEFT JOIN TX_IN on TXO.TX_ID = TX_IN.TX_OUT_ID
           AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint
-        LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
       WHERE
         sa.id = ANY(sa_id_list)
         AND TX_IN.TX_IN_ID IS NULL

--- a/files/grest/rpc/address/address_assets.sql
+++ b/files/grest/rpc/address/address_assets.sql
@@ -14,6 +14,7 @@ BEGIN
       ma.policy,
       ma.name,
       ma.fingerprint,
+      aic.decimals,
       SUM(mtx.quantity) as quantity
     FROM
       MA_TX_OUT MTX
@@ -21,6 +22,7 @@ BEGIN
       INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
       LEFT JOIN TX_IN ON TXO.TX_ID = TX_IN.TX_OUT_ID
         AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint
+      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
     WHERE
       TXO.address = ANY(_addresses)
       AND TX_IN.TX_IN_ID IS NULL
@@ -39,6 +41,7 @@ BEGIN
           'policy_id', ENCODE(aa.policy, 'hex'),
           'asset_name', ENCODE(aa.name, 'hex'),
           'fingerprint', aa.fingerprint,
+          'decimals', COALESCE(aa.decimals, 0),
           'quantity', aa.quantity::text
         )
       ) as asset_list

--- a/files/grest/rpc/address/address_assets.sql
+++ b/files/grest/rpc/address/address_assets.sql
@@ -19,10 +19,10 @@ BEGIN
     FROM
       MA_TX_OUT MTX
       INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
+      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
       INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
       LEFT JOIN TX_IN ON TXO.TX_ID = TX_IN.TX_OUT_ID
         AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint
-      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
     WHERE
       TXO.address = ANY(_addresses)
       AND TX_IN.TX_IN_ID IS NULL
@@ -41,7 +41,7 @@ BEGIN
           'policy_id', ENCODE(aa.policy, 'hex'),
           'asset_name', ENCODE(aa.name, 'hex'),
           'fingerprint', aa.fingerprint,
-          'decimals', COALESCE(aa.decimals, 0),
+          'decimals', aa.decimals,
           'quantity', aa.quantity::text
         )
       ) as asset_list

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -90,11 +90,13 @@ BEGIN
                       'policy_id', ENCODE(MA.policy, 'hex'),
                       'asset_name', ENCODE(MA.name, 'hex'),
                       'fingerprint', MA.fingerprint,
+                      'decimals', COALESCE(aic.decimals, 0),
                       'quantity', MTX.quantity::text
                       ))
                   FROM
                       ma_tx_out MTX
                       INNER JOIN multi_asset MA ON MA.id = MTX.ident
+                      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
                   WHERE
                       MTX.tx_out_id = au.txo_id
                 ),

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -90,13 +90,13 @@ BEGIN
                       'policy_id', ENCODE(MA.policy, 'hex'),
                       'asset_name', ENCODE(MA.name, 'hex'),
                       'fingerprint', MA.fingerprint,
-                      'decimals', COALESCE(aic.decimals, 0),
+                      'decimals', aic.decimals,
                       'quantity', MTX.quantity::text
                       ))
                   FROM
                       ma_tx_out MTX
                       INNER JOIN multi_asset MA ON MA.id = MTX.ident
-                      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+                      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
                   WHERE
                       MTX.tx_out_id = au.txo_id
                 ),

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -14,100 +14,11 @@ CREATE OR REPLACE FUNCTION grest.asset_info (_asset_policy text, _asset_name tex
   )
   LANGUAGE PLPGSQL
   AS $$
-DECLARE
-  _asset_policy_decoded bytea;
-  _asset_name_decoded bytea;
-  _asset_id int;
 BEGIN
-  SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-
-  SELECT DECODE(
-    CASE WHEN _asset_name IS NULL
-      THEN ''
-    ELSE
-      _asset_name
-    END,
-    'hex'
-  ) INTO _asset_name_decoded;
-
-  SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
-
+  
   RETURN QUERY
-    SELECT
-      _asset_policy,
-      _asset_name,
-      ENCODE(_asset_name_decoded, 'escape'),
-      MA.fingerprint,
-      (
-        SELECT
-          ENCODE(tx.hash, 'hex')
-        FROM
-          ma_tx_mint MTM
-          INNER JOIN tx ON tx.id = MTM.tx_id
-        WHERE
-          MTM.ident = _asset_id AND MTM.quantity > 0
-        ORDER BY
-          MTM.tx_id DESC
-        LIMIT 1
-      ) AS tx_hash,
-      minting_data.total_supply,
-      minting_data.mint_cnt,
-      minting_data.burn_cnt,
-      EXTRACT(epoch from minting_data.date)::integer,
-      (
-        SELECT
-          JSONB_OBJECT_AGG(
-            key::text,
-            json
-          ) as minting_tx_metadata
-        FROM
-          (
-            SELECT TM.key, TM.json, MTM.tx_id
-              FROM tx_metadata TM
-                INNER JOIN ma_tx_mint MTM
-                ON TM.tx_id = MTM.tx_id
-              WHERE
-                MTM.ident = _asset_id
-                AND MTM.tx_id = (SELECT max(tx_id) from ma_tx_mint where ident = _asset_id)
-                AND MTM.quantity > 0
-                AND TM.JSON IS NOT NULL
-          ) x
-      ) AS minting_tx_metadata,
-      (
-        SELECT
-          JSON_BUILD_OBJECT(
-            'name', ARC.name,
-            'description', ARC.description,
-            'ticker', ARC.ticker,
-            'url', ARC.url,
-            'logo', ARC.logo,
-            'decimals', ARC.decimals
-          ) as metadata
-        FROM
-          grest.asset_registry_cache ARC
-        WHERE
-          ARC.asset_policy = _asset_policy
-          AND
-          ARC.asset_name = _asset_name
-        LIMIT 1
-      ) AS token_registry_metadata
-    FROM
-      multi_asset MA
-      LEFT JOIN LATERAL (
-        SELECT
-          MIN(B.time) AS date,
-          SUM(MTM.quantity)::text AS total_supply,
-          SUM(CASE WHEN quantity > 0 then 1 else 0 end) AS mint_cnt,
-          SUM(CASE WHEN quantity < 0 then 1 else 0 end) AS burn_cnt
-        FROM
-          ma_tx_mint MTM
-          INNER JOIN tx ON tx.id = MTM.tx_id
-          INNER JOIN block B ON B.id = tx.block_id
-        WHERE
-          MTM.ident = MA.id
-      ) minting_data ON TRUE
-    WHERE
-      MA.id = _asset_id;
+    SELECT grest.asset_info_bulk(array[array[_asset_policy, _asset_name]]);
+      
 END;
 $$;
 

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -1,0 +1,82 @@
+CREATE OR REPLACE FUNCTION grest.asset_info_bulk (_asset_list text[][])
+  RETURNS TABLE (
+    policy_id text,
+    asset_name text,
+    asset_name_ascii text,
+    fingerprint character varying,
+    minting_tx_hash text,
+    total_supply text,
+    mint_cnt bigint,
+    burn_cnt bigint,
+    creation_time integer,
+    minting_tx_metadata jsonb,
+    token_registry_metadata json
+  )
+  LANGUAGE PLPGSQL
+  AS $$
+DECLARE
+  _asset_id_list      bigint[];
+BEGIN
+
+  -- find all asset id's based on nested array input
+  SELECT INTO _asset_id_list ARRAY_AGG(id)
+  FROM (
+    SELECT DISTINCT mu.id
+    FROM (
+      SELECT
+        DECODE(asset_list->>0, 'hex') AS policy,
+        DECODE(asset_list->>1, 'hex') AS name
+      FROM
+      JSONB_ARRAY_ELEMENTS(TO_JSONB(_asset_list)) asset_list
+    ) ald
+    INNER JOIN multi_asset mu ON mu.policy = ald.policy AND mu.name = ald.name
+  ) AS tmp;
+
+  RETURN QUERY
+
+    SELECT
+      ENCODE(ma.policy, 'hex'),
+      ENCODE(ma.name, 'hex'),
+      ENCODE(ma.name, 'escape'),
+      ma.fingerprint,
+      ENCODE(tx.hash, 'hex'),
+      aic.total_supply::text,
+      aic.mint_cnt,
+      aic.burn_cnt,
+      EXTRACT(epoch from aic.creation_time)::integer,
+      metadata.minting_tx_metadata,
+      CASE WHEN arc.name IS NULL THEN NULL
+      ELSE
+        JSON_BUILD_OBJECT(
+          'name', arc.name,
+          'description', arc.description,
+          'ticker', arc.ticker,
+          'url', arc.url,
+          'logo', arc.logo,
+          'decimals', arc.decimals
+        )
+      END
+    FROM
+      multi_asset ma
+      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      LEFT JOIN tx ON tx.id = aic.last_mint_tx_id
+      LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
+      LEFT JOIN LATERAL (
+        SELECT
+          JSONB_OBJECT_AGG(
+            key::text,
+            json
+          ) AS minting_tx_metadata
+        FROM
+          tx_metadata tm
+        WHERE
+          tm.tx_id = tx.id
+      ) metadata ON TRUE
+    WHERE
+      ma.id = any (_asset_id_list);
+
+END;
+$$;
+
+COMMENT ON FUNCTION grest.asset_info IS 'Get the information of an asset incl first minting & token registry metadata';
+

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION grest.asset_info_bulk (_asset_list text[][])
+CREATE OR REPLACE FUNCTION grest.asset_info (_asset_list text[][])
   RETURNS TABLE (
     policy_id text,
     asset_name text,
@@ -58,7 +58,7 @@ BEGIN
       END
     FROM
       multi_asset ma
-      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
       LEFT JOIN tx ON tx.id = aic.last_mint_tx_id
       LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
       LEFT JOIN LATERAL (
@@ -77,6 +77,3 @@ BEGIN
 
 END;
 $$;
-
-COMMENT ON FUNCTION grest.asset_info IS 'Get the information of an asset incl first minting & token registry metadata';
-

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -37,7 +37,7 @@ BEGIN
       EXTRACT(epoch from aic.creation_time)::integer
     FROM 
       multi_asset ma
-      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
       LEFT JOIN tx ON tx.id = aic.last_mint_tx_id
       LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
       LEFT JOIN LATERAL (

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -6,7 +6,6 @@ CREATE FUNCTION grest.asset_policy_info (_asset_policy text)
     minting_tx_metadata jsonb,
     token_registry_metadata jsonb,
     total_supply text,
-    decimals integer,
     creation_time integer
   )
   LANGUAGE PLPGSQL
@@ -16,100 +15,44 @@ DECLARE
   _policy_asset_ids bigint[];
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT INTO _policy_asset_ids ARRAY_AGG(id) FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded;
-
-  RETURN QUERY (
-    WITH
-      minting_tx_metadatas AS (
-        SELECT DISTINCT ON (MTM.ident)
-          MTM.ident,
-          JSONB_BUILD_OBJECT(
-            'key', TM.key::text,
-            'json', TM.json
-          ) AS metadata
-        FROM
-          tx_metadata TM
-          INNER JOIN ma_tx_mint MTM on MTM.tx_id = TM.tx_id
-        WHERE
-          MTM.ident = ANY(_policy_asset_ids) AND MTM.quantity > 0
-        ORDER BY
-          MTM.ident,
-          TM.tx_id DESC
-      ),
-      token_registry_metadatas AS (
-        SELECT DISTINCT ON (asset_policy, asset_name)
-          asset_policy,
-          ARC.asset_name,
-          JSONB_BUILD_OBJECT(
-            'name', ARC.name,
-            'description', ARC.description,
-            'ticker', ARC.ticker,
-            'url', ARC.url,
-            'logo', ARC.logo,
-            'decimals', ARC.decimals
-          ) as metadata
-        FROM
-          grest.asset_registry_cache ARC
-        WHERE
-          asset_policy = _asset_policy
-        ORDER BY
-          asset_policy,
-          ARC.asset_name
-      ),
-      total_supplies AS (
-        SELECT
-          MTM.ident,
-          SUM(MTM.quantity)::text AS amount
-        FROM
-          ma_tx_mint MTM
-        WHERE
-          MTM.ident = ANY(_policy_asset_ids)
-        GROUP BY
-          MTM.ident
-      ),
-      creation_times AS (
-        SELECT
-          MTM.ident,
-          MIN(B.time) AS date
-        FROM
-          ma_tx_mint MTM
-          INNER JOIN tx ON tx.id = MTM.tx_id
-          INNER JOIN block B ON B.id = tx.block_id
-        WHERE
-          MTM.ident = ANY(_policy_asset_ids)
-        GROUP BY
-          MTM.ident
-      )
-
+  
+  RETURN QUERY 
     SELECT
-      ENCODE(MA.name, 'hex') as asset_name,
-      ENCODE(MA.name, 'escape') as asset_name_ascii,
-      MA.fingerprint as fingerprint,
-      mtm.metadata as minting_tx_metadata,
-      trm.metadata as token_registry_metadata,
-      ts.amount::text as total_supply,
-      aic.decimals as decimals,
-      EXTRACT(epoch from ct.date)::integer
+      ENCODE(ma.name, 'hex') AS asset_name,
+      ENCODE(ma.name, 'escape') AS asset_name_ascii,
+      ma.fingerprint,
+      metadata.minting_tx_metadata,
+      CASE WHEN arc.name IS NULL THEN NULL
+      ELSE
+        JSON_BUILD_OBJECT(
+          'name', arc.name,
+          'description', arc.description,
+          'ticker', arc.ticker,
+          'url', arc.url,
+          'logo', arc.logo,
+          'decimals', arc.decimals
+        )
+      END,
+      aic.total_supply,
+      EXTRACT(epoch from aic.creation_time)::integer
     FROM 
-      multi_asset MA
-      LEFT JOIN asset_info_cache aic ON aic.asset_id = MA.id
-      LEFT JOIN minting_tx_metadatas mtm ON mtm.ident = MA.id
-      LEFT JOIN token_registry_metadatas trm ON trm.asset_policy = _asset_policy
-        AND DECODE(trm.asset_name, 'hex') = MA.name
-      INNER JOIN total_supplies ts on ts.ident = MA.id
-      INNER JOIN  creation_times ct ON ct.ident = MA.id
+      multi_asset ma
+      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      LEFT JOIN tx ON tx.id = aic.last_mint_tx_id
+      LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
+      LEFT JOIN LATERAL (
+        SELECT
+          JSONB_OBJECT_AGG(
+            key::text,
+            json
+          ) AS minting_tx_metadata
+        FROM
+          tx_metadata tm
+        WHERE
+          tm.tx_id = tx.id
+      ) metadata ON TRUE
     WHERE
-      MA.id = ANY(_policy_asset_ids)
-    GROUP BY
-      MA.policy,
-      MA.name,
-      MA.fingerprint,
-      MA.id,
-      mtm.metadata,
-      trm.metadata,
-      ts.amount,
-      ct.date
-  );
+      ma.policy = _asset_policy_decoded;
 END;
 $$;
 

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -6,6 +6,7 @@ CREATE FUNCTION grest.asset_policy_info (_asset_policy text)
     minting_tx_metadata jsonb,
     token_registry_metadata jsonb,
     total_supply text,
+    decimals integer,
     creation_time integer
   )
   LANGUAGE PLPGSQL
@@ -87,9 +88,11 @@ BEGIN
       mtm.metadata as minting_tx_metadata,
       trm.metadata as token_registry_metadata,
       ts.amount::text as total_supply,
+      aic.decimals as decimals,
       EXTRACT(epoch from ct.date)::integer
     FROM 
       multi_asset MA
+      LEFT JOIN asset_info_cache aic ON aic.asset_id = MA.id
       LEFT JOIN minting_tx_metadatas mtm ON mtm.ident = MA.id
       LEFT JOIN token_registry_metadatas trm ON trm.asset_policy = _asset_policy
         AND DECODE(trm.asset_name, 'hex') = MA.name

--- a/files/grest/rpc/assets/asset_policy_list.sql
+++ b/files/grest/rpc/assets/asset_policy_list.sql
@@ -22,7 +22,7 @@ BEGIN
       aic.decimals
     FROM 
       multi_asset ma
-      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
     WHERE
       ma.policy = _asset_policy_decoded;
 

--- a/files/grest/rpc/assets/asset_policy_list.sql
+++ b/files/grest/rpc/assets/asset_policy_list.sql
@@ -1,0 +1,32 @@
+CREATE FUNCTION grest.asset_policy_info (_asset_policy text)
+  RETURNS TABLE (
+    asset_name text,
+    fingerprint varchar,
+    total_supply text,
+    decimals integer
+  )
+  LANGUAGE PLPGSQL
+  AS $$
+DECLARE
+  _asset_policy_decoded bytea;
+BEGIN
+
+  SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
+
+  RETURN QUERY
+    
+    SELECT
+      ENCODE(ma.name, 'hex') AS asset_name,
+      ma.fingerprint AS fingerprint,
+      aic.total_supply,
+      aic.decimals
+    FROM 
+      multi_asset ma
+      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+    WHERE
+      ma.policy = _asset_policy_decoded;
+
+END;
+$$;
+
+COMMENT ON FUNCTION grest.asset_policy_info IS 'Get a list of all asset under a policy';

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -95,7 +95,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -150,7 +150,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -205,7 +205,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -260,7 +260,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -313,7 +313,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -388,7 +388,7 @@ BEGIN
           FROM 
             ma_tx_mint MTM
             INNER JOIN MULTI_ASSET MA ON MA.id = MTM.ident
-            LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+            INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           WHERE
             MTM.tx_id = ANY (_tx_id_list)
         ) AS tmp

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -95,6 +95,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -126,6 +127,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
@@ -148,6 +150,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -179,6 +182,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
@@ -201,6 +205,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -232,6 +237,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
@@ -254,6 +260,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -283,6 +290,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
@@ -305,6 +313,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -334,6 +343,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
@@ -372,11 +382,13 @@ BEGIN
               'policy_id', ENCODE(MA.policy, 'hex'),
               'asset_name', ENCODE(MA.name, 'hex'),
               'fingerprint', MA.fingerprint,
+              'decimals', COALESCE(aic.decimals, 0),
               'quantity', MTM.quantity::text
             ) AS data
           FROM 
             ma_tx_mint MTM
             INNER JOIN MULTI_ASSET MA ON MA.id = MTM.ident
+            LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           WHERE
             MTM.tx_id = ANY (_tx_id_list)
         ) AS tmp

--- a/files/grest/rpc/transactions/tx_utxos.sql
+++ b/files/grest/rpc/transactions/tx_utxos.sql
@@ -57,7 +57,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END
@@ -90,7 +90,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
-                'decimals', COALESCE(aic.decimals, 0),
+                'decimals', aic.decimals,
                 'quantity', MTO.quantity::text
               )
             END

--- a/files/grest/rpc/transactions/tx_utxos.sql
+++ b/files/grest/rpc/transactions/tx_utxos.sql
@@ -57,6 +57,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -69,6 +70,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
         WHERE 
           tx_in.tx_in_id = ANY (_tx_id_list)
       ),
@@ -88,6 +90,7 @@ BEGIN
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
                 'fingerprint', MA.fingerprint,
+                'decimals', COALESCE(aic.decimals, 0),
                 'quantity', MTO.quantity::text
               )
             END
@@ -98,6 +101,7 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
         WHERE 
           tx_out.tx_id = ANY (_tx_id_list)
       )

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -858,6 +858,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:
@@ -1635,6 +1655,25 @@ components:
               _datum_hashes:
                   - 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
                   - 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
+                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
   securitySchemes: {}
   schemas:
     tip:
@@ -3160,8 +3199,6 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -861,7 +861,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":
@@ -1666,6 +1666,7 @@ components:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -3212,8 +3212,6 @@ components:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -2650,6 +2650,10 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -2833,6 +2837,8 @@ components:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -2864,6 +2870,8 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -3152,6 +3160,8 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -3202,9 +3212,24 @@ components:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -858,6 +858,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:
@@ -1635,6 +1655,25 @@ components:
               _datum_hashes:
                   - 818ee3db3bbbd04f9f2ce21778cac3ac605802a4fcb00c8b3a58ee2dafc17d46
                   - 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']
+                - ['1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e','776f726c646d6f62696c65746f6b656e']
   securitySchemes: {}
   schemas:
     tip:
@@ -3160,8 +3199,6 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -861,7 +861,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":
@@ -1666,6 +1666,7 @@ components:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -3212,8 +3212,6 @@ components:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -2650,6 +2650,10 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -2833,6 +2837,8 @@ components:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -2864,6 +2870,8 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -3152,6 +3160,8 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -3202,9 +3212,24 @@ components:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -861,7 +861,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":
@@ -1666,6 +1666,7 @@ components:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -3212,8 +3212,6 @@ components:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -858,6 +858,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:
@@ -1635,6 +1655,25 @@ components:
               _datum_hashes:
                   - 5571e2c3549f15934a38382d1318707a86751fb70827f4cbd29b104480f1be9b
                   - 5f7212f546d7e7308ce99b925f05538db19981f4ea3084559c0b28a363245826
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']
+                - ['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']
   securitySchemes: {}
   schemas:
     tip:
@@ -3160,8 +3199,6 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -2650,6 +2650,10 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -2833,6 +2837,8 @@ components:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -2864,6 +2870,8 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -3152,6 +3160,8 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -3202,9 +3212,24 @@ components:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -861,7 +861,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":
@@ -1666,6 +1666,7 @@ components:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -3212,8 +3212,6 @@ components:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -858,6 +858,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:
@@ -1635,6 +1655,25 @@ components:
               _datum_hashes:
                   - 6181b3dc623cd8812caf027a3507e9b3095388a7cf3db65983e1fddd3a84c88c
                   - f8ae55ff89e1f5366f23e16bcaf2073252337b96031a02d79e41d653b5f0a978
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']
+                - ['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']
   securitySchemes: {}
   schemas:
     tip:
@@ -3160,8 +3199,6 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -2650,6 +2650,10 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -2833,6 +2837,8 @@ components:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -2864,6 +2870,8 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -3152,6 +3160,8 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -3202,9 +3212,24 @@ components:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -861,7 +861,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":
@@ -1666,6 +1666,7 @@ components:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -3212,8 +3212,6 @@ components:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -858,6 +858,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:
@@ -1635,6 +1655,25 @@ components:
               _datum_hashes:
                   - 5865d96e4313780a37af26055cdcc90308db23adaf4f2082178355e5e1dc20f6
                   - 4932dce28712ccc4858e3d83cc8e79b12740f66007dc9a287bb640a264c899de
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ['000327a9e427a3a3256eb6212ae26b7f53f7969b8e62d37ea9138a7b','54735465737431']
+                - ['000327a9e427a3a3256eb6212ae26b7f53f7969b8e62d37ea9138a7b','54735465737431']
   securitySchemes: {}
   schemas:
     tip:
@@ -3160,8 +3199,6 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/results/koiosapi-testnet.yaml
+++ b/specs/results/koiosapi-testnet.yaml
@@ -2650,6 +2650,10 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -2833,6 +2837,8 @@ components:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -2864,6 +2870,8 @@ components:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -3152,6 +3160,8 @@ components:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -3202,9 +3212,24 @@ components:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/templates/3-api-requestBodies.yaml
+++ b/specs/templates/3-api-requestBodies.yaml
@@ -199,3 +199,22 @@ requestBodies:
               _datum_hashes:
                   - ##datum_hashes1_rb##
                   - ##datum_hashes2_rb##
+    asset_list:
+      content:
+        application/json:
+          schema:
+            required:
+              - _asset_list
+            type: object
+            properties:
+              _asset_list:
+                format: text
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: string
+            example:
+              _asset_list:
+                - ##asset1_rb##
+                - ##asset2_rb##

--- a/specs/templates/3-api-requestBodies.yaml
+++ b/specs/templates/3-api-requestBodies.yaml
@@ -210,6 +210,7 @@ requestBodies:
               _asset_list:
                 format: text
                 type: array
+                description: Array of array of policy ID and asset names (hex)
                 items:
                   type: array
                   items:

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1012,6 +1012,10 @@ schemas:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  type: integer
+                  description: Asset decimals
+                  example: 6
                 quantity:
                   type: string
                   description: Asset quantity owned by account
@@ -1195,6 +1199,8 @@ schemas:
                         $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                       fingerprint:
                         $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                      decimals:
+                        $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                       quantity:
                         type: string
                         description: Quantity of assets on the UTxO
@@ -1226,6 +1232,8 @@ schemas:
                   $ref: "#/components/schemas/asset_info/items/properties/asset_name"
                 fingerprint:
                   $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
                 quantity:
                   type: string
                   description: Quantity of minted assets (negative on burn)
@@ -1514,6 +1522,8 @@ schemas:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
+    asset_info_bulk:
+      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:
@@ -1564,9 +1574,24 @@ schemas:
           total_supply:
             type: string
             example: "35000"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+    asset_policy_list:
+      type: array
+      description: List of policy assets
+      items:
+        properties:
+          asset_name:
+            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+          fingerprint:
+            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+          total_supply:
+            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+          decimals:
+            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
     asset_txs:
       type: array
       description: An array of Tx hashes that included the given asset (latest first)

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1522,8 +1522,6 @@ schemas:
             type: integer
             description: UNIX timestamp of the first asset mint
             example: 1506635091
-    asset_info_bulk:
-      $ref: "#/components/schemas/asset_info"
     asset_history:
       type: array
       items:

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1574,8 +1574,6 @@ schemas:
           total_supply:
             type: string
             example: "35000"
-          decimals:
-            $ref: "#/components/schemas/account_assets/items/properties/asset_list/items/properties/decimals"
           creation_time:
             type: string
             $ref: "#/components/schemas/asset_info/items/properties/creation_time"

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -645,7 +645,7 @@ paths:
     post:
       tags:
         - Asset
-      prequestBody:
+      requestBody:
         $ref: "#/components/requestBodies/asset_list"
       responses:
         "200":

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -642,6 +642,26 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Information
       description: Get the information of an asset including first minting & token registry metadata
+    post:
+      tags:
+        - Asset
+      prequestBody:
+        $ref: "#/components/requestBodies/asset_list"
+      responses:
+        "200":
+          description: Array of detailed asset information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/asset_info"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Asset Information
+      description: Get the information of a list of assets including first minting & token registry metadata
   /asset_history: #RPC
     get:
       tags:

--- a/specs/templates/example-map.json
+++ b/specs/templates/example-map.json
@@ -93,6 +93,20 @@
       "pv": "11",
       "pp": "30"
     },
+    "asset1": {
+      "m": "['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']",
+      "t": "['000327a9e427a3a3256eb6212ae26b7f53f7969b8e62d37ea9138a7b','54735465737431']",
+      "g": "['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']",
+      "pv": "['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']",
+      "pp": "['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']"
+    },
+    "asset2": {
+      "m": "['1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e','776f726c646d6f62696c65746f6b656e']",
+      "t": "['000327a9e427a3a3256eb6212ae26b7f53f7969b8e62d37ea9138a7b','54735465737431']",
+      "g": "['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']",
+      "pv": "['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']",
+      "pp": "['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']"
+    },
     "stake_addresses1": {
       "m": "stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250",
       "t": "stake_test1uqrw9tjymlm8wrwq7jk68n6v7fs9qz8z0tkdkve26dylmfc2ux2hj",


### PR DESCRIPTION
## Description
- New asset_info_cache table
- Update rpc's where it makes sense to add decimals
- New asset_info_bulk rpc that takes bulk input. Current asset_info is untouched and is to be phased out.

## Where should the reviewer start?
Making sure the cache table is populated and the correctness of data. 
Performance testing to make sure both cache table and rpc's perform as expected. 

## Motivation and context
Supporting bulk asset requests reduces the number of queries needed and the cache table helps reduce the server load for each call while adding a scheduled load. 

## Which issue it fixes?
#138 & #127

## How has this been tested?
Tests have been done but as it adds a new cache table, updates rpc's, and has schema changes. All these things need to be verified to be correct. The asset info cache table is updated every 1 min, so new mints could take up to this limit at worst before some fields in the asset_info_bulk endpoint are populated. 
