### PR TITLE
addresses: Filter input tx IDs by _after_block_height

### DIFF
--- a/files/grest/rpc/address/credential_txs.sql
+++ b/files/grest/rpc/address/credential_txs.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_height integer DEFAULT 0)
+CREATE OR REPLACE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_height integer DEFAULT 0)
   RETURNS TABLE (
     tx_hash text,
     epoch_no word31type,
@@ -9,6 +9,7 @@ CREATE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_
   AS $$
 DECLARE
   _payment_cred_bytea  bytea[];
+  _tx_id_min bigint;
   _tx_id_list     bigint[];
 BEGIN
   -- convert input _payment_credentials array into bytea array
@@ -20,6 +21,11 @@ BEGIN
       UNNEST(_payment_credentials) AS cred_hex
   ) AS tmp;
 
+  SELECT INTO _tx_id_min id
+  FROM tx
+  WHERE block_id >= (SELECT id FROM block WHERE block_no = _after_block_height)
+  ORDER BY id limit 1;
+
   -- all tx_out & tx_in tx ids
   SELECT INTO _tx_id_list ARRAY_AGG(tx_id)
   FROM (
@@ -29,6 +35,7 @@ BEGIN
       tx_out
     WHERE
       payment_cred = ANY (_payment_cred_bytea)
+      AND tx_id >= _tx_id_min
     --
     UNION
     --
@@ -41,6 +48,7 @@ BEGIN
     WHERE
       tx_in.tx_in_id IS NOT NULL
       AND tx_out.payment_cred = ANY (_payment_cred_bytea)
+      AND tx_in.tx_in_id >= _tx_id_min
   ) AS tmp;
 
   RETURN QUERY


### PR DESCRIPTION
## Description

The input tx_id fields are not filtered by `_after_block_height` , this PR addresses the same
  - [x] address_txs
  - [x] credential_txs

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
