### PR TITLE
Update [most] cron jobs to exit if the database has not received block in 5 mins

### DIFF
--- a/files/grest/cron/jobs/asset-info-cache-update.sh
+++ b/files/grest/cron/jobs/asset-info-cache-update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Running asset info cache update..."
-psql ${DB_NAME} -qbt -c "SELECT grest.asset_info_cache_update();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "SELECT grest.asset_info_cache_update();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/cron/jobs/epoch-info-cache-update.sh
+++ b/files/grest/cron/jobs/epoch-info-cache-update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Running epoch info cache update..."
-psql ${DB_NAME} -qbt -c "SELECT GREST.EPOCH_INFO_CACHE_UPDATE();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "SELECT GREST.EPOCH_INFO_CACHE_UPDATE();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/cron/jobs/pool-history-cache-update.sh
+++ b/files/grest/cron/jobs/pool-history-cache-update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Running pool history cache update..."
-psql ${DB_NAME} -qbt -c "SELECT GREST.pool_history_cache_update();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "SELECT GREST.pool_history_cache_update();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/cron/jobs/stake-distribution-new-accounts-update.sh
+++ b/files/grest/cron/jobs/stake-distribution-new-accounts-update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Running stake distribution update for new accounts..."
-psql ${DB_NAME} -qbt -c "CALL GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "CALL GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/cron/jobs/stake-distribution-update.sh
+++ b/files/grest/cron/jobs/stake-distribution-update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Running stake distribution update..."
-psql ${DB_NAME} -qbt -c "SELECT GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "SELECT GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/cron/jobs/stake-snapshot-cache.sh
+++ b/files/grest/cron/jobs/stake-snapshot-cache.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DB_NAME=cexplorer
 
+tip=$(psql ${DB_NAME} -qbt -c "select time from block order by id desc limit 1;")
+
+if [[ $(( $(date +%s) - $(TZ=UTC date --date="${tip}" +%s) )) -gt 300 ]]; then
+  echo "$(date +%F_%H:%M:%S) Skipping as database has not received a new block in past 300 seconds!" && exit 1
+fi
+
 echo "$(date +%F_%H:%M:%S) Capturing last epochs' snapshot..."
-psql ${DB_NAME} -qbt -c "CALL GREST.CAPTURE_LAST_EPOCH_SNAPSHOT();" 2>&1 1>/dev/null
+psql ${DB_NAME} -qbt -c "CALL GREST.CAPTURE_LAST_EPOCH_SNAPSHOT();" 1>/dev/null 2>&1
 echo "$(date +%F_%H:%M:%S) Job done!"


### PR DESCRIPTION
## Description

Update cron jobs (except asset registry cache) to exit if database has not received block in past 5 minutes

## Motivation and context

Starting cache update too early can risk slowing the sync process further (as well as the cache itself could be stale/redundant)

## How has this been tested?
Applied on my instance while database was synching to avoid triggering another run, while after on tip ensured those cron jobs ran
