### PR TITLE
Null fields in latest epoch info

### DIFF
--- a/files/grest/rpc/epoch/epoch_info.sql
+++ b/files/grest/rpc/epoch/epoch_info.sql
@@ -1,4 +1,7 @@
-CREATE FUNCTION grest.epoch_info (_epoch_no numeric DEFAULT NULL)
+
+DROP FUNCTION IF EXISTS grest.epoch_info (_epoch_no numeric);
+
+CREATE OR REPLACE FUNCTION grest.epoch_info (_epoch_no numeric DEFAULT NULL, _include_unstarted_epoch boolean DEFAULT false)
   RETURNS TABLE (
     epoch_no word31type,
     out_sum text,
@@ -46,9 +49,11 @@ BEGIN
     grest.epoch_info_cache ei
     LEFT JOIN grest.EPOCH_ACTIVE_STAKE_CACHE eas ON eas.epoch_no = ei.epoch_no
   WHERE
-    ei.epoch_no::text LIKE CASE WHEN _epoch_no IS NULL THEN '%' ELSE _epoch_no::text END;
+    ei.epoch_no::text LIKE CASE WHEN _epoch_no IS NULL THEN '%' ELSE _epoch_no::text END
+    AND
+    (_include_unstarted_epoch OR ei.i_first_block_time::integer is not null);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.epoch_info IS 'Get the epoch information, all epochs if no epoch specified';
+COMMENT ON FUNCTION grest.epoch_info IS 'Get the epoch information, all epochs if no epoch specified - if _include_unstarted_epoch is used and set to true also return next epoch that has not commenced yet if cached information is available';
 

--- a/specs/templates/2-api-params.yaml
+++ b/specs/templates/2-api-params.yaml
@@ -160,6 +160,16 @@ parameters:
       in: query
       required: false
       allowEmptyValue: false
+    _include_unstarted_epoch:
+      deprecated: false
+      name: _history
+      description: Include information about nearing but not yet started epoch, to get access to active stake information if available
+      schema:
+        type: boolean
+        example: "false"
+      in: query
+      required: false
+      allowEmptyValue: false
     _pool_bech32:
       deprecated: false
       name: _pool_bech32

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -72,6 +72,7 @@ paths:
         - Epoch
       parameters:
         - $ref: "#/components/parameters/_epoch_no"
+        - $ref: "#/components/parameters/_include_unstarted_epoch"
       responses:
         "200":
           description: Array of detailed summary for each epoch


### PR DESCRIPTION
## Description
Added new optional parameter _include_unstarted_epoch to epoch_info endpoint, to control whether not yet started epoch that gets an entry created by epoch_nonce cron job gets included in query output or not (it's sometimes useful for getting active stake amount for next epoch, is my understanding)

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
https://github.com/cardano-community/koios-artifacts/issues/139

## How has this been tested?
Tested by running the epoch_info curl without new parameter used, and with new parameter set to true against guild and preview networks, observed behaviour just before epoch boundary (expected the parameter-less case to not show not yet started epoch and that's what was observed)

