### PR TITLE
Switch JSON references to JSONB

### DIFF
--- a/files/grest/rpc/01_cached_tables/pool_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_info_cache.sql
@@ -107,7 +107,7 @@ BEGIN
             WHERE po.pool_update_id = _update_id
         ),
         ARRAY(
-            SELECT json_build_object(
+            SELECT JSONB_BUILD_OBJECT(
                 'ipv4', pr.ipv4,
                 'ipv6', pr.ipv6,
                 'dns', pr.dns_name,
@@ -239,7 +239,7 @@ BEGIN
 
         UPDATE grest.pool_info_cache
         SET
-            relays = relays || jsonb_build_object (
+            relays = relays || JSONB_BUILD_OBJECT (
                                     'ipv4', NEW.ipv4,
                                     'ipv6', NEW.ipv6,
                                     'dns', NEW.dns_name,

--- a/files/grest/rpc/account/account_addresses.sql
+++ b/files/grest/rpc/account/account_addresses.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION grest.account_addresses (_stake_addresses text[], _first_only boolean default false, _empty boolean default false)
   RETURNS TABLE (
     stake_address varchar,
-    addresses json
+    addresses jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -38,7 +38,7 @@ BEGIN
       )
       SELECT
         sa.view as stake_address,
-        JSON_AGG(txo_addr.address) as addresses
+        JSONB_AGG(txo_addr.address) as addresses
       FROM
         txo_addr
         INNER JOIN STAKE_ADDRESS sa ON sa.id = txo_addr.stake_address_id
@@ -65,7 +65,7 @@ BEGIN
       )
       SELECT
         sa.view as stake_address,
-        JSON_AGG(txo_addr.address) as addresses
+        JSONB_AGG(txo_addr.address) as addresses
       FROM
         txo_addr
         INNER JOIN STAKE_ADDRESS sa ON sa.id = txo_addr.stake_address_id

--- a/files/grest/rpc/account/account_assets.sql
+++ b/files/grest/rpc/account/account_assets.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION grest.account_assets (_stake_addresses text[])
   RETURNS TABLE (
     stake_address varchar,
-    asset_list json
+    asset_list jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -45,8 +45,8 @@ BEGIN
   FROM (
     SELECT
       aa.view,
-      JSON_AGG(
-        JSON_BUILD_OBJECT(
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
           'policy_id', ENCODE(aa.policy, 'hex'),
           'asset_name', ENCODE(aa.name, 'hex'),
           'fingerprint', aa.fingerprint,

--- a/files/grest/rpc/account/account_history.sql
+++ b/files/grest/rpc/account/account_history.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION grest.account_history (_stake_addresses text[], _epoch_no integer DEFAULT NULL)
   RETURNS TABLE (
     stake_address varchar,
-    history json
+    history jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -19,8 +19,8 @@ BEGIN
     RETURN QUERY
       SELECT
         sa.view as stake_address,
-        JSON_AGG(
-          JSON_BUILD_OBJECT(
+        JSONB_AGG(
+          JSONB_BUILD_OBJECT(
             'pool_id', ph.view,
             'epoch_no', es.epoch_no::bigint,
             'active_stake', es.amount::text
@@ -40,8 +40,8 @@ BEGIN
     RETURN QUERY
       SELECT
         sa.view as stake_address,
-        JSON_AGG(
-          JSON_BUILD_OBJECT(
+        JSONB_AGG(
+          JSONB_BUILD_OBJECT(
             'pool_id', ph.view,
             'epoch_no', es.epoch_no::bigint,
             'active_stake', es.amount::text

--- a/files/grest/rpc/account/account_rewards.sql
+++ b/files/grest/rpc/account/account_rewards.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION grest.account_rewards (_stake_addresses text[], _epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
     stake_address varchar,
-    rewards json
+    rewards jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -19,8 +19,8 @@ BEGIN
     RETURN QUERY
       SELECT
         sa.view,
-        JSON_AGG(
-          JSON_BUILD_OBJECT(
+        JSONB_AGG(
+          JSONB_BUILD_OBJECT(
           'earned_epoch', r.earned_epoch,
           'spendable_epoch', r.spendable_epoch,
           'amount', r.amount::text,
@@ -40,8 +40,8 @@ BEGIN
     RETURN QUERY
       SELECT
         sa.view,
-        JSON_AGG(
-          JSON_BUILD_OBJECT(
+        JSONB_AGG(
+          JSONB_BUILD_OBJECT(
             'earned_epoch', r.earned_epoch,
             'spendable_epoch', r.spendable_epoch,
             'amount', r.amount::text,

--- a/files/grest/rpc/account/account_updates.sql
+++ b/files/grest/rpc/account/account_updates.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION grest.account_updates (_stake_addresses text[])
   RETURNS TABLE (
     stake_address varchar,
-    updates json
+    updates jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -18,8 +18,8 @@ BEGIN
   RETURN QUERY
     SELECT
       SA.view as stake_address,
-      JSON_AGG(
-        JSON_BUILD_OBJECT(
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
           'action_type', ACTIONS.action_type,
           'tx_hash', ENCODE(TX.HASH, 'hex'),
           'epoch_no', b.epoch_no,

--- a/files/grest/rpc/address/address_assets.sql
+++ b/files/grest/rpc/address/address_assets.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION grest.address_assets (_addresses text[])
   RETURNS TABLE (
     address varchar,
-    asset_list json
+    asset_list jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -36,8 +36,8 @@ BEGIN
   FROM (
     SELECT
       aa.address,
-      JSON_AGG(
-        JSON_BUILD_OBJECT(
+      JSONB_AGG(
+        JSONB_BUILD_OBJECT(
           'policy_id', ENCODE(aa.policy, 'hex'),
           'asset_name', ENCODE(aa.name, 'hex'),
           'fingerprint', aa.fingerprint,

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -1,10 +1,10 @@
-CREATE FUNCTION grest.address_info (_addresses text[])
+CREATE OR REPLACE FUNCTION grest.address_info (_addresses text[])
   RETURNS TABLE (
     address varchar,
     balance text,
     stake_address character varying,
     script_address boolean,
-    utxo_set json
+    utxo_set jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -56,8 +56,8 @@ BEGIN
         CASE WHEN EXISTS (
           SELECT TRUE FROM _all_utxos aus WHERE aus.address = ka.address
         ) THEN
-          JSON_AGG(
-            JSON_BUILD_OBJECT(
+          JSONB_AGG(
+            JSONB_BUILD_OBJECT(
               'tx_hash', ENCODE(au.hash, 'hex'), 
               'tx_index', au.index,
               'block_height', block.block_no,
@@ -86,7 +86,7 @@ BEGIN
               'asset_list', COALESCE(
                 (
                   SELECT
-                    JSON_AGG(JSON_BUILD_OBJECT(
+                    JSONB_AGG(JSONB_BUILD_OBJECT(
                       'policy_id', ENCODE(MA.policy, 'hex'),
                       'asset_name', ENCODE(MA.name, 'hex'),
                       'fingerprint', MA.fingerprint,
@@ -100,12 +100,12 @@ BEGIN
                   WHERE
                       MTX.tx_out_id = au.txo_id
                 ),
-                JSON_BUILD_ARRAY()
+                JSONB_BUILD_ARRAY()
               )
             )
           )
         ELSE
-          '[]'::json
+          '[]'::jsonb
         END as utxo_set
       FROM
         _known_addresses ka

--- a/files/grest/rpc/assets/asset_history.sql
+++ b/files/grest/rpc/assets/asset_history.sql
@@ -1,9 +1,9 @@
-CREATE FUNCTION grest.asset_history (_asset_policy text, _asset_name text default '')
+CREATE OR REPLACE FUNCTION grest.asset_history (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     policy_id text,
     asset_name text,
     fingerprint character varying,
-    minting_txs json[]
+    minting_txs jsonb[]
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -29,7 +29,7 @@ BEGIN
       _asset_name,
       minting_data.fingerprint,
       ARRAY_AGG(
-        JSON_BUILD_OBJECT(
+        JSONB_BUILD_OBJECT(
           'tx_hash', minting_data.tx_hash,
           'block_time', minting_data.block_time,
           'quantity', minting_data.quantity,
@@ -44,10 +44,10 @@ BEGIN
         ENCODE(tx.hash, 'hex') AS tx_hash,
         EXTRACT(epoch from b.time)::integer as block_time,
         mtm.quantity::text,
-        ( CASE WHEN TM.key IS NULL THEN JSON_BUILD_ARRAY()
+        ( CASE WHEN TM.key IS NULL THEN JSONB_BUILD_ARRAY()
           ELSE
-            JSON_AGG(
-              JSON_BUILD_OBJECT(
+            JSONB_AGG(
+              JSONB_BUILD_OBJECT(
                 'key', TM.key::text,
                 'json', TM.json
               )

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION grest.asset_info (_asset_policy text, _asset_name tex
     burn_cnt bigint,
     creation_time integer,
     minting_tx_metadata jsonb,
-    token_registry_metadata json
+    token_registry_metadata jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -43,7 +43,7 @@ BEGIN
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
-        JSON_BUILD_OBJECT(
+        JSONB_BUILD_OBJECT(
           'name', arc.name,
           'description', arc.description,
           'ticker', arc.ticker,

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION grest.asset_info (_asset_list text[][])
     burn_cnt bigint,
     creation_time integer,
     minting_tx_metadata jsonb,
-    token_registry_metadata json
+    token_registry_metadata jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -47,7 +47,7 @@ BEGIN
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
-        JSON_BUILD_OBJECT(
+        JSONB_BUILD_OBJECT(
           'name', arc.name,
           'description', arc.description,
           'ticker', arc.ticker,

--- a/files/grest/rpc/assets/policy_asset_info.sql
+++ b/files/grest/rpc/assets/policy_asset_info.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION grest.asset_policy_info (_asset_policy text)
     burn_cnt bigint,
     creation_time integer,
     minting_tx_metadata jsonb,
-    token_registry_metadata json
+    token_registry_metadata jsonb
   ) 
   LANGUAGE PLPGSQL
   AS $$
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION grest.policy_asset_info (_asset_policy text)
     burn_cnt bigint,
     creation_time integer,
     minting_tx_metadata jsonb,
-    token_registry_metadata json
+    token_registry_metadata jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -53,7 +53,7 @@ BEGIN
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
-        JSON_BUILD_OBJECT(
+        JSONB_BUILD_OBJECT(
           'name', arc.name,
           'description', arc.description,
           'ticker', arc.ticker,

--- a/files/grest/rpc/script/script_redeemers.sql
+++ b/files/grest/rpc/script/script_redeemers.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION grest.script_redeemers (_script_hash text) 
   RETURNS TABLE (
     script_hash text,
-    redeemers json
+    redeemers jsonb
   ) 
 LANGUAGE PLPGSQL AS
 $$
@@ -10,8 +10,8 @@ BEGIN
 SELECT INTO _script_hash_bytea DECODE(_script_hash, 'hex');
 RETURN QUERY
 select _script_hash,
-    JSON_AGG(
-        JSON_BUILD_OBJECT(
+    JSONB_AGG(
+        JSONB_BUILD_OBJECT(
             'tx_hash',
             ENCODE(tx.hash, 'hex'),
             'tx_index',


### PR DESCRIPTION
## Description
Switch all JSON references to JSONB (non-breaking for Koios endpoints consumption):
- Helps columns be kept consistent
- Allows use of filters in PostgREST URL as `cs.[{"key":"value"}]` , allowing filters for arrays.
- Faster to read (tho slower to form) - output performance should not have much impact for 1000 observations (sure, some JSON arrays might be larger, but still - the overhead in larger scheme for creating JSON vs JSONB shouldn't be as big)