### PR TITLE
Apply Fixes from testing on non-mainnet networks

### DIFF
--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -145,7 +145,7 @@ BEGIN
       INNER JOIN tx ON tx.id = mtm.tx_id
       INNER JOIN block b ON b.id = tx.block_id
       INNER JOIN tx_meta tm ON tm.ident = ma.id
-      LEFT JOIN grest.asset_registry_cache arc ON DECODE(arc.asset_policy, 'hex') = ma.policy AND DECODE(arc.asset_name, 'hex') = ma.name
+      LEFT JOIN grest.asset_registry_cache arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = encode(ma.name,'hex')
     WHERE
       CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
         THEN

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.pool_list ()
+CREATE OR REPLACE FUNCTION grest.pool_list ()
   RETURNS TABLE (
     pool_id_bech32 character varying,
     ticker character varying)
@@ -10,24 +10,35 @@ BEGIN
   RETURN QUERY (
     WITH
       -- Get last pool update for each pool
-      _pool_updates AS (
+      _pool_list AS (
         SELECT
           DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
-          pod.ticker_name,
-          pic.pool_status
+          pool_status
+        FROM
+          grest.pool_info_cache AS pic
+        ORDER BY
+          pic.pool_id_bech32,
+          pic.tx_id DESC
+      ),
+      _pool_meta AS (
+        SELECT
+          DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
+          pod.ticker_name
         FROM
           grest.pool_info_cache AS pic
           LEFT JOIN public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
+        WHERE pod.ticker_name IS NOT NULL
         ORDER BY
           pic.pool_id_bech32,
           pic.tx_id DESC
       )
 
     SELECT
-      pool_id_bech32,
-      ticker_name
+      pl.pool_id_bech32,
+      pm.ticker_name
     FROM
-      _pool_updates
+      _pool_list AS pl
+      LEFT JOIN _pool_meta AS pm ON pl.pool_id_bech32 = pm.pool_id_bech32
     WHERE
       pool_status != 'retired'
 

--- a/files/grest/rpc/pool/pool_updates.sql
+++ b/files/grest/rpc/pool/pool_updates.sql
@@ -43,7 +43,7 @@ BEGIN
         retiring_epoch
     FROM
         grest.pool_info_cache pic
-        LEFT JOIN public.pool_offline_data pod ON pod.id = pic.meta_id 
+        LEFT JOIN public.pool_offline_data pod ON pod.pmr_id = pic.meta_id
     WHERE
         _pool_bech32 IS NULL
         OR

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -728,7 +728,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Account Information (Cached)
-      description: Get the cached account information for given stake addresses
+      description: Get the cached account information for given stake addresses, effective for registered accounts
   /account_rewards: #RPC
     post:
       tags:

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -728,7 +728,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Account Information (Cached)
-      description: Get the cached account information for given stake addresses
+      description: Get the cached account information for given stake addresses, effective for registered accounts
   /account_rewards: #RPC
     post:
       tags:

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -728,7 +728,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Account Information (Cached)
-      description: Get the cached account information for given stake addresses
+      description: Get the cached account information for given stake addresses, effective for registered accounts
   /account_rewards: #RPC
     post:
       tags:

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -728,7 +728,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Account Information (Cached)
-      description: Get the cached account information for given stake addresses
+      description: Get the cached account information for given stake addresses, effective for registered accounts
   /account_rewards: #RPC
     post:
       tags:

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -533,7 +533,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Account Information (Cached)
-      description: Get the cached account information for given stake addresses
+      description: Get the cached account information for given stake addresses, effective for registered accounts
   /account_rewards: #RPC
     post:
       tags:


### PR DESCRIPTION
  - Fix Asset Info Cache to not rely on being able to decode policy ID (bad data on IO repo)
  - Handle Pool_list to check metadata entries that have not been populated in pool_offline_data (closes #109 from Koios point of view)
  - Fix pool_updates to use pmr_id instead of pool_offline_data.id (wasnt reported earlier, but the endpoint was showing wrong data)
  - Update account_info_cached description to clarify it is effective for registered accounts

