### PR TITLE
Minor patches for koios-1.0.10

### DIFF
--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -42,7 +42,7 @@ BEGIN
     public.tx;
 
   SELECT
-    COALESCE(last_value::bigint,100) - 100 INTO _asset_info_cache_last_tx_id
+    COALESCE(last_value::bigint,1000) - 1000 INTO _asset_info_cache_last_tx_id
   FROM
     grest.control_table
   WHERE

--- a/files/grest/rpc/account/account_assets.sql
+++ b/files/grest/rpc/account/account_assets.sql
@@ -22,14 +22,14 @@ BEGIN
         ma.policy,
         ma.name,
         ma.fingerprint,
-        aic.decimals,
+        COALESCE(aic.decimals, 0) as decimals,
         SUM(mtx.quantity) as quantity
       FROM
         MA_TX_OUT MTX
         INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
         INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
         INNER JOIN STAKE_ADDRESS sa ON sa.id = TXO.stake_address_id
-        INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+        LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
         LEFT JOIN TX_IN on TXO.TX_ID = TX_IN.TX_OUT_ID
           AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint
       WHERE

--- a/files/grest/rpc/address/address_assets.sql
+++ b/files/grest/rpc/address/address_assets.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.address_assets (_addresses text[])
+CREATE OR REPLACE FUNCTION grest.address_assets (_addresses text[])
   RETURNS TABLE (
     address varchar,
     asset_list jsonb
@@ -14,12 +14,12 @@ BEGIN
       ma.policy,
       ma.name,
       ma.fingerprint,
-      aic.decimals,
+      COALESCE(aic.decimals, 0) as decimals,
       SUM(mtx.quantity) as quantity
     FROM
       MA_TX_OUT MTX
       INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
-      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
       INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
       LEFT JOIN TX_IN ON TXO.TX_ID = TX_IN.TX_OUT_ID
         AND TXO.INDEX::smallint = TX_IN.TX_OUT_INDEX::smallint

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -90,13 +90,13 @@ BEGIN
                       'policy_id', ENCODE(MA.policy, 'hex'),
                       'asset_name', ENCODE(MA.name, 'hex'),
                       'fingerprint', MA.fingerprint,
-                      'decimals', aic.decimals,
+                      'decimals', COALESCE(aic.decimals, 0),
                       'quantity', MTX.quantity::text
                       ))
                   FROM
                       ma_tx_out MTX
                       INNER JOIN multi_asset MA ON MA.id = MTX.ident
-                      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+                      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
                   WHERE
                       MTX.tx_out_id = au.txo_id
                 ),

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -388,7 +388,7 @@ BEGIN
           FROM 
             ma_tx_mint MTM
             INNER JOIN MULTI_ASSET MA ON MA.id = MTM.ident
-            INNER JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+            LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
           WHERE
             MTM.tx_id = ANY (_tx_id_list)
         ) AS tmp

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -1584,7 +1584,7 @@ components:
       description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
       schema:
         type: string
-        example: 41484c636f696e
+        example: "41484c636f696e"
       in: query
       required: false
       allowEmptyValue: true
@@ -3294,6 +3294,7 @@ components:
                   type: string
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+                  nullable: true
                 script_hash:
                   $ref: "#/components/schemas/plutus_script_list/items/properties/script_hash"
                 bytecode:

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -1584,7 +1584,7 @@ components:
       description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
       schema:
         type: string
-        example: 424f4f4b
+        example: "424f4f4b"
       in: query
       required: false
       allowEmptyValue: true
@@ -3294,6 +3294,7 @@ components:
                   type: string
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+                  nullable: true
                 script_hash:
                   $ref: "#/components/schemas/plutus_script_list/items/properties/script_hash"
                 bytecode:

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -1584,7 +1584,7 @@ components:
       description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
       schema:
         type: string
-        example: 7447454e53
+        example: "7447454e53"
       in: query
       required: false
       allowEmptyValue: true
@@ -1634,7 +1634,7 @@ components:
       description: Pool ID in bech32 format
       schema:
         type: string
-        example: pool1tc3suyyxh9796rd92744mne82chxpmfc6mu7qgqzlx56sjfwvvl
+        example: pool1x4p3cwemsm356vpxnjwuud7w76jz64hyss729zp7xa6wuey6yr9
       in: query
       required: true
       allowEmptyValue: false
@@ -1644,7 +1644,7 @@ components:
       description: Pool ID in bech32 format (optional)
       schema:
         type: string
-        example: pool1tc3suyyxh9796rd92744mne82chxpmfc6mu7qgqzlx56sjfwvvl
+        example: pool1x4p3cwemsm356vpxnjwuud7w76jz64hyss729zp7xa6wuey6yr9
       in: query
       required: false
       allowEmptyValue: true
