### PR TITLE
Update projects list of community tools/libraries/projects using Koios

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3,6 +3,10 @@
     {
       "text": "Koios CLI in GoLang",
       "link": "https://github.com/cardano-community/koios-cli"
+    },
+    {
+      "text": "CardanoSharp CSCLI",
+      "link": "https://github.com/CardanoSharp/cscli"
     }
   ],
   "Libraries": [
@@ -15,15 +19,27 @@
       "link": "https://github.com/cardano-community/koios-go-client"
     },
     {
-      "text": "Java client",
+      "text": "Java Client",
       "link": "https://github.com/cardano-community/koios-java-client"
     },
     {
-      "text": "Python Client",
+      "text": "JavaScript Client",
+      "link": "https://meshjs.dev/providers/koios"
+    },
+    {
+      "text": "Python Library - Quixote",
       "link": "https://github.com/cardano-community/koios-python"
+    },
+    {
+      "text": "Python Library - Apex",
+      "link": "https://github.com/cardano-apexpool/koios-api-python"
     }
   ],
   "Community Projects/Tools": [
+    {
+      "text": "ADABox",
+      "link": "https://explorer.adabox.io/pools"
+    },
     {
       "text": "Building On Cardano",
       "link": "https://buildingoncardano.com"
@@ -38,11 +54,11 @@
     },
     {
       "text": "CNTools",
-      "link": "https://cardano-community.github.io/guild-operators/Scripts/cntools/"
-    },
-    {
-      "text": "cscli",
-      "link": "https://github.com/CardanoSharp/cscli"
+      "link": "https://cardano-community.github.io/guild-operators/Scripts/cntools/",
+      "logo": {
+         "dark": "https://github.com/cardano-community/guild-operators/raw/alpha/guild.png",
+         "light": "https://github.com/cardano-community/guild-operators/raw/alpha/guild.png"
+      }
     },
     {
       "text": "Dandelion",
@@ -53,12 +69,32 @@
       "link": "https://eternl.io/"
     },
     {
+      "text": "Mesh SDK",
+      "link": "https://meshjs.dev",
+      "logo": {
+        "dark": "https://meshjs.dev/logo-mesh/black/logo-mesh-black-256x256.png",
+        "light": "https://meshjs.dev/logo-mesh/white/logo-mesh-white-256x256.png"
+      }
+    },
+    {
+      "text": "MusicBox",
+      "link": "https://musicboxnft.com",
+      "logo": {
+        "dark": "https://github.com/adabox-aio/musicbox-website/blob/main/src/main/resources/static/favicon/android-icon-192x192.png",
+        "light": "https://github.com/adabox-aio/musicbox-website/blob/main/src/main/resources/static/favicon/android-icon-192x192.png"
+      }
+    },
+    {
       "text": "Poolpeek",
       "link": "https://poolpeek.com"
     },
     {
       "text": "TosiDrop",
-      "link": "https://tosidrop.io"
+      "link": "https://tosidrop.io",
+      "logo": {
+        "dark": "https://www.tosidrop.io/img/umbrella_blue.png",
+        "light": "https://www.tosidrop.io/img/umbrella_blue.png"
+      }
     },
     {
       "text": "Raw Cardano Explorer",

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -172,28 +172,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days:
-
-    ## CLI
-
-      - [Koios CLI in GoLang](https://github.com/cardano-community/koios-cli)
-
-    ## Libraries
-
-      - [.Net SDK](https://github.com/CardanoSharp/cardanosharp-koios)
-      - [Go Client](https://github.com/cardano-community/koios-go-client)
-      - [Java Client](https://github.com/cardano-community/koios-java-client)
-
-    ## Community Projects/Tools
-
-      - [Building On Cardano](https://buildingoncardano.com)
-      - [CardaStat](cardastat.info)
-      - [CNFT.IO](https://cnft.io)
-      - [CNTools](https://cardano-community.github.io/guild-operators/Scripts/cntools/)
-      - [Dandelion](https://dandelion.link)
-      - [Eternl](https://eternl.io/)
-      - [PoolPeek](https://poolpeek.com)
-      - [TosiDrop](https://tosidrop.io)
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
 
     # FAQ
 

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -172,28 +172,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days:
-
-    ## CLI
-
-      - [Koios CLI in GoLang](https://github.com/cardano-community/koios-cli)
-
-    ## Libraries
-
-      - [.Net SDK](https://github.com/CardanoSharp/cardanosharp-koios)
-      - [Go Client](https://github.com/cardano-community/koios-go-client)
-      - [Java Client](https://github.com/cardano-community/koios-java-client)
-
-    ## Community Projects/Tools
-
-      - [Building On Cardano](https://buildingoncardano.com)
-      - [CardaStat](cardastat.info)
-      - [CNFT.IO](https://cnft.io)
-      - [CNTools](https://cardano-community.github.io/guild-operators/Scripts/cntools/)
-      - [Dandelion](https://dandelion.link)
-      - [Eternl](https://eternl.io/)
-      - [PoolPeek](https://poolpeek.com)
-      - [TosiDrop](https://tosidrop.io)
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
 
     # FAQ
 

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -172,28 +172,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days:
-
-    ## CLI
-
-      - [Koios CLI in GoLang](https://github.com/cardano-community/koios-cli)
-
-    ## Libraries
-
-      - [.Net SDK](https://github.com/CardanoSharp/cardanosharp-koios)
-      - [Go Client](https://github.com/cardano-community/koios-go-client)
-      - [Java Client](https://github.com/cardano-community/koios-java-client)
-
-    ## Community Projects/Tools
-
-      - [Building On Cardano](https://buildingoncardano.com)
-      - [CardaStat](cardastat.info)
-      - [CNFT.IO](https://cnft.io)
-      - [CNTools](https://cardano-community.github.io/guild-operators/Scripts/cntools/)
-      - [Dandelion](https://dandelion.link)
-      - [Eternl](https://eternl.io/)
-      - [PoolPeek](https://poolpeek.com)
-      - [TosiDrop](https://tosidrop.io)
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
 
     # FAQ
 

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -172,28 +172,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days:
-
-    ## CLI
-
-      - [Koios CLI in GoLang](https://github.com/cardano-community/koios-cli)
-
-    ## Libraries
-
-      - [.Net SDK](https://github.com/CardanoSharp/cardanosharp-koios)
-      - [Go Client](https://github.com/cardano-community/koios-go-client)
-      - [Java Client](https://github.com/cardano-community/koios-java-client)
-
-    ## Community Projects/Tools
-
-      - [Building On Cardano](https://buildingoncardano.com)
-      - [CardaStat](cardastat.info)
-      - [CNFT.IO](https://cnft.io)
-      - [CNTools](https://cardano-community.github.io/guild-operators/Scripts/cntools/)
-      - [Dandelion](https://dandelion.link)
-      - [Eternl](https://eternl.io/)
-      - [PoolPeek](https://poolpeek.com)
-      - [TosiDrop](https://tosidrop.io)
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
 
     # FAQ
 

--- a/specs/templates/1-api-info.yaml
+++ b/specs/templates/1-api-info.yaml
@@ -171,28 +171,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days:
-
-    ## CLI
-
-      - [Koios CLI in GoLang](https://github.com/cardano-community/koios-cli)
-
-    ## Libraries
-
-      - [.Net SDK](https://github.com/CardanoSharp/cardanosharp-koios)
-      - [Go Client](https://github.com/cardano-community/koios-go-client)
-      - [Java Client](https://github.com/cardano-community/koios-java-client)
-
-    ## Community Projects/Tools
-
-      - [Building On Cardano](https://buildingoncardano.com)
-      - [CardaStat](cardastat.info)
-      - [CNFT.IO](https://cnft.io)
-      - [CNTools](https://cardano-community.github.io/guild-operators/Scripts/cntools/)
-      - [Dandelion](https://dandelion.link)
-      - [Eternl](https://eternl.io/)
-      - [PoolPeek](https://poolpeek.com)
-      - [TosiDrop](https://tosidrop.io)
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
 
     # FAQ
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Few minor updates to list of projects:
- Remove list from API specs site and link them to koios.rest instead.
- Move CSCLI to CLI
- Add ADABox and MusicBox
- Add MeshJS and Mesh SDK (subsumes #152 - thanks @jinglescode )
- Add both Python libraries (for now - they would not want to merge due to style and completeness, but it could be an option in future for them to collaborate)
- Add logos (need to check with the rest or add links to uploaded versions for upcoming website, the current values are just to add template examples)