@@ -3294,6 +3294,7 @@ components:
                   type: string
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+                  nullable: true
                 script_hash:
                   $ref: "#/components/schemas/plutus_script_list/items/properties/script_hash"
                 bytecode:

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -1584,7 +1584,7 @@ components:
       description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
       schema:
         type: string
-        example: 433374
+        example: "433374"
       in: query
       required: false
       allowEmptyValue: true
@@ -1758,7 +1758,7 @@ components:
                 description: Only fetch information for a specific epoch
             example:
               _stake_addresses:
-                - stake_test1upv7n2x0lxepkyx8ux2gjt74ecaa39tjgaccxl6hw5fwzngpzf5zt
+                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
                 - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
               _epoch_no: 11
     stake_addresses_with_first_only_and_empty:
@@ -1785,7 +1785,7 @@ components:
                 description: Include zero quantity entries
             example:
               _stake_addresses:
-                - stake_test1upv7n2x0lxepkyx8ux2gjt74ecaa39tjgaccxl6hw5fwzngpzf5zt
+                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
                 - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
     stake_addresses:
       content:
@@ -1803,7 +1803,7 @@ components:
                 description: Array of Cardano stake address(es) in bech32 format
             example:
               _stake_addresses:
-                - stake_test1upv7n2x0lxepkyx8ux2gjt74ecaa39tjgaccxl6hw5fwzngpzf5zt
+                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
                 - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
     credential_txs:
       content:
@@ -3294,6 +3294,7 @@ components:
                   type: string
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+                  nullable: true
                 script_hash:
                   $ref: "#/components/schemas/plutus_script_list/items/properties/script_hash"
                 bytecode:

--- a/specs/templates/2-api-params.yaml
+++ b/specs/templates/2-api-params.yaml
@@ -146,7 +146,7 @@ parameters:
       description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
       schema:
         type: string
-        example: ##_asset_name_param##
+        example: "##_asset_name_param##"
       in: query
       required: false
       allowEmptyValue: true

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1348,6 +1348,7 @@ schemas:
                   type: string
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+                  nullable: true
                 script_hash:
                   $ref: "#/components/schemas/plutus_script_list/items/properties/script_hash"
                 bytecode:

--- a/specs/templates/example-map.json
+++ b/specs/templates/example-map.json
@@ -70,13 +70,13 @@
       "m": "pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc",
       "g": "pool1xc9eywck4e20tydz4yvh5vfe0ep8whawvwz8wqkc9k046a2ypp4",
       "pv": "pool1leml52hm4fcp3hhe4zye08qz27llhj7d339p3gs0tl85cstx59q",
-      "pp": "pool1tc3suyyxh9796rd92744mne82chxpmfc6mu7qgqzlx56sjfwvvl"
+      "pp": "pool1x4p3cwemsm356vpxnjwuud7w76jz64hyss729zp7xa6wuey6yr9"
     },
     "_pool_bech32_optional": {
       "m": "pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc",
       "g": "pool1xc9eywck4e20tydz4yvh5vfe0ep8whawvwz8wqkc9k046a2ypp4",
       "pv": "pool1leml52hm4fcp3hhe4zye08qz27llhj7d339p3gs0tl85cstx59q",
-      "pp": "pool1tc3suyyxh9796rd92744mne82chxpmfc6mu7qgqzlx56sjfwvvl"
+      "pp": "pool1x4p3cwemsm356vpxnjwuud7w76jz64hyss729zp7xa6wuey6yr9"
     },
     "_script_hash": {
       "m": "d8480dc869b94b80e81ec91b0abe307279311fe0e7001a9488f61ff8",
@@ -107,7 +107,7 @@
     "stake_addresses1": {
       "m": "stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250",
       "g": "stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2",
-      "pv": "stake_test1upv7n2x0lxepkyx8ux2gjt74ecaa39tjgaccxl6hw5fwzngpzf5zt",
+      "pv": "stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p",
       "pp": "stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l"
     },
     "stake_addresses2": {


### PR DESCRIPTION
## Description

- Bump up margin for tx rollback lookup for asset_info_cache to 1000 , as 100 is too small a margin for 2-3 blocks , which can contain more than 100 transactions (of which if oldest transaction contains a mint, it will not get into the cache)
- Specs:
  - Fix examples in for preprod/preview
  - Update tx_info > plutus_contracts > address to be nullable
- For `asset_list` object in address/account/tx related endpoints - reduce strictness with asset_info_cache, making it a `LEFT JOIN` instead of `INNER JOIN` in case the cache does not (yet) have an entry for those assets - since it's only used for decimals. The asset_info/policy_asset_info/asset_addresses/asset_nft_address/policy_asset_list endpoints have more dependency on this cache - they're untouched

## How has this been tested?

- Asset info cache was tested based on results against user reported error
- Spec changes were tested using schemathesis on preprod/preview