### PR TITLE
Add SQL Format updates as per SQLFluff guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tests/**/__pycache__
 tests/**/.*
 .vscode
+.swp

--- a/files/grest/.sqlfluff
+++ b/files/grest/.sqlfluff
@@ -1,0 +1,18 @@
+[sqlfluff]
+dialect = postgres
+exclude_rules = structure.column_order, references.keywords
+max_line_length=260
+recurse = 0
+capitalisation_policy = upper
+extended_capitalisation_policy = upper
+idented_joins = True
+indented_using_on = False
+tab_space_size = 2
+large_file_skip_byte_limit=35000
+
+[sqlfluff:indentation]
+tab_space_size = 2
+allow_implicit_indents = True
+
+[sqlfluff:rules:convention.count_rows]
+prefer_count_1 = True

--- a/files/grest/rpc/00_blockchain/genesis.sql
+++ b/files/grest/rpc/00_blockchain/genesis.sql
@@ -1,36 +1,36 @@
-CREATE FUNCTION grest.genesis ()
-  RETURNS TABLE (
-    NETWORKMAGIC varchar,
-    NETWORKID varchar,
-    ACTIVESLOTCOEFF varchar,
-    UPDATEQUORUM varchar,
-    MAXLOVELACESUPPLY varchar,
-    EPOCHLENGTH varchar,
-    SYSTEMSTART integer,
-    SLOTSPERKESPERIOD varchar,
-    SLOTLENGTH varchar,
-    MAXKESREVOLUTIONS varchar,
-    SECURITYPARAM varchar,
-    ALONZOGENESIS varchar
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.genesis()
+RETURNS TABLE (
+  networkmagic varchar,
+  networkid varchar,
+  activeslotcoeff varchar,
+  updatequorum varchar,
+  maxlovelacesupply varchar,
+  epochlength varchar,
+  systemstart integer,
+  slotsperkesperiod varchar,
+  slotlength varchar,
+  maxkesrevolutions varchar,
+  securityparam varchar,
+  alonzogenesis varchar
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   SELECT
-    g.NETWORKMAGIC,
-    g.NETWORKID,
-    g.ACTIVESLOTCOEFF,
-    g.UPDATEQUORUM,
-    g.MAXLOVELACESUPPLY,
-    g.EPOCHLENGTH,
-    EXTRACT(epoch from g.SYSTEMSTART::timestamp)::integer,
-    g.SLOTSPERKESPERIOD,
-    g.SLOTLENGTH,
-    g.MAXKESREVOLUTIONS,
-    g.SECURITYPARAM,
-    g.ALONZOGENESIS
+    g.networkmagic,
+    g.networkid,
+    g.activeslotcoeff,
+    g.updatequorum,
+    g.maxlovelacesupply,
+    g.epochlength,
+    EXTRACT(EPOCH FROM g.systemstart::timestamp)::integer,
+    g.slotsperkesperiod,
+    g.slotlength,
+    g.maxkesrevolutions,
+    g.securityparam,
+    g.alonzogenesis
   FROM
-    grest.genesis g;
+    grest.genesis AS g;
 END;
 $$;

--- a/files/grest/rpc/00_blockchain/param_updates.sql
+++ b/files/grest/rpc/00_blockchain/param_updates.sql
@@ -1,20 +1,19 @@
-CREATE OR REPLACE FUNCTION grest.param_updates ()
-  RETURNS TABLE (
-    tx_hash text,
-    block_height word31type,
-    block_time integer,
-    epoch_no word31type,
-    data jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
-
+CREATE OR REPLACE FUNCTION grest.param_updates()
+RETURNS TABLE (
+  tx_hash text,
+  block_height word31type,
+  block_time integer,
+  epoch_no word31type,
+  data jsonb
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
     SELECT DISTINCT ON (pp.registered_tx_id)
-      ENCODE(t.hash,'hex') as tx_hash,
+      ENCODE(t.hash,'hex') AS tx_hash,
       b.block_no AS block_height,
-      EXTRACT(epoch from b.time)::integer as block_time,
+      EXTRACT(EPOCH FROM b.time)::integer AS block_time,
       b.epoch_no,
       JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
           'min_fee_a', pp.min_fee_a,
@@ -47,13 +46,12 @@ BEGIN
           'max_collateral_inputs', pp.max_collateral_inputs,
           'coins_per_utxo_size', pp.coins_per_utxo_size
         )) AS data
-      FROM
-        public.param_proposal pp
-        INNER JOIN tx t ON t.id = pp.registered_tx_id
-        INNER JOIN block b ON t.block_id = b.id
-        LEFT JOIN cost_model CM ON CM.id = pp.cost_model_id
-      ;
+    FROM
+      public.param_proposal pp
+      INNER JOIN tx t ON t.id = pp.registered_tx_id
+      INNER JOIN block b ON t.block_id = b.id
+      LEFT JOIN cost_model CM ON CM.id = pp.cost_model_id;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.param_updates IS 'Parameter updates applied to the network';
+COMMENT ON FUNCTION grest.param_updates IS 'Parameter updates applied to the network'; -- noqa: LT01

--- a/files/grest/rpc/00_blockchain/tip.sql
+++ b/files/grest/rpc/00_blockchain/tip.sql
@@ -1,30 +1,29 @@
-CREATE FUNCTION grest.tip ()
-  RETURNS TABLE (
-    hash text,
-    epoch_no word31type,
-    abs_slot word63type,
-    epoch_slot word31type,
-    block_no word31type,
-    block_time integer
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.tip()
+RETURNS TABLE (
+  hash text,
+  epoch_no word31type,
+  abs_slot word63type,
+  epoch_slot word31type,
+  block_no word31type,
+  block_time integer
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   SELECT
-    ENCODE(B.HASH::bytea, 'hex') AS BLOCK_HASH,
-    b.EPOCH_NO AS EPOCH_NO,
-    b.SLOT_NO AS ABS_SLOT,
-    b.EPOCH_SLOT_NO AS EPOCH_SLOT,
-    b.BLOCK_NO,
-    EXTRACT(EPOCH from b.TIME)::integer
+    ENCODE(b.hash::bytea, 'hex') AS block_hash,
+    b.epoch_no AS epoch_no,
+    b.slot_no AS abs_slot,
+    b.epoch_slot_no AS epoch_slot,
+    b.block_no,
+    EXTRACT(EPOCH FROM b.time)::integer
   FROM
-    BLOCK B
+    block b
   ORDER BY
-    B.ID DESC
+    b.id DESC
   LIMIT 1;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.tip IS 'Get the tip info about the latest block seen by chain';
-
+COMMENT ON FUNCTION grest.tip IS 'Get the tip info about the latest block seen by chain'; -- noqa: LT01

--- a/files/grest/rpc/00_blockchain/totals.sql
+++ b/files/grest/rpc/00_blockchain/totals.sql
@@ -1,36 +1,44 @@
-CREATE FUNCTION grest.totals (_epoch_no numeric DEFAULT NULL)
-  RETURNS TABLE (
-    epoch_no word31type,
-    circulation text,
-    treasury text,
-    reward text,
-    supply text,
-    reserves text
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.totals(_epoch_no numeric DEFAULT NULL)
+RETURNS TABLE (
+  epoch_no word31type,
+  circulation text,
+  treasury text,
+  reward text,
+  supply text,
+  reserves text
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   IF _epoch_no IS NULL THEN
     RETURN QUERY (
       SELECT
-          ap.epoch_no, ap.utxo::text, ap.treasury::text, ap.rewards::text, (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees)::text as supply, ap.reserves::text
-        FROM
-          public.ada_pots as ap
-        ORDER BY
-          ap.epoch_no DESC) ;
+        ap.epoch_no,
+        ap.utxo::text,
+        ap.treasury::text,
+        ap.rewards::text,
+        (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees)::text AS supply,
+        ap.reserves::text
+      FROM
+        public.ada_pots AS ap
+      ORDER BY
+        ap.epoch_no DESC);
   ELSE
     RETURN QUERY (
       SELECT
-          ap.epoch_no, ap.utxo::text, ap.treasury::text, ap.rewards::text, (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees)::text as supply, ap.reserves::text
-        FROM
-          public.ada_pots as ap
-        WHERE
-          ap.epoch_no = _epoch_no
-        ORDER BY
-          ap.epoch_no DESC);
+        ap.epoch_no, ap.utxo::text,
+        ap.treasury::text,
+        ap.rewards::text,
+        (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees)::text AS supply,
+        ap.reserves::text
+      FROM
+        public.ada_pots AS ap
+      WHERE
+        ap.epoch_no = _epoch_no
+      ORDER BY
+        ap.epoch_no DESC);
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.totals IS 'Get the circulating utxo, treasury, rewards, supply and reserves in lovelace for specified epoch, all epochs if empty';
-
+COMMENT ON FUNCTION grest.totals IS 'Get the circulating utxo, treasury, rewards, supply and reserves in lovelace for specified epoch, all epochs if empty'; -- noqa: LT01

--- a/files/grest/rpc/01_cached_tables/active_stake_cache.sql
+++ b/files/grest/rpc/01_cached_tables/active_stake_cache.sql
@@ -1,182 +1,133 @@
-CREATE TABLE IF NOT EXISTS GREST.POOL_ACTIVE_STAKE_CACHE (
-  POOL_ID varchar NOT NULL,
-  EPOCH_NO bigint NOT NULL,
-  AMOUNT LOVELACE NOT NULL,
-  PRIMARY KEY (POOL_ID, EPOCH_NO)
+CREATE TABLE IF NOT EXISTS grest.pool_active_stake_cache (
+  pool_id varchar NOT NULL,
+  epoch_no bigint NOT NULL,
+  amount lovelace NOT NULL,
+  PRIMARY KEY (pool_id, epoch_no)
 );
 
-CREATE TABLE IF NOT EXISTS GREST.EPOCH_ACTIVE_STAKE_CACHE (
-  EPOCH_NO bigint NOT NULL,
-  AMOUNT LOVELACE NOT NULL,
-  PRIMARY KEY (EPOCH_NO)
+CREATE TABLE IF NOT EXISTS grest.epoch_active_stake_cache (
+  epoch_no bigint NOT NULL,
+  amount lovelace NOT NULL,
+  PRIMARY KEY (epoch_no)
 );
 
-CREATE TABLE IF NOT EXISTS GREST.ACCOUNT_ACTIVE_STAKE_CACHE (
-  STAKE_ADDRESS varchar NOT NULL,
-  POOL_ID varchar NOT NULL,
-  EPOCH_NO bigint NOT NULL,
-  AMOUNT LOVELACE NOT NULL,
-  PRIMARY KEY (STAKE_ADDRESS, POOL_ID, EPOCH_NO)
+CREATE TABLE IF NOT EXISTS grest.account_active_stake_cache (
+  stake_address varchar NOT NULL,
+  pool_id varchar NOT NULL,
+  epoch_no bigint NOT NULL,
+  amount lovelace NOT NULL,
+  PRIMARY KEY (stake_address, pool_id, epoch_no)
 );
 
-CREATE FUNCTION grest.active_stake_cache_update_check ()
-  RETURNS BOOLEAN
-  LANGUAGE plpgsql
-  AS
-$$
-  DECLARE
+CREATE OR REPLACE FUNCTION grest.active_stake_cache_update_check()
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
   _current_epoch_no integer;
   _last_active_stake_validated_epoch text;
-  BEGIN
-
-    -- Get Last Active Stake Validated Epoch
-    SELECT last_value
-      INTO _last_active_stake_validated_epoch
-    FROM
-      grest.control_table
-    WHERE
-      key = 'last_active_stake_validated_epoch';
-
-    -- Get Current Epoch
-    SELECT MAX(NO)
-      INTO _current_epoch_no
-    FROM epoch;
-
-    RAISE NOTICE 'Current epoch: %',
-      _current_epoch_no;
-    RAISE NOTICE 'Last active stake validated epoch: %',
-      _last_active_stake_validated_epoch;
-
-    IF 
-      _current_epoch_no > COALESCE(_last_active_stake_validated_epoch::integer, 0)
-    THEN 
-      RETURN TRUE;
-    END IF;
-
-    RETURN FALSE;
-  END;
+BEGIN
+  -- Get Last Active Stake Validated Epoch
+  SELECT last_value INTO _last_active_stake_validated_epoch
+  FROM grest.control_table
+  WHERE key = 'last_active_stake_validated_epoch';
+  -- Get Current Epoch
+  SELECT MAX(no) INTO _current_epoch_no
+  FROM epoch;
+  RAISE NOTICE 'Current epoch: %', _current_epoch_no;
+  RAISE NOTICE 'Last active stake validated epoch: %', _last_active_stake_validated_epoch;
+  IF _current_epoch_no > COALESCE(_last_active_stake_validated_epoch::integer, 0) THEN
+    RETURN TRUE;
+  END IF;
+  RETURN FALSE;
+END;
 $$;
 
-COMMENT ON FUNCTION grest.active_stake_cache_update_check
-  IS 'Internal function to determine whether active stake cache should be updated';
+COMMENT ON FUNCTION grest.active_stake_cache_update_check IS 'Internal function to determine whether active stake cache should be updated'; -- noqa: LT01
 
-CREATE FUNCTION grest.active_stake_cache_update (_epoch_no integer)
-  RETURNS VOID
-  LANGUAGE plpgsql
-  AS
-$$
-  DECLARE
+CREATE OR REPLACE FUNCTION grest.active_stake_cache_update(_epoch_no integer)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
   _last_active_stake_validated_epoch integer;
   _last_account_active_stake_cache_epoch_no integer;
-  BEGIN
-
-    /* CHECK PREVIOUS QUERY FINISHED RUNNING */
+BEGIN
+    -- CHECK PREVIOUS QUERY FINISHED RUNNING
     IF (
-      SELECT
-        COUNT(pid) > 1
-      FROM
-        pg_stat_activity
-      WHERE
-        state = 'active'
-          AND 
-        query ILIKE '%grest.active_stake_cache_update(%'
-          AND 
-        datname = (
-          SELECT
-          current_database()
-      )
-    ) THEN 
-      RAISE EXCEPTION 
+      SELECT COUNT(pid) > 1
+      FROM pg_stat_activity
+      WHERE state = 'active'
+        AND query ILIKE '%grest.active_stake_cache_update(%'
+        AND datname = (SELECT current_database())
+    ) THEN
+      RAISE EXCEPTION
         'Previous query still running but should have completed! Exiting...';
     END IF;
-    
-    /* GET PREVIOUS RUN's EPOCH_NO */
-    SELECT
-      COALESCE(last_value::integer, 0)
-    INTO
-      _last_active_stake_validated_epoch
-    FROM
-      GREST.CONTROL_TABLE
-    WHERE key = 'last_active_stake_validated_epoch';
-
-    /* POOL ACTIVE STAKE CACHE */
-    INSERT INTO GREST.POOL_ACTIVE_STAKE_CACHE
+    -- GET PREVIOUS RUN's epoch_no
+    SELECT COALESCE(
+      (SELECT last_value::integer
+        FROM grest.control_table
+        WHERE key = 'last_active_stake_validated_epoch'), 0) INTO _last_active_stake_validated_epoch;
+    -- POOL ACTIVE STAKE CACHE
+    INSERT INTO grest.pool_active_stake_cache
       SELECT
-        POOL_HASH.VIEW AS POOL_ID,
-        EPOCH_STAKE.EPOCH_NO,
-        SUM(EPOCH_STAKE.AMOUNT) AS AMOUNT
-      FROM
-        PUBLIC.EPOCH_STAKE
-        INNER JOIN PUBLIC.POOL_HASH ON POOL_HASH.ID = EPOCH_STAKE.POOL_ID
-      WHERE
-        EPOCH_STAKE.EPOCH_NO >= _last_active_stake_validated_epoch
-          AND
-        EPOCH_STAKE.EPOCH_NO <= _epoch_no
+        pool_hash.view AS pool_id,
+        epoch_stake.epoch_no,
+        SUM(epoch_stake.amount) AS amount
+      FROM public.epoch_stake
+      INNER JOIN public.pool_hash ON pool_hash.id = epoch_stake.pool_id
+      WHERE epoch_stake.epoch_no >= _last_active_stake_validated_epoch
+        AND epoch_stake.epoch_no <= _epoch_no
       GROUP BY
-        POOL_HASH.VIEW,
-        EPOCH_STAKE.EPOCH_NO
+        pool_hash.view,
+        epoch_stake.epoch_no
     ON CONFLICT (
-      POOL_ID,
-      EPOCH_NO
+      pool_id,
+      epoch_no
     ) DO UPDATE
-      SET AMOUNT = EXCLUDED.AMOUNT
-      WHERE POOL_ACTIVE_STAKE_CACHE.AMOUNT IS DISTINCT FROM EXCLUDED.AMOUNT;
-    
-    /* EPOCH ACTIVE STAKE CACHE */
-    INSERT INTO GREST.EPOCH_ACTIVE_STAKE_CACHE
+      SET amount = excluded.amount
+      WHERE pool_active_stake_cache.amount IS DISTINCT FROM excluded.amount;
+    -- EPOCH ACTIVE STAKE CACHE
+    INSERT INTO grest.epoch_active_stake_cache
       SELECT
-        EPOCH_STAKE.EPOCH_NO,
-        SUM(EPOCH_STAKE.AMOUNT) AS AMOUNT
-      FROM
-        PUBLIC.EPOCH_STAKE
-      WHERE
-        EPOCH_STAKE.EPOCH_NO >= _last_active_stake_validated_epoch
-          AND
-        EPOCH_STAKE.EPOCH_NO <= _epoch_no
-      GROUP BY
-        EPOCH_STAKE.EPOCH_NO
-      ON CONFLICT (
-        EPOCH_NO
-      ) DO UPDATE
-        SET AMOUNT = EXCLUDED.AMOUNT
-        WHERE EPOCH_ACTIVE_STAKE_CACHE.AMOUNT IS DISTINCT FROM EXCLUDED.AMOUNT;
+        epoch_stake.epoch_no,
+        SUM(epoch_stake.amount) AS amount
+      FROM public.epoch_stake
+      WHERE epoch_stake.epoch_no >= _last_active_stake_validated_epoch
+        AND epoch_stake.epoch_no <= _epoch_no
+      GROUP BY epoch_stake.epoch_no
+      ON CONFLICT (epoch_no) DO UPDATE
+        SET amount = excluded.amount
+        WHERE epoch_active_stake_cache.amount IS DISTINCT FROM excluded.amount;
+    -- ACCOUNT ACTIVE STAKE CACHE
+    SELECT COALESCE(MAX(epoch_no), (_epoch_no - 4)) INTO _last_account_active_stake_cache_epoch_no
+    FROM grest.account_active_stake_cache;
 
-    /* ACCOUNT ACTIVE STAKE CACHE */
-    SELECT
-      COALESCE(MAX(epoch_no), (_epoch_no - 4) )
-    INTO _last_account_active_stake_cache_epoch_no
-    FROM
-      GREST.ACCOUNT_ACTIVE_STAKE_CACHE;
-
-    INSERT INTO GREST.ACCOUNT_ACTIVE_STAKE_CACHE
+    INSERT INTO grest.account_active_stake_cache
       SELECT
-        STAKE_ADDRESS.VIEW AS STAKE_ADDRESS,
-        POOL_HASH.VIEW AS POOL_ID,
-        EPOCH_STAKE.EPOCH_NO AS EPOCH_NO,
-        SUM(EPOCH_STAKE.AMOUNT) AS AMOUNT
-      FROM
-        PUBLIC.EPOCH_STAKE
-        INNER JOIN PUBLIC.POOL_HASH ON POOL_HASH.ID = EPOCH_STAKE.POOL_ID
-        INNER JOIN PUBLIC.STAKE_ADDRESS ON STAKE_ADDRESS.ID = EPOCH_STAKE.ADDR_ID
-      WHERE
-        EPOCH_STAKE.EPOCH_NO > _last_account_active_stake_cache_epoch_no
-          AND
-        EPOCH_STAKE.EPOCH_NO <= _epoch_no
+        stake_address.view AS stake_address,
+        pool_hash.view AS pool_id,
+        epoch_stake.epoch_no AS epoch_no,
+        SUM(epoch_stake.amount) AS amount
+      FROM public.epoch_stake
+      INNER JOIN public.pool_hash ON pool_hash.id = epoch_stake.pool_id
+      INNER JOIN public.stake_address ON stake_address.id = epoch_stake.addr_id
+      WHERE epoch_stake.epoch_no > _last_account_active_stake_cache_epoch_no
+        AND epoch_stake.epoch_no <= _epoch_no
       GROUP BY
-        STAKE_ADDRESS.ID,
-        POOL_HASH.ID,
-        EPOCH_STAKE.EPOCH_NO
+        stake_address.id,
+        pool_hash.id,
+        epoch_stake.epoch_no
     ON CONFLICT (
-      STAKE_ADDRESS,
-      POOL_ID,
-      EPOCH_NO
+      stake_address,
+      pool_id,
+      epoch_no
     ) DO UPDATE
-      SET AMOUNT = EXCLUDED.AMOUNT;
-
-    DELETE FROM GREST.ACCOUNT_ACTIVE_STAKE_CACHE
-      WHERE EPOCH_NO <= (_epoch_no - 4);
-
-    /* CONTROL TABLE ENTRY */
+      SET amount = excluded.amount;
+    DELETE FROM grest.account_active_stake_cache
+    WHERE epoch_no <= (_epoch_no - 4);
+    -- CONTROL TABLE ENTRY
     PERFORM grest.update_control_table(
       'last_active_stake_validated_epoch',
       _epoch_no::text
@@ -184,5 +135,4 @@ $$
   END;
 $$;
 
-COMMENT ON FUNCTION grest.active_stake_cache_update
-  IS 'Internal function to update active stake cache (epoch, pool, and account tables).';
+COMMENT ON FUNCTION grest.active_stake_cache_update IS 'Internal function to update active stake cache (epoch, pool, and account tables).'; -- noqa: LT01

--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -6,18 +6,18 @@ CREATE TABLE IF NOT EXISTS grest.asset_info_cache (
   mint_cnt bigint,
   burn_cnt bigint,
   first_mint_tx_id bigint,
-  first_mint_keys text[],
+  first_mint_keys text [],
   last_mint_tx_id bigint,
-  last_mint_keys text[]
+  last_mint_keys text []
 );
 
 CREATE INDEX IF NOT EXISTS idx_first_mint_tx_id ON grest.asset_info_cache (first_mint_tx_id);
 CREATE INDEX IF NOT EXISTS idx_last_mint_tx_id ON grest.asset_info_cache (last_mint_tx_id);
 
-CREATE OR REPLACE FUNCTION grest.asset_info_cache_update ()
-  RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_info_cache_update()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _lastest_tx_id bigint;
   _asset_info_cache_last_tx_id bigint;
@@ -25,40 +25,30 @@ DECLARE
 BEGIN
   -- Check previous cache update completed before running
   IF (
-    SELECT
-      COUNT(pid) > 1
-    FROM
-      pg_stat_activity
-    WHERE
-      state = 'active' AND query ILIKE '%grest.asset_info_cache_update%'
+    SELECT COUNT(pid) > 1
+    FROM pg_stat_activity
+    WHERE state = 'active'
+      AND query ILIKE '%grest.asset_info_cache_update%'
       AND datname = (SELECT current_database())
   ) THEN 
     RAISE EXCEPTION 'Previous asset_info_cache_update query still running but should have completed! Exiting...';
   END IF;
 
-  SELECT
-    MAX(id) INTO _lastest_tx_id
-  FROM
-    public.tx;
+  SELECT MAX(id) INTO _lastest_tx_id
+  FROM public.tx;
 
-  SELECT
-    COALESCE(last_value::bigint,1000) - 1000 INTO _asset_info_cache_last_tx_id
-  FROM
-    grest.control_table
-  WHERE
-    key = 'asset_info_cache_last_tx_id';
+  SELECT COALESCE(last_value::bigint,1000) - 1000 INTO _asset_info_cache_last_tx_id
+  FROM grest.control_table
+  WHERE key = 'asset_info_cache_last_tx_id';
 
   IF _asset_info_cache_last_tx_id IS NULL THEN
     RAISE NOTICE 'Asset info cache table is empty, deleting all previous cache records and starting initial population...';
     TRUNCATE TABLE grest.asset_info_cache;
   ELSE
-    RAISE NOTICE 'Updating asset info based on data from transaction id in range % - % ...', _asset_info_cache_last_tx_id, _lastest_tx_id;
-    SELECT
-      ARRAY_AGG(DISTINCT ident) INTO _asset_id_list
-    FROM
-      ma_tx_mint
-    WHERE
-      tx_id > _asset_info_cache_last_tx_id;
+    RAISE NOTICE 'Updating asset info based ON data FROM transaction id in range % - % ...', _asset_info_cache_last_tx_id, _lastest_tx_id;
+    SELECT ARRAY_AGG(DISTINCT ident) INTO _asset_id_list
+    FROM ma_tx_mint
+    WHERE tx_id > _asset_info_cache_last_tx_id;
   END IF;
 
   WITH
@@ -68,17 +58,15 @@ BEGIN
         mtm.ident,
         MIN(mtm.tx_id) AS first_mint_tx_id, 
         MAX(mtm.tx_id) AS last_mint_tx_id
-      FROM 
-        ma_tx_mint mtm
-        INNER JOIN tx_metadata tm ON tm.tx_id = mtm.tx_id
+      FROM ma_tx_mint AS mtm
+      INNER JOIN tx_metadata AS tm ON tm.tx_id = mtm.tx_id
       WHERE
         CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
           THEN
-            mtm.ident = any(_asset_id_list)
+            mtm.ident = ANY(_asset_id_list)
             AND mtm.tx_id > _asset_info_cache_last_tx_id
           ELSE TRUE
         END
-        AND mtm.quantity > 0
         AND tm.json IS NOT NULL
       GROUP BY mtm.ident
     ),
@@ -88,21 +76,19 @@ BEGIN
         mtm.ident,
         MIN(mtm.tx_id) AS first_mint_tx_id, 
         MAX(mtm.tx_id) AS last_mint_tx_id
-      FROM 
-        ma_tx_mint mtm
-        LEFT JOIN tx_mint_meta ON tx_mint_meta.ident = mtm.ident
+      FROM ma_tx_mint AS mtm
+      LEFT JOIN tx_mint_meta ON tx_mint_meta.ident = mtm.ident
       WHERE
         CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
           THEN
-            mtm.ident = any(_asset_id_list)
+            mtm.ident = ANY(_asset_id_list)
             AND mtm.tx_id > _asset_info_cache_last_tx_id
           ELSE TRUE
         END
         AND tx_mint_meta IS NULL
-        AND mtm.quantity > 0
       GROUP BY mtm.ident
     ),
-    
+
     tx_meta AS (
       SELECT
         tmm.ident,
@@ -110,9 +96,8 @@ BEGIN
         ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.first_mint_tx_id) AS first_mint_keys,
         tmm.last_mint_tx_id,
         ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.last_mint_tx_id) AS last_mint_keys
-      FROM
-        tx_mint_meta tmm
-        INNER JOIN tx_metadata tm ON tm.tx_id = tmm.first_mint_tx_id OR tm.tx_id = tmm.last_mint_tx_id
+      FROM tx_mint_meta AS tmm
+      INNER JOIN tx_metadata AS tm ON tm.tx_id = tmm.first_mint_tx_id OR tm.tx_id = tmm.last_mint_tx_id
       GROUP BY tmm.ident, tmm.first_mint_tx_id, tmm.last_mint_tx_id
       --
       UNION ALL
@@ -123,8 +108,7 @@ BEGIN
         '{}',
         tx_mint_nometa.last_mint_tx_id,
         '{}'
-      FROM
-        tx_mint_nometa
+      FROM tx_mint_nometa
     )
 
   INSERT INTO grest.asset_info_cache  
@@ -140,28 +124,28 @@ BEGIN
       tm.last_mint_tx_id,
       tm.last_mint_keys
     FROM
-      multi_asset ma
-      INNER JOIN ma_tx_mint mtm ON mtm.ident = ma.id
+      multi_asset AS ma
+      INNER JOIN ma_tx_mint AS mtm ON mtm.ident = ma.id
       INNER JOIN tx ON tx.id = mtm.tx_id
-      INNER JOIN block b ON b.id = tx.block_id
-      INNER JOIN tx_meta tm ON tm.ident = ma.id
-      LEFT JOIN grest.asset_registry_cache arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = encode(ma.name,'hex')
+      INNER JOIN block AS b ON b.id = tx.block_id
+      INNER JOIN tx_meta AS tm ON tm.ident = ma.id
+      LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = encode(ma.name,'hex')
     WHERE
       CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
         THEN
-          mtm.ident = any(_asset_id_list)
+          mtm.ident = ANY(_asset_id_list)
         ELSE TRUE
       END
     GROUP BY ma.id, arc.decimals, tm.first_mint_tx_id, tm.first_mint_keys, tm.last_mint_tx_id, tm.last_mint_keys
   ON CONFLICT (asset_id)
   DO UPDATE SET
-    creation_time     = excluded.creation_time,
-    total_supply      = excluded.total_supply,
-    decimals          = excluded.decimals,
-    mint_cnt          = excluded.mint_cnt,
-    burn_cnt          = excluded.burn_cnt,
-    last_mint_tx_id   = excluded.last_mint_tx_id,
-    last_mint_keys    = excluded.last_mint_keys;
+    creation_time = excluded.creation_time,
+    total_supply = excluded.total_supply,
+    decimals = excluded.decimals,
+    mint_cnt = excluded.mint_cnt,
+    burn_cnt = excluded.burn_cnt,
+    last_mint_tx_id = excluded.last_mint_tx_id,
+    last_mint_keys = excluded.last_mint_keys;
 
   IF _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL THEN
     RAISE NOTICE '% assets added or updated', ARRAY_LENGTH(_asset_id_list, 1);

--- a/files/grest/rpc/01_cached_tables/asset_registry_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_registry_cache.sql
@@ -1,59 +1,59 @@
 DROP TABLE IF EXISTS grest.asset_registry_cache CASCADE;
 
 CREATE TABLE grest.asset_registry_cache (
-    asset_policy text NOT NULL,
-    asset_name text NOT NULL,
-    name text NOT NULL,
-    description text NOT NULL,
-    ticker text,
-    url text,
-    logo text,
-    decimals integer
+  asset_policy text NOT NULL,
+  asset_name text NOT NULL,
+  name text NOT NULL,
+  description text NOT NULL,
+  ticker text,
+  url text,
+  logo text,
+  decimals integer
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_asset ON grest.asset_registry_cache (asset_policy, asset_name);
 
-CREATE FUNCTION grest.asset_registry_cache_update (
-        _asset_policy text,
-        _asset_name text,
-        _name text,
-        _description text,
-        _ticker text DEFAULT NULL,
-        _url text DEFAULT NULL,
-        _logo text DEFAULT NULL,
-        _decimals word31type DEFAULT 0
-    )
-    RETURNS void
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION grest.asset_registry_cache_update(
+  _asset_policy text,
+  _asset_name text,
+  _name text,
+  _description text,
+  _ticker text DEFAULT NULL,
+  _url text DEFAULT NULL,
+  _logo text DEFAULT NULL,
+  _decimals word31type DEFAULT 0
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 BEGIN
-    INSERT INTO grest.asset_registry_cache (
-        asset_policy,
-        asset_name,
-        name,
-        description,
-        ticker,
-        url,
-        logo,
-        decimals
-    )
-    VALUES(
-        _asset_policy, 
-        _asset_name,
-        _name,
-        _description,
-        _ticker,
-        _url,
-        _logo,
-        _decimals
-    )
-    ON CONFLICT (asset_policy, asset_name)
-    DO UPDATE SET
-        name = _name,
-        description = _description,
-        ticker = _ticker,
-        url = _url,
-        logo = _logo,
-        decimals = _decimals;
+  INSERT INTO grest.asset_registry_cache (
+    asset_policy,
+    asset_name,
+    name,
+    description,
+    ticker,
+    url,
+    logo,
+    decimals
+  )
+  VALUES(
+    _asset_policy, 
+    _asset_name,
+    _name,
+    _description,
+    _ticker,
+    _url,
+    _logo,
+    _decimals
+  )
+  ON CONFLICT (asset_policy, asset_name)
+  DO UPDATE SET
+    name = _name,
+    description = _description,
+    ticker = _ticker,
+    url = _url,
+    logo = _logo,
+    decimals = _decimals;
 END;
 $$;

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -44,51 +44,38 @@ CREATE TABLE IF NOT EXISTS grest.epoch_info_cache (
 
 COMMENT ON TABLE grest.epoch_info_cache IS 'Contains detailed info for epochs including protocol parameters';
 
-CREATE FUNCTION grest.EPOCH_INFO_CACHE_UPDATE (
-    _epoch_no_to_insert_from bigint default NULL
-  )
-  RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION grest.epoch_info_cache_update(
+  _epoch_no_to_insert_from bigint DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _curr_epoch bigint;
   _latest_epoch_no_in_cache bigint;
 BEGIN
   -- Check previous cache update completed before running
   IF (
-    SELECT
-      COUNT(pid) > 1
-    FROM
-      pg_stat_activity
-    WHERE
-      state = 'active' AND query ILIKE '%GREST.EPOCH_INFO_CACHE_UPDATE%'
+    SELECT COUNT(pid) > 1
+    FROM pg_stat_activity
+    WHERE state = 'active'
+      AND query ILIKE '%grest.epoch_info_cache_update%'
       AND datname = (SELECT current_database())
     ) THEN
-        RAISE EXCEPTION 'Previous EPOCH_INFO_CACHE_UPDATE query still running but should have completed! Exiting...';
+        RAISE EXCEPTION 'Previous epoch_info_cache_update query still running but should have completed! Exiting...';
   END IF;
 
-  -- GREST control table entry
-  PERFORM grest.update_control_table(
-    'epoch_info_cache_last_updated',
-    (now() at time zone 'utc')::text
-  );
-
-  SELECT
-    MAX(no) INTO _curr_epoch
-  FROM
-    public.epoch;
+  SELECT MAX(no) INTO _curr_epoch
+  FROM public.epoch;
 
   IF _epoch_no_to_insert_from IS NULL THEN
-    SELECT
-      COALESCE(MAX(epoch_no), 0) INTO _latest_epoch_no_in_cache
-    FROM
-      grest.epoch_info_cache
-    WHERE
-      i_first_block_time IS NOT NULL;
+    SELECT COALESCE(MAX(epoch_no), 0) INTO _latest_epoch_no_in_cache
+    FROM grest.epoch_info_cache
+    WHERE i_first_block_time IS NOT NULL;
 
     IF _latest_epoch_no_in_cache = 0 THEN
       RAISE NOTICE 'Epoch info cache table is empty, starting initial population...';
-      PERFORM grest.EPOCH_INFO_CACHE_UPDATE (0);
+      PERFORM grest.epoch_info_cache_update(0);
       RETURN;
     END IF;
 
@@ -96,7 +83,7 @@ BEGIN
 
     IF _curr_epoch = _latest_epoch_no_in_cache THEN
       RAISE NOTICE 'Updating latest epoch info in cache...';
-      PERFORM grest.UPDATE_LATEST_EPOCH_INFO_CACHE(_curr_epoch, _latest_epoch_no_in_cache);
+      PERFORM grest.update_latest_epoch_info_cache(_curr_epoch, _latest_epoch_no_in_cache);
       RETURN;
     END IF;
 
@@ -107,16 +94,16 @@ BEGIN
 
     RAISE NOTICE 'Updating cache with new epoch(s) data...';
     -- We need to update last epoch one last time before going to new one
-    PERFORM grest.UPDATE_LATEST_EPOCH_INFO_CACHE(_curr_epoch, _latest_epoch_no_in_cache);
+    PERFORM grest.update_latest_epoch_info_cache(_curr_epoch, _latest_epoch_no_in_cache);
     -- Populate rewards data for epoch n - 2
-    PERFORM grest.UPDATE_TOTAL_REWARDS_EPOCH_INFO_CACHE(_latest_epoch_no_in_cache - 1);
+    PERFORM grest.update_total_rewards_epoch_info_cache(_latest_epoch_no_in_cache - 1);
     -- Continue new epoch data insert
     _epoch_no_to_insert_from := _latest_epoch_no_in_cache + 1;
   END IF;
 
-  RAISE NOTICE 'Deleting cache records from epoch % onwards...', _epoch_no_to_insert_from;
+  RAISE NOTICE 'Deleting cache records FROM epoch % onwards...', _epoch_no_to_insert_from;
   DELETE FROM grest.epoch_info_cache
-    WHERE epoch_no >= _epoch_no_to_insert_from;
+  WHERE epoch_no >= _epoch_no_to_insert_from;
 
   INSERT INTO grest.epoch_info_cache
     SELECT DISTINCT ON (b.time)
@@ -125,8 +112,8 @@ BEGIN
       e.fees AS i_fees,
       e.tx_count AS i_tx_count,
       e.blk_count AS i_blk_count,
-      EXTRACT(epoch from e.start_time) AS i_first_block_time,
-      EXTRACT(epoch from e.end_time) AS i_last_block_time,
+      EXTRACT(EPOCH FROM e.start_time) AS i_first_block_time,
+      EXTRACT(EPOCH FROM e.end_time) AS i_last_block_time,
       CASE -- populated in epoch n + 2
         WHEN e.no <= _curr_epoch - 2 THEN reward_pot.amount 
         ELSE NULL
@@ -167,76 +154,70 @@ BEGIN
       ep.collateral_percent AS p_collateral_percent,
       ep.max_collateral_inputs AS p_max_collateral_inputs,
       ep.coins_per_utxo_size AS p_coins_per_utxo_size
-    FROM
-      epoch e
-      LEFT JOIN epoch_param ep ON ep.epoch_no = e.no
-      LEFT JOIN cost_model cm ON cm.id = ep.cost_model_id
-      INNER JOIN block b ON b.time = e.start_time
-      LEFT JOIN LATERAL (
+    FROM epoch AS e
+    LEFT JOIN epoch_param AS ep ON ep.epoch_no = e.no
+    LEFT JOIN cost_model AS cm ON cm.id = ep.cost_model_id
+    INNER JOIN block AS b ON b.time = e.start_time
+    LEFT JOIN LATERAL (
         SELECT
           e.no,
-          SUM(r.amount) as amount
-        FROM
-          reward r
-        WHERE
-          r.earned_epoch = e.no
+          SUM(r.amount) AS amount
+        FROM reward AS r
+        WHERE r.earned_epoch = e.no
         GROUP BY
           e.no
-      ) reward_pot ON TRUE
-      LEFT JOIN LATERAL (
-        SELECT
-          MAX(tx.id) AS tx_id
-        FROM
-          block b
-          INNER JOIN tx ON tx.block_id = b.id
-        WHERE
-          b.epoch_no <= e.no
+      ) AS reward_pot ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT MAX(tx.id) AS tx_id
+        FROM block AS b
+        INNER JOIN tx ON tx.block_id = b.id
+        WHERE b.epoch_no <= e.no
           AND b.block_no IS NOT NULL
           AND b.tx_count != 0
-      ) last_tx ON TRUE
-    WHERE
-      e.no >= _epoch_no_to_insert_from
+      ) AS last_tx ON TRUE
+    WHERE e.no >= _epoch_no_to_insert_from
     ORDER BY
       b.time ASC,
       b.id ASC,
       e.no ASC;
+
+  -- GREST control table entry
+  PERFORM grest.update_control_table(
+    'epoch_info_cache_last_updated',
+    (now() at time zone 'utc')::text
+  );
+
 END;
 $$;
 
 -- Helper function for updating current epoch data
-CREATE FUNCTION grest.UPDATE_LATEST_EPOCH_INFO_CACHE (_curr_epoch bigint, _epoch_no_to_update bigint)
-  RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION grest.update_latest_epoch_info_cache(_curr_epoch bigint, _epoch_no_to_update bigint)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 BEGIN
   -- only update last tx id in case of new epoch
   IF _curr_epoch <> _epoch_no_to_update THEN
-    UPDATE
-      grest.epoch_info_cache
-    SET
-      i_last_tx_id = last_tx.tx_id
+    UPDATE grest.epoch_info_cache
+    SET i_last_tx_id = last_tx.tx_id
     FROM (
-      SELECT
-        MAX(tx.id) AS tx_id
-      FROM
-        block b
-        INNER JOIN tx ON tx.block_id = b.id
-      WHERE
-        b.epoch_no <= _epoch_no_to_update
+      SELECT MAX(tx.id) AS tx_id
+      FROM block AS b
+      INNER JOIN tx ON tx.block_id = b.id
+      WHERE b.epoch_no <= _epoch_no_to_update
         AND b.block_no IS NOT NULL
         AND b.tx_count != 0
-    ) last_tx
+    ) AS last_tx
     WHERE epoch_no = _epoch_no_to_update;
   END IF;
 
-  UPDATE
-    grest.epoch_info_cache
+  UPDATE grest.epoch_info_cache
   SET
     i_out_sum = update_table.out_sum,
     i_fees = update_table.fees,
     i_tx_count = update_table.tx_count,
     i_blk_count = update_table.blk_count,
-    i_last_block_time = EXTRACT(epoch from update_table.end_time)
+    i_last_block_time = EXTRACT(EPOCH FROM update_table.end_time)
   FROM (
     SELECT
       e.out_sum,
@@ -244,24 +225,20 @@ BEGIN
       e.tx_count,
       e.blk_count,
       e.end_time
-    FROM
-      epoch e
-    WHERE
-      e.no = _epoch_no_to_update
-  ) update_table
-  WHERE
-    epoch_no = _epoch_no_to_update;
+    FROM epoch AS e
+    WHERE e.no = _epoch_no_to_update
+  ) AS update_table
+  WHERE epoch_no = _epoch_no_to_update;
 END;
 $$;
 
 -- Helper function for updating epoch total rewards (epoch n - 2)
-CREATE FUNCTION grest.UPDATE_TOTAL_REWARDS_EPOCH_INFO_CACHE (_epoch_no_to_update bigint)
-  RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION grest.update_total_rewards_epoch_info_cache(_epoch_no_to_update bigint)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 BEGIN
-  UPDATE
-    grest.epoch_info_cache
+  UPDATE grest.epoch_info_cache
   SET
     i_total_rewards = update_t.amount,
     i_avg_blk_reward = update_t.avg_blk_reward
@@ -273,18 +250,13 @@ BEGIN
       SELECT
         r.earned_epoch,
         SUM(r.amount) AS amount
-      FROM
-        reward r
-      WHERE
-        r.earned_epoch = _epoch_no_to_update
-      GROUP BY
-        r.earned_epoch
-    ) reward_pot
-    INNER JOIN epoch e ON reward_pot.earned_epoch = e.no
+      FROM reward AS r
+      WHERE r.earned_epoch = _epoch_no_to_update
+      GROUP BY r.earned_epoch
+    ) AS reward_pot
+    INNER JOIN epoch AS e ON reward_pot.earned_epoch = e.no
       AND e.no = _epoch_no_to_update
-  ) update_t
-  WHERE
-    epoch_no = _epoch_no_to_update;
+  ) AS update_t
+  WHERE epoch_no = _epoch_no_to_update;
 END;
 $$;
-

--- a/files/grest/rpc/01_cached_tables/pool_history_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_history_cache.sql
@@ -1,4 +1,4 @@
-drop table if exists grest.pool_history_cache;
+DROP TABLE IF EXISTS grest.pool_history_cache;
 
 CREATE TABLE grest.pool_history_cache (
   pool_id varchar,
@@ -17,256 +17,274 @@ CREATE TABLE grest.pool_history_cache (
   PRIMARY KEY (pool_id, epoch_no)
 );
 
-COMMENT ON TABLE grest.pool_history_cache IS 'A history of pool performance including blocks, delegators, active stake, fees and rewards';
+COMMENT ON TABLE grest.pool_history_cache IS 'A history of pool performance including blocks, delegators, active stake, fees AND rewards';
 
-CREATE OR REPLACE grest.pool_history_cache_update (_epoch_no_to_insert_from bigint default NULL)
-  returns void
-  language plpgsql
-  as $$
-declare
+CREATE OR REPLACE FUNCTION grest.pool_history_cache_update(_epoch_no_to_insert_from bigint DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
   _curr_epoch bigint;
   _latest_epoch_no_in_cache bigint;
-begin
+BEGIN
   IF (
-    SELECT
-      COUNT(pid) > 1
-    FROM
-      pg_stat_activity
-    WHERE
-      state = 'active' AND query ILIKE '%GREST.pool_history_cache_update%'
+    SELECT COUNT(pid) > 1
+    FROM pg_stat_activity
+    WHERE state = 'active' AND query ILIKE '%grest.pool_history_cache_update%'
       AND datname = (SELECT current_database())
     ) THEN
-        RAISE EXCEPTION 'Previous pool_history_cache_update query still running but should have completed! Exiting...';
-    END IF;
+      RAISE EXCEPTION 'Previous pool_history_cache_update query still running but should have completed! Exiting...';
+  END IF;
 
-  INSERT INTO GREST.CONTROL_TABLE (key, last_value)
-      values('pool_history_cache_last_updated', now() at time zone 'utc')
-    ON CONFLICT (key)
-      DO UPDATE SET last_value = now() at time zone 'utc';
+  IF (
+    SELECT COUNT(key) != 1
+    FROM GREST.CONTROL_TABLE
+    WHERE key = 'epoch_info_cache_last_updated'
+  ) THEN
+    RAISE EXCEPTION 'Epoch Info Cache not yet populated! Exiting...';
+  END IF;
 
-  if _epoch_no_to_insert_from is null then
-    select
-      COALESCE(MAX(epoch_no), 0) into _latest_epoch_no_in_cache
-    from
-      grest.pool_history_cache;
-    if _latest_epoch_no_in_cache = 0 then
+  IF _epoch_no_to_insert_from IS NULL THEN
+    SELECT COALESCE(MAX(epoch_no), 0) INTO _latest_epoch_no_in_cache
+    FROM grest.pool_history_cache;
+    IF _latest_epoch_no_in_cache = 0 THEN
       RAISE NOTICE 'Pool history cache table is empty, starting initial population...';
       PERFORM grest.pool_history_cache_update (0);
-      return;
-    end if;
-    select
-      MAX(no) into _curr_epoch
-    from
-      epoch;
-    -- no-op if we already have data up until second most recent epoch
-    if _latest_epoch_no_in_cache >= (_curr_epoch - 1) then
-      return;
-    end if;
-    -- if current epoch is at least 2 ahead of latest in cache, repopulate from latest in cache until current-1
+      RETURN;
+    END IF;
+    SELECT MAX(no) INTO _curr_epoch
+    FROM epoch;
+    -- no-op IF we already have data up until second most recent epoch
+    IF _latest_epoch_no_in_cache >= (_curr_epoch - 1) THEN
+      RETURN;
+    END IF;
+    -- IF current epoch is at least 2 ahead of latest in cache, repopulate FROM latest in cache until current-1
     _epoch_no_to_insert_from := _latest_epoch_no_in_cache;
-  end if;
-  -- purge the data for the given epoch range, in theory should do nothing if invoked only at start of new epoch
-  delete from grest.pool_history_cache
-  where epoch_no >= _epoch_no_to_insert_from;
-  insert into grest.pool_history_cache ( with blockcounts as (
-      select
+  END IF;
+  -- purge the data for the given epoch range, in theory should do nothing IF invoked only at start of new epoch
+  DELETE FROM grest.pool_history_cache
+  WHERE epoch_no >= _epoch_no_to_insert_from;
+  INSERT INTO grest.pool_history_cache (
+  WITH
+    blockcounts AS (
+      SELECT
         sl.pool_hash_id,
         b.epoch_no,
-        COUNT(*) as block_cnt
-      from
-        block b,
-        slot_leader sl
-      where
+        COUNT(*) AS block_cnt
+      FROM
+        block AS b,
+        slot_leader AS sl
+      WHERE
         b.slot_leader_id = sl.id
-        and epoch_no >= _epoch_no_to_insert_from
-      group by
+        AND b.epoch_no >= _epoch_no_to_insert_from
+      GROUP BY
         sl.pool_hash_id,
-        b.epoch_no),
-      leadertotals as (
-        select
-          pool_id,
-          earned_epoch,
-          COALESCE(SUM(amount), 0) as leadertotal
-        from
-          reward r
-        where
-          r.type = 'leader'
-          and earned_epoch >= _epoch_no_to_insert_from
-        group by
-          pool_id,
-          earned_epoch),
-        membertotals as (
-          select
-            pool_id,
-            earned_epoch,
-            COALESCE(SUM(amount), 0) as memtotal
-          from
-            reward r
-          where
-            r.type = 'member'
-            and earned_epoch >= _epoch_no_to_insert_from
-          group by
-            pool_id,
-            earned_epoch),
-          activeandfees as (
-            select
-              pool_id,
-              epoch_no,
-              amount as active_stake,
-              (
-                select
-                  margin
-                from
-                  pool_update
-                where
-                  id = (
-                    select
-                      MAX(pup2.id)
-                    from
-                      pool_hash ph,
-                      pool_update pup2
-                    where
-                      pup2.hash_id = ph.id
-                      and ph.view = act.pool_id
-                      and pup2.active_epoch_no <= act.epoch_no)) pool_fee_variable,
-                  (
-                    select
-                      fixed_cost
-                    from
-                      pool_update
-                    where
-                      id = (
-                        select
-                          MAX(pup2.id)
-                        from
-                          pool_update pup2,
-                          pool_hash ph
-                        where
-                          ph.view = act.pool_id
-                          and pup2.hash_id = ph.id
-                          and pup2.active_epoch_no <= act.epoch_no)) pool_fee_fixed,
-                    (amount / (
-                        select
-                          NULLIF (amount, 0)
-                        from
-                          grest.EPOCH_ACTIVE_STAKE_CACHE epochActiveStakeCache
-                        where
-                          epochActiveStakeCache.epoch_no = act.epoch_no)) * 100 active_stake_pct,
-                      ROUND((amount / (
-                          select
-                            supply::bigint / (
-                              select
-                                p_optimal_pool_count from grest.epoch_info_cache
-                              where
-                                epoch_no = act.epoch_no)
-                              from grest.totals (act.epoch_no)) * 100), 2) saturation_pct
-                    from
-                      grest.pool_active_stake_cache act
-                    where
-                      epoch_no >= _epoch_no_to_insert_from
-                      -- TODO: revisit later: currently ignore latest epoch as active stake might not be populated for it yet
-                      and epoch_no < (
-                        select
-                          MAX(e."no")
-                        from
-                          epoch e)),
-                      delegators as (
-                        select
-                          pool_id,
-                          epoch_no,
-                          COUNT(*) as delegator_cnt
-                        from
-                          epoch_stake es
-                        where
-                          epoch_no >= _epoch_no_to_insert_from
-                        group by
-                          pool_id,
-                          epoch_no
-)
-                        select
-                          ph.view as pool_id,
-                          actf.epoch_no,
-                          actf.active_stake,
-                          actf.active_stake_pct,
-                          actf.saturation_pct,
-                          COALESCE(b.block_cnt, 0) as block_cnt,
-                          del.delegator_cnt,
-                          actf.pool_fee_variable,
-                          actf.pool_fee_fixed,
-                          -- for debugging: m.memtotal,
-                          -- for debugging: l.leadertotal,
-                          case COALESCE(b.block_cnt, 0)
-                          when 0 then
-                            0
-                          else
-                            -- special case for when reward information is not available yet
-                            case COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
-                            when 0 then
-                              null
-                            else
-                                case 
-                                    when COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed then COALESCE(l.leadertotal, 0)
-                                    else ROUND(actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0) + COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))
-                                end
-                            end
-                          end pool_fees,
-                          case COALESCE(b.block_cnt, 0)
-                          when 0 then
-                            0
-                          else
-                            -- special case for when reward information is not available yet
-                            case COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
-                            when 0 then
-                              null
-                            else
-                              case
-                              when COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed then COALESCE(m.memtotal, 0)
-                              else ROUND(COALESCE(m.memtotal, 0) + (COALESCE(l.leadertotal, 0) - (actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0) + COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))))
-                              end
-                            end
-                          end deleg_rewards,
-                          case COALESCE(b.block_cnt, 0)
-                          when 0 then
-                            0
-                          else
-                            case COALESCE(m.memtotal, 0)
-                            when 0 then
-                              null
-                            else
-                              COALESCE(m.memtotal, 0)
-                            end
-                          end member_rewards,
-                          case COALESCE(b.block_cnt, 0)
-                          when 0 then
-                            0
-                          else
-                            -- special case for when reward information is not available yet
-                            case COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
-                            when 0 then
-                              null
-                            else
-                              case
-                              when COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed then 
-                                   ROUND((((POW(( LEAST(( (COALESCE(m.memtotal, 0)) / (NULLIF(actf.active_stake,0)) ), 1000) + 1), 73) - 1)) * 100)::numeric, 9)
-                              -- using LEAST as a way to prevent overflow, in case of dodgy database data (e.g. giant rewards / tiny active stake)
-                              else ROUND((((POW(( LEAST(( ((COALESCE(m.memtotal, 0) + (COALESCE(l.leadertotal, 0) - (actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0) + 
-								              COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))))) / (NULLIF(actf.active_stake,0)) ), 1000) + 1), 73) - 1)) * 100)::numeric, 9)
-                              end
-                            end
-                          end epoch_ros
-                        from
-                          pool_hash ph
-                          inner join activeandfees actf on actf.pool_id = ph."view"
-                          left join blockcounts b on ph.id = b.pool_hash_id
-                            and actf.epoch_no = b.epoch_no
-                        left join leadertotals l on ph.id = l.pool_id
-                          and actf.epoch_no = l.earned_epoch
-                      left join membertotals m on ph.id = m.pool_id
-                        and actf.epoch_no = m.earned_epoch
-                    left join delegators del on ph.id = del.pool_id
-                      and actf.epoch_no = del.epoch_no);
-end;
+        b.epoch_no
+    ),
+
+    leadertotals AS (
+      SELECT
+        r.pool_id,
+        r.earned_epoch,
+        COALESCE(SUM(r.amount), 0) AS leadertotal
+      FROM
+        reward AS r
+      WHERE
+        r.type = 'leader'
+        AND r.earned_epoch >= _epoch_no_to_insert_from
+      GROUP BY
+        r.pool_id,
+        r.earned_epoch
+    ),
+
+    membertotals AS (
+      SELECT
+        r.pool_id,
+        r.earned_epoch,
+        COALESCE(SUM(r.amount), 0) AS memtotal
+      FROM
+        reward AS r
+      WHERE
+        r.type = 'member'
+        AND r.earned_epoch >= _epoch_no_to_insert_from
+      GROUP BY
+        r.pool_id,
+        r.earned_epoch
+    ),
+
+    activeandfees AS (
+      SELECT
+        act.pool_id,
+        act.epoch_no,
+        act.amount AS active_stake,
+        (
+          SELECT margin
+          FROM
+            pool_update
+          WHERE
+            id = (
+              SELECT MAX(pup2.id)
+              FROM
+                pool_hash AS ph,
+                pool_update AS pup2
+              WHERE
+                pup2.hash_id = ph.id
+                AND ph.view = act.pool_id
+                AND pup2.active_epoch_no <= act.epoch_no
+            )
+        ) AS pool_fee_variable,
+        (
+          SELECT fixed_cost
+          FROM
+            pool_update
+          WHERE
+            id = (
+              SELECT MAX(pup2.id)
+              FROM
+                pool_update AS pup2,
+                pool_hash AS ph
+              WHERE
+                ph.view = act.pool_id
+                AND pup2.hash_id = ph.id
+                AND pup2.active_epoch_no <= act.epoch_no)
+        ) AS pool_fee_fixed,
+        (act.amount / (
+          SELECT NULLIF(act.amount, 0)
+          FROM
+            grest.epoch_active_stake_cache AS easc
+          WHERE
+            easc.epoch_no = act.epoch_no
+          )
+        ) * 100 AS active_stake_pct,
+        ROUND(
+          (act.amount / (
+            SELECT supply::bigint / (
+                SELECT eic.p_optimal_pool_count
+                FROM
+                  grest.epoch_info_cache AS eic
+                WHERE
+                  eic.epoch_no = act.epoch_no
+              )
+            FROM grest.totals (act.epoch_no)
+            ) * 100
+          ), 2
+        ) AS saturation_pct
+      FROM
+        grest.pool_active_stake_cache AS act
+      WHERE
+        act.epoch_no >= _epoch_no_to_insert_from
+        -- TODO: revisit later: currently ignore latest epoch AS active stake might not be populated for it yet
+        AND act.epoch_no < (
+          SELECT MAX(e."no")
+          FROM
+            epoch AS e
+        )
+    ),
+
+    delegators AS (
+      SELECT
+        es.pool_id,
+        es.epoch_no,
+        COUNT(1) AS delegator_cnt
+      FROM
+        epoch_stake AS es
+      WHERE
+        es.epoch_no >= _epoch_no_to_insert_from
+      GROUP BY
+        es.pool_id,
+        es.epoch_no
+    )
+
+    SELECT
+      ph.view AS pool_id,
+      actf.epoch_no,
+      actf.active_stake,
+      actf.active_stake_pct,
+      actf.saturation_pct,
+      COALESCE(b.block_cnt, 0) AS block_cnt,
+      del.delegator_cnt,
+      actf.pool_fee_variable,
+      actf.pool_fee_fixed,
+      -- for debugging: m.memtotal,
+      -- for debugging: l.leadertotal,
+      CASE COALESCE(b.block_cnt, 0)
+      WHEN 0 THEN
+        0
+      ELSE
+        -- special CASE for WHEN reward information is not available yet
+        CASE COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
+        WHEN 0 THEN
+          NULL
+        ELSE
+            CASE
+                WHEN COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed THEN COALESCE(l.leadertotal, 0)
+                ELSE ROUND(actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0) + COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))
+            END
+        END
+      END AS pool_fees,
+      CASE COALESCE(b.block_cnt, 0)
+      WHEN 0 THEN
+        0
+      ELSE
+        -- special CASE for WHEN reward information is not available yet
+        CASE COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
+        WHEN 0 THEN
+          NULL
+        ELSE
+          CASE
+          WHEN COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed THEN COALESCE(m.memtotal, 0)
+          ELSE ROUND(COALESCE(m.memtotal, 0) + (COALESCE(l.leadertotal, 0) - (actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0) + COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))))
+          END
+        END
+      END AS deleg_rewards,
+      CASE COALESCE(b.block_cnt, 0)
+      WHEN 0 THEN
+        0
+      ELSE
+        CASE COALESCE(m.memtotal, 0)
+        WHEN 0 THEN
+          NULL
+        ELSE
+          COALESCE(m.memtotal, 0)
+        END
+      END AS member_rewards,
+      CASE COALESCE(b.block_cnt, 0)
+      WHEN 0 THEN
+        0
+      ELSE
+        -- special CASE for WHEN reward information is not available yet
+        CASE COALESCE(l.leadertotal, 0) + COALESCE(m.memtotal, 0)
+        WHEN 0 THEN
+          NULL
+        ELSE
+          CASE
+          WHEN COALESCE(l.leadertotal, 0) < actf.pool_fee_fixed THEN
+            ROUND((((POW((LEAST(((COALESCE(m.memtotal, 0)) / (NULLIF(actf.active_stake, 0))), 1000) + 1), 73) - 1)) * 100)::numeric, 9)
+          -- using LEAST AS a way to prevent overflow, in CASE of dodgy database data (e.g. giant rewards / tiny active stake)
+          ELSE ROUND((((POW((LEAST((((COALESCE(m.memtotal, 0) + (COALESCE(l.leadertotal, 0) - (actf.pool_fee_fixed + (((COALESCE(m.memtotal, 0)
+	          + COALESCE(l.leadertotal, 0)) - actf.pool_fee_fixed) * actf.pool_fee_variable))))) / (NULLIF(actf.active_stake, 0))), 1000) + 1), 73) - 1)) * 100)::numeric, 9)
+          END
+        END
+      END AS epoch_ros
+    FROM
+      pool_hash AS ph
+    INNER JOIN activeandfees AS actf ON actf.pool_id = ph."view"
+    LEFT JOIN blockcounts AS b ON ph.id = b.pool_hash_id
+      AND actf.epoch_no = b.epoch_no
+    LEFT JOIN leadertotals AS l ON ph.id = l.pool_id
+      AND actf.epoch_no = l.earned_epoch
+    LEFT JOIN membertotals AS m ON ph.id = m.pool_id
+      AND actf.epoch_no = m.earned_epoch
+    LEFT JOIN delegators AS del ON ph.id = del.pool_id
+      AND actf.epoch_no = del.epoch_no
+  );
+
+  INSERT INTO grest.control_table (key, last_value)
+    VALUES ('pool_history_cache_last_updated', NOW() AT TIME ZONE 'utc')
+  ON CONFLICT (key)
+    DO UPDATE SET last_value = NOW() AT TIME ZONE 'utc';
+
+END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_history_cache_update IS 'Internal function to update pool history for data from specified epoch until 
-current-epoch-minus-one. Invoke with non-empty param for initial population, with empty for subsequent updates';
+COMMENT ON FUNCTION grest.pool_history_cache_update IS 'Internal function to update pool history for data FROM specified epoch until current-epoch-minus-one. Invoke WITH non-empty param for initial population, WITH empty for subsequent updates'; --noqa: LT01

--- a/files/grest/rpc/01_cached_tables/pool_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_info_cache.sql
@@ -1,127 +1,126 @@
 DROP TABLE IF EXISTS grest.pool_info_cache;
 
 CREATE TABLE grest.pool_info_cache (
-    id SERIAL PRIMARY KEY,
-    tx_id bigint NOT NULL,
-    update_id bigint NOT NULL,
-    tx_hash text,
-    block_time numeric,
-    pool_hash_id bigint NOT NULL,
-    pool_id_bech32 character varying NOT NULL,
-    pool_id_hex text NOT NULL,
-    active_epoch_no bigint NOT NULL,
-    vrf_key_hash text NOT NULL,
-    margin double precision NOT NULL,
-    fixed_cost lovelace NOT NULL,
-    pledge lovelace NOT NULL,
-    reward_addr character varying,
-    owners character varying [],
-    relays jsonb [],
-    meta_id bigint,
-    meta_url character varying,
-    meta_hash text,
-    pool_status text,
-    retiring_epoch word31type
+  id serial PRIMARY KEY,
+  tx_id bigint NOT NULL,
+  update_id bigint NOT NULL,
+  tx_hash text,
+  block_time numeric,
+  pool_hash_id bigint NOT NULL,
+  pool_id_bech32 character varying NOT NULL,
+  pool_id_hex text NOT NULL,
+  active_epoch_no bigint NOT NULL,
+  vrf_key_hash text NOT NULL,
+  margin double precision NOT NULL,
+  fixed_cost lovelace NOT NULL,
+  pledge lovelace NOT NULL,
+  reward_addr character varying,
+  owners character varying [],
+  relays jsonb [],
+  meta_id bigint,
+  meta_url character varying,
+  meta_hash text,
+  pool_status text,
+  retiring_epoch word31type
 );
 
 COMMENT ON TABLE grest.pool_info_cache IS 'A summary of all pool parameters and updates';
 
-CREATE FUNCTION grest.pool_info_insert (
-        _update_id bigint,
-        _tx_id bigint,
-        _hash_id bigint,
-        _active_epoch_no bigint,
-        _vrf_key_hash hash32type,
-        _margin double precision,
-        _fixed_cost lovelace,
-        _pledge lovelace,
-        _reward_addr_id bigint,
-        _meta_id bigint
-    )
-    RETURNS void
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION grest.pool_info_insert(
+  _update_id bigint,
+  _tx_id bigint,
+  _hash_id bigint,
+  _active_epoch_no bigint,
+  _vrf_key_hash hash32type,
+  _margin double precision,
+  _fixed_cost lovelace,
+  _pledge lovelace,
+  _reward_addr_id bigint,
+  _meta_id bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
 DECLARE
-    _current_epoch_no word31type;
-    _retiring_epoch word31type;
-    _pool_status text;
+  _current_epoch_no word31type;
+  _retiring_epoch word31type;
+  _pool_status text;
 BEGIN
-    SELECT COALESCE(MAX(no), 0) INTO _current_epoch_no FROM public.epoch;
+  SELECT COALESCE(MAX(no), 0) INTO _current_epoch_no FROM public.epoch;
 
-    SELECT pr.retiring_epoch INTO _retiring_epoch
-    FROM public.pool_retire AS pr
-    WHERE pr.hash_id = _hash_id
+  SELECT pr.retiring_epoch INTO _retiring_epoch
+  FROM public.pool_retire AS pr
+  WHERE pr.hash_id = _hash_id
     AND pr.announced_tx_id > _tx_id
-    ORDER BY pr.id
-    LIMIT 1;
+  ORDER BY pr.id
+  LIMIT 1;
 
-    IF _retiring_epoch IS NULL THEN 
-        _pool_status := 'registered';
-    ELSIF _retiring_epoch > _current_epoch_no THEN
-        _pool_status := 'retiring';
-    ELSE
-        _pool_status := 'retired';
-    END IF;
+  IF _retiring_epoch IS NULL THEN 
+    _pool_status := 'registered';
+  ELSIF _retiring_epoch > _current_epoch_no THEN
+    _pool_status := 'retiring';
+  ELSE
+    _pool_status := 'retired';
+  END IF;
 
-    INSERT INTO grest.pool_info_cache (
-        tx_id,
-        update_id,
-        tx_hash,
-        block_time,
-        pool_hash_id,
-        pool_id_bech32, 
-        pool_id_hex,
-        active_epoch_no,
-        vrf_key_hash,
-        margin,
-        fixed_cost,
-        pledge,
-        reward_addr,
-        owners,
-        relays,
-        meta_id,
-        meta_url,
-        meta_hash,
-        pool_status,
-        retiring_epoch
-    )
+  INSERT INTO grest.pool_info_cache (
+    tx_id,
+    update_id,
+    tx_hash,
+    block_time,
+    pool_hash_id,
+    pool_id_bech32, 
+    pool_id_hex,
+    active_epoch_no,
+    vrf_key_hash,
+    margin,
+    fixed_cost,
+    pledge,
+    reward_addr,
+    owners,
+    relays,
+    meta_id,
+    meta_url,
+    meta_hash,
+    pool_status,
+    retiring_epoch
+  )
     SELECT
-        _tx_id,
-        _update_id,
-        encode(tx.hash::bytea, 'hex'), 
-        EXTRACT(epoch from b.time),
-        _hash_id,
-        ph.view,
-        encode(ph.hash_raw::bytea, 'hex'),
-        _active_epoch_no,
-        encode(_vrf_key_hash::bytea, 'hex'),
-        _margin,
-        _fixed_cost,
-        _pledge,
-        sa.view,
-        ARRAY(
-            SELECT 
-                sa.view
-            FROM public.pool_owner AS po
-            INNER JOIN public.stake_address AS sa ON sa.id = po.addr_id
-            WHERE po.pool_update_id = _update_id
-        ),
-        ARRAY(
-            SELECT JSONB_BUILD_OBJECT(
-                'ipv4', pr.ipv4,
-                'ipv6', pr.ipv6,
-                'dns', pr.dns_name,
-                'srv', pr.dns_srv_name,
-                'port', pr.port
-            ) relay
-            FROM public.pool_relay AS pr
-            WHERE pr.update_id = _update_id
-        ),
-        _meta_id,
-        pmr.url,
-        encode(pmr.hash::bytea, 'hex'),
-        _pool_status,
-        _retiring_epoch
+      _tx_id,
+      _update_id,
+      encode(tx.hash::bytea, 'hex'), 
+      EXTRACT(EPOCH FROM b.time),
+      _hash_id,
+      ph.view,
+      encode(ph.hash_raw::bytea, 'hex'),
+      _active_epoch_no,
+      encode(_vrf_key_hash::bytea, 'hex'),
+      _margin,
+      _fixed_cost,
+      _pledge,
+      sa.view,
+      ARRAY(
+        SELECT sa.view
+        FROM public.pool_owner AS po
+        INNER JOIN public.stake_address AS sa ON sa.id = po.addr_id
+        WHERE po.pool_update_id = _update_id
+      ),
+      ARRAY(
+        SELECT JSONB_BUILD_OBJECT(
+          'ipv4', pr.ipv4,
+          'ipv6', pr.ipv6,
+          'dns', pr.dns_name,
+          'srv', pr.dns_srv_name,
+          'port', pr.port
+        ) relay
+        FROM public.pool_relay AS pr
+        WHERE pr.update_id = _update_id
+      ),
+      _meta_id,
+      pmr.url,
+      encode(pmr.hash::bytea, 'hex'),
+      _pool_status,
+      _retiring_epoch
     FROM public.pool_hash AS ph
     INNER JOIN public.tx ON tx.id = _tx_id
     INNER JOIN public.block AS b ON b.id = tx.block_id
@@ -131,210 +130,198 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_info_insert IS 'Internal function to insert a single pool update';
+COMMENT ON FUNCTION grest.pool_info_insert IS 'Internal function to insert a single pool update'; -- noqa: LT01
 
-CREATE FUNCTION grest.pool_info_retire_status ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION grest.pool_info_retire_status()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
 BEGIN
+  UPDATE grest.pool_info_cache
+  SET pool_status = 'retired'
+  WHERE pool_status = 'retiring'
+    AND retiring_epoch <= new.no;
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.pool_info_retire_status IS 'Internal function to update pool_info_cache with new retire status based ON epoch switch'; -- noqa: LT01
+
+CREATE OR REPLACE FUNCTION grest.pool_info_retire_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _current_epoch_no word31type;
+  _pool_hash_id bigint;
+  _latest_pool_update_tx_id bigint;
+  _retiring_epoch word31type;
+  _pool_status text;
+BEGIN
+  SELECT COALESCE(MAX(no), 0) INTO _current_epoch_no FROM public.epoch;
+
+  IF (tg_op = 'DELETE') THEN
+    _pool_hash_id := OLD.hash_id;
+  ELSIF (tg_op = 'INSERT') THEN
+    _pool_hash_id := new.hash_id;
+  END IF;
+  SELECT COALESCE(MAX(tx_id), 0) INTO _latest_pool_update_tx_id FROM grest.pool_info_cache AS pic WHERE pic.pool_hash_id = _pool_hash_id;
+
+  SELECT pr.retiring_epoch INTO _retiring_epoch
+  FROM public.pool_retire AS pr
+  WHERE pr.hash_id = _pool_hash_id
+  AND pr.announced_tx_id > _latest_pool_update_tx_id
+  ORDER BY pr.id
+  LIMIT 1;
+
+  IF _retiring_epoch IS NULL THEN 
+    _pool_status := 'registered';
+  ELSIF _retiring_epoch > _current_epoch_no THEN
+    _pool_status := 'retiring';
+  ELSE
+    _pool_status := 'retired';
+  END IF;
+
+  UPDATE grest.pool_info_cache
+  SET
+      pool_status = _pool_status,
+      retiring_epoch = _retiring_epoch
+  WHERE pool_hash_id = _pool_hash_id
+    AND tx_id = _latest_pool_update_tx_id;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.pool_info_retire_update IS 'Internal function to update pool_info cache table based ON insert/delete ON pool_retire table'; -- noqa: LT01
+
+CREATE OR REPLACE FUNCTION grest.pool_info_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _latest_pool_update_id integer;
+BEGIN
+  IF (tg_table_name = 'pool_update') THEN
+    IF (tg_op = 'INSERT') THEN
+      PERFORM grest.pool_info_insert(
+        new.id,
+        new.registered_tx_id,
+        new.hash_id,
+        new.active_epoch_no,
+        new.vrf_key_hash,
+        new.margin,
+        new.fixed_cost,
+        new.pledge,
+        new.reward_addr_id,
+        new.meta_id
+      );
+    ELSIF (tg_op = 'DELETE') THEN
+      DELETE FROM grest.pool_info_cache
+      WHERE tx_id = OLD.registered_tx_id;
+    END IF;
+
+  ELSIF (tg_table_name = 'pool_relay') THEN
+    SELECT pic.id INTO _latest_pool_update_id 
+    FROM grest.pool_info_cache AS pic 
+    INNER JOIN public.pool_update AS pu ON pu.hash_id = pic.pool_hash_id AND pu.registered_tx_id = pic.tx_id
+    WHERE pu.id = new.update_id;
+
+    IF (_latest_pool_update_id IS NULL) THEN
+      RETURN NULL;
+    END IF;
+
     UPDATE grest.pool_info_cache
     SET
-        pool_status = 'retired'
+      relays = relays || JSONB_BUILD_OBJECT (
+        'ipv4', new.ipv4,
+        'ipv6', new.ipv6,
+        'dns', new.dns_name,
+        'srv', new.dns_srv_name,
+        'port', new.port
+      )
     WHERE
-        pool_status = 'retiring'
-        AND
-        retiring_epoch <= NEW.no;
-    RETURN NULL;
+      id = _latest_pool_update_id;
+
+  ELSIF (tg_table_name = 'pool_owner') THEN
+      UPDATE grest.pool_info_cache
+      SET
+        owners = owners || (SELECT sa.view FROM public.stake_address AS sa WHERE sa.id = new.addr_id)
+      WHERE
+        update_id = new.pool_update_id;
+  END IF;
+
+  RETURN NULL;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_info_retire_status IS 'Internal function to update pool_info_cache with new retire status based on epoch switch';
+COMMENT ON FUNCTION grest.pool_info_update IS 'Internal function to insert/delete pool updates in pool_info cache table'; -- noqa: LT01
 
-CREATE FUNCTION grest.pool_info_retire_update ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    _current_epoch_no word31type;
-    _pool_hash_id bigint;
-    _latest_pool_update_tx_id bigint;
-    _retiring_epoch word31type;
-    _pool_status text;
-BEGIN
-    SELECT COALESCE(MAX(no), 0) INTO _current_epoch_no FROM public.epoch;
-
-    IF (TG_OP = 'DELETE') THEN
-        _pool_hash_id := OLD.hash_id;
-    ELSIF (TG_OP = 'INSERT') THEN
-        _pool_hash_id := NEW.hash_id;
-    END IF;
-    SELECT COALESCE(MAX(tx_id), 0) INTO _latest_pool_update_tx_id FROM grest.pool_info_cache AS pic WHERE pic.pool_hash_id = _pool_hash_id;
-
-    SELECT pr.retiring_epoch INTO _retiring_epoch
-    FROM public.pool_retire AS pr
-    WHERE pr.hash_id = _pool_hash_id
-    AND pr.announced_tx_id > _latest_pool_update_tx_id
-    ORDER BY pr.id
-    LIMIT 1;
-
-    IF _retiring_epoch IS NULL THEN 
-        _pool_status := 'registered';
-    ELSIF _retiring_epoch > _current_epoch_no THEN
-        _pool_status := 'retiring';
-    ELSE
-        _pool_status := 'retired';
-    END IF;
-
-    UPDATE grest.pool_info_cache
-    SET
-        pool_status = _pool_status,
-        retiring_epoch = _retiring_epoch
-    WHERE
-        pool_hash_id = _pool_hash_id
-        AND
-        tx_id = _latest_pool_update_tx_id;
-        
-    RETURN NULL;
-END;
-$$;
-
-COMMENT ON FUNCTION grest.pool_info_retire_update IS 'Internal function to update pool_info cache table based on insert/delete on pool_retire table';
-
-CREATE FUNCTION grest.pool_info_update ()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    _latest_pool_update_id integer;
-BEGIN
-    IF (TG_TABLE_NAME = 'pool_update') THEN
-        IF (TG_OP = 'INSERT') THEN
-            PERFORM grest.pool_info_insert(
-                NEW.id,
-                NEW.registered_tx_id,
-                NEW.hash_id,
-                NEW.active_epoch_no,
-                NEW.vrf_key_hash,
-                NEW.margin,
-                NEW.fixed_cost,
-                NEW.pledge,
-                NEW.reward_addr_id,
-                NEW.meta_id
-            );
-        ELSIF (TG_OP = 'DELETE') THEN
-            DELETE FROM grest.pool_info_cache
-            WHERE tx_id = OLD.registered_tx_id;
-        END IF;
-
-    ELSIF (TG_TABLE_NAME = 'pool_relay') THEN
-        SELECT pic.id INTO _latest_pool_update_id 
-        FROM grest.pool_info_cache AS pic 
-        INNER JOIN public.pool_update AS pu ON pu.hash_id = pic.pool_hash_id AND pu.registered_tx_id = pic.tx_id
-        WHERE pu.id = NEW.update_id;
-
-        IF (_latest_pool_update_id IS NULL) THEN
-            RETURN NULL;
-        END IF;
-
-        UPDATE grest.pool_info_cache
-        SET
-            relays = relays || JSONB_BUILD_OBJECT (
-                                    'ipv4', NEW.ipv4,
-                                    'ipv6', NEW.ipv6,
-                                    'dns', NEW.dns_name,
-                                    'srv', NEW.dns_srv_name,
-                                    'port', NEW.port
-                                )
-        WHERE
-            id = _latest_pool_update_id;
-
-    ELSIF (TG_TABLE_NAME = 'pool_owner') THEN
-        UPDATE grest.pool_info_cache
-        SET
-            owners = owners || (SELECT sa.view FROM public.stake_address AS sa WHERE sa.id = NEW.addr_id)
-        WHERE
-            update_id = NEW.pool_update_id;
-    END IF;
-
-    RETURN NULL;
-END;
-$$;
-
-COMMENT ON FUNCTION grest.pool_info_update IS 'Internal function to insert/delete pool updates in pool_info cache table';
-
-
--- Create pool_info_cache trigger based on new/deleted pool updates
+-- Create pool_info_cache trigger based ON new/deleted pool updates
 DROP TRIGGER IF EXISTS pool_info_update_trigger ON public.pool_update;
 
 CREATE TRIGGER pool_info_update_trigger
-    AFTER INSERT OR DELETE ON public.pool_update
-    FOR EACH ROW
-        EXECUTE FUNCTION grest.pool_info_update ();
+AFTER INSERT OR DELETE ON public.pool_update
+FOR EACH ROW EXECUTE FUNCTION grest.pool_info_update();
 
--- Create pool_info_cache trigger based on new entry in pool_relay
+-- Create pool_info_cache trigger based ON new entry in pool_relay
 DROP TRIGGER IF EXISTS pool_info_update_trigger ON public.pool_relay;
 
 CREATE TRIGGER pool_info_update_trigger
-    AFTER INSERT ON public.pool_relay
-    FOR EACH ROW
-        EXECUTE FUNCTION grest.pool_info_update ();
+AFTER INSERT ON public.pool_relay
+FOR EACH ROW EXECUTE FUNCTION grest.pool_info_update();
 
--- Create pool_info_cache trigger based on new entry in pool_owner
+-- Create pool_info_cache trigger based ON new entry in pool_owner
 DROP TRIGGER IF EXISTS pool_info_update_trigger ON public.pool_owner;
 
 CREATE TRIGGER pool_info_update_trigger
-    AFTER INSERT ON public.pool_owner
-    FOR EACH ROW
-        EXECUTE FUNCTION grest.pool_info_update ();
+AFTER INSERT ON public.pool_owner
+FOR EACH ROW EXECUTE FUNCTION grest.pool_info_update();
 
--- Create pool_info_cache trigger based on new/deleted pool retire entries
+-- Create pool_info_cache trigger based ON new/deleted pool retire entries
 DROP TRIGGER IF EXISTS pool_info_retire_update_trigger ON public.pool_retire;
 
 CREATE TRIGGER pool_info_retire_update_trigger
-    AFTER INSERT OR DELETE ON public.pool_retire
-    FOR EACH ROW
-        EXECUTE FUNCTION grest.pool_info_retire_update ();
+AFTER INSERT OR DELETE ON public.pool_retire
+FOR EACH ROW EXECUTE FUNCTION grest.pool_info_retire_update();
 
--- Create pool_info_cache trigger based on new epoch for retire status update
+-- Create pool_info_cache trigger based ON new epoch for retire status update
 DROP TRIGGER IF EXISTS pool_info_retire_status_trigger ON public.epoch;
 
 CREATE TRIGGER pool_info_retire_status_trigger
-    AFTER INSERT ON public.epoch
-    FOR EACH ROW
-        EXECUTE FUNCTION grest.pool_info_retire_status ();
+AFTER INSERT ON public.epoch
+FOR EACH ROW EXECUTE FUNCTION grest.pool_info_retire_status();
 
 
 -- Initialize pool_info_cache table with all current pool data
 DO $$
 DECLARE
-    _latest_pool_info_tx_id bigint;
-    rec RECORD;
+  _latest_pool_info_tx_id bigint;
+  rec RECORD;
 BEGIN
-    SELECT COALESCE(MAX(tx_id), 0) INTO _latest_pool_info_tx_id FROM grest.pool_info_cache;
+  SELECT COALESCE(MAX(tx_id), 0) INTO _latest_pool_info_tx_id FROM grest.pool_info_cache;
 
-    FOR rec IN (
-        SELECT * FROM public.pool_update AS pu WHERE pu.registered_tx_id > _latest_pool_info_tx_id
-    ) LOOP
-        PERFORM grest.pool_info_insert(
-            rec.id,
-            rec.registered_tx_id,
-            rec.hash_id,
-            rec.active_epoch_no,
-            rec.vrf_key_hash,
-            rec.margin,
-            rec.fixed_cost,
-            rec.pledge,
-            rec.reward_addr_id,
-            rec.meta_id
-        );
-    END LOOP;
+  FOR rec IN (
+    SELECT * FROM public.pool_update AS pu WHERE pu.registered_tx_id > _latest_pool_info_tx_id
+  ) LOOP
+    PERFORM grest.pool_info_insert(
+      rec.id,
+      rec.registered_tx_id,
+      rec.hash_id,
+      rec.active_epoch_no,
+      rec.vrf_key_hash,
+      rec.margin,
+      rec.fixed_cost,
+      rec.pledge,
+      rec.reward_addr_id,
+      rec.meta_id
+    );
+  END LOOP;
 
-    CREATE INDEX IF NOT EXISTS idx_tx_id ON grest.pool_info_cache (tx_id);
-    CREATE INDEX IF NOT EXISTS idx_pool_id_bech32 ON grest.pool_info_cache (pool_id_bech32);
-    CREATE INDEX IF NOT EXISTS idx_pool_hash_id ON grest.pool_info_cache (pool_hash_id);
-    CREATE INDEX IF NOT EXISTS idx_pool_status ON grest.pool_info_cache (pool_status);
-    CREATE INDEX IF NOT EXISTS idx_meta_id ON grest.pool_info_cache (meta_id);
+  CREATE INDEX IF NOT EXISTS idx_tx_id ON grest.pool_info_cache (tx_id);
+  CREATE INDEX IF NOT EXISTS idx_pool_id_bech32 ON grest.pool_info_cache (pool_id_bech32);
+  CREATE INDEX IF NOT EXISTS idx_pool_hash_id ON grest.pool_info_cache (pool_hash_id);
+  CREATE INDEX IF NOT EXISTS idx_pool_status ON grest.pool_info_cache (pool_status);
+  CREATE INDEX IF NOT EXISTS idx_meta_id ON grest.pool_info_cache (meta_id);
 END;
 $$;
-

--- a/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
@@ -1,14 +1,16 @@
-CREATE TABLE IF NOT EXISTS GREST.STAKE_DISTRIBUTION_CACHE (
-  STAKE_ADDRESS varchar PRIMARY KEY,
-  POOL_ID varchar,
-  TOTAL_BALANCE numeric,
-  UTXO numeric,
-  REWARDS numeric,
-  WITHDRAWALS numeric,
-  REWARDS_AVAILABLE numeric
+CREATE TABLE IF NOT EXISTS grest.stake_distribution_cache (
+  stake_address varchar PRIMARY KEY,
+  pool_id varchar,
+  total_balance numeric,
+  utxo numeric,
+  rewards numeric,
+  withdrawals numeric,
+  rewards_available numeric
 );
 
-CREATE OR REPLACE PROCEDURE GREST.UPDATE_STAKE_DISTRIBUTION_CACHE () LANGUAGE PLPGSQL AS $$
+CREATE OR REPLACE PROCEDURE grest.update_stake_distribution_cache()
+LANGUAGE plpgsql
+AS $$
 DECLARE -- Last block height to control future re-runs of the query
   _last_accounted_block_height bigint;
   _last_account_tx_id bigint;
@@ -16,216 +18,252 @@ DECLARE -- Last block height to control future re-runs of the query
   _last_active_stake_blockid bigint;
   _latest_epoch bigint;
 BEGIN
-
-  SELECT MAX(block_no) FROM PUBLIC.BLOCK
+  SELECT MAX(block_no) FROM public.block
     WHERE block_no IS NOT NULL INTO _last_accounted_block_height;
-
-  SELECT (last_value::integer - 2)::integer INTO _active_stake_epoch FROM GREST.CONTROL_TABLE
+  SELECT (last_value::integer - 2)::integer INTO _active_stake_epoch FROM grest.control_table
     WHERE key = 'last_active_stake_validated_epoch';
-
   SELECT MAX(tx.id) INTO _last_account_tx_id
-  FROM PUBLIC.TX
-  INNER JOIN BLOCK b ON b.id = tx.block_id
+  FROM public.tx
+  INNER JOIN block AS b ON b.id = tx.block_id
   WHERE b.epoch_no <= _active_stake_epoch
     AND b.block_no IS NOT NULL
     AND b.tx_count != 0;
-
-  SELECT MAX(no) INTO _latest_epoch FROM PUBLIC.EPOCH WHERE NO IS NOT NULL;
+  SELECT MAX(no) INTO _latest_epoch FROM public.epoch WHERE no IS NOT NULL;
 
   WITH
     accounts_with_delegated_pools AS (
-      SELECT DISTINCT ON (STAKE_ADDRESS.ID) stake_address.id as stake_address_id, stake_address.view as stake_address, pool_hash_id
-      FROM STAKE_ADDRESS
-        INNER JOIN DELEGATION ON DELEGATION.ADDR_ID = STAKE_ADDRESS.ID
+      SELECT DISTINCT ON (stake_address.id)
+        stake_address.id AS stake_address_id,
+        stake_address.view AS stake_address,
+        pool_hash_id
+      FROM stake_address
+        INNER JOIN delegation ON delegation.addr_id = stake_address.id
         WHERE
           NOT EXISTS (
-            SELECT TRUE FROM DELEGATION D
-              WHERE D.ADDR_ID = DELEGATION.ADDR_ID AND D.ID > DELEGATION.ID
+            SELECT TRUE
+            FROM delegation AS d
+            WHERE d.addr_id = delegation.addr_id AND d.id > delegation.id
           )
           AND NOT EXISTS (
-            SELECT TRUE FROM STAKE_DEREGISTRATION
-              WHERE STAKE_DEREGISTRATION.ADDR_ID = DELEGATION.ADDR_ID
-                AND STAKE_DEREGISTRATION.TX_ID > DELEGATION.TX_ID
+            SELECT TRUE
+            FROM stake_deregistration
+            WHERE stake_deregistration.addr_id = delegation.addr_id
+              AND stake_deregistration.tx_id > delegation.tx_id
           )
           -- Account must be present in epoch_stake table for the last validated epoch
           AND EXISTS (
-            SELECT TRUE FROM EPOCH_STAKE
-              WHERE EPOCH_STAKE.EPOCH_NO = (
-                SELECT last_value::integer FROM GREST.CONTROL_TABLE
-                  WHERE key = 'last_active_stake_validated_epoch'
-                )
-                AND EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
+            SELECT TRUE
+            FROM epoch_stake
+            WHERE epoch_stake.epoch_no = (
+                SELECT last_value::integer
+                FROM grest.control_table
+                WHERE key = 'last_active_stake_validated_epoch'
+              )
+              AND epoch_stake.addr_id = stake_address.id
           )
     ),
-    pool_ids as (
-      SELECT awdp.stake_address_id,
+
+    pool_ids AS (
+      SELECT
+        awdp.stake_address_id,
         pool_hash.view AS pool_id
-      FROM POOL_HASH
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.pool_hash_id = pool_hash.id
+      FROM pool_hash
+        INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.pool_hash_id = pool_hash.id
     ),
+
     account_active_stake AS (
-      SELECT awdp.stake_address_id, acsc.amount
-      FROM grest.account_active_stake_cache acsc
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address = acsc.stake_address
-        WHERE epoch_no = (_active_stake_epoch + 2)
+      SELECT
+        awdp.stake_address_id,
+        acsc.amount
+      FROM grest.account_active_stake_cache AS acsc
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address = acsc.stake_address
+      WHERE epoch_no = (_active_stake_epoch + 2)
     ),
+
     account_delta_tx_ins AS (
-      SELECT awdp.stake_address_id, tx_in.tx_out_id AS txoid, tx_in.tx_out_index AS txoidx FROM tx_in
-        LEFT JOIN tx_out ON tx_in.tx_out_id = tx_out.tx_id AND tx_in.tx_out_index::smallint = tx_out.index::smallint
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-        WHERE tx_in.tx_in_id > _last_account_tx_id
+      SELECT
+        awdp.stake_address_id,
+        tx_in.tx_out_id AS txoid,
+        tx_in.tx_out_index AS txoidx
+      FROM tx_in
+      LEFT JOIN tx_out
+        ON tx_in.tx_out_id = tx_out.tx_id
+          AND tx_in.tx_out_index::smallint = tx_out.index::smallint
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      WHERE tx_in.tx_in_id > _last_account_tx_id
     ),
+
     account_delta_input AS (
-      SELECT tx_out.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        tx_out.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM account_delta_tx_ins
-        LEFT JOIN tx_out ON account_delta_tx_ins.txoid=tx_out.tx_id AND account_delta_tx_ins.txoidx = tx_out.index
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-        GROUP BY tx_out.stake_address_id
+      LEFT JOIN tx_out
+        ON account_delta_tx_ins.txoid=tx_out.tx_id
+          AND account_delta_tx_ins.txoidx = tx_out.index
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      GROUP BY tx_out.stake_address_id
     ),
+
     account_delta_output AS (
-      SELECT awdp.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        awdp.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM tx_out
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-      WHERE TX_OUT.TX_ID > _last_account_tx_id
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      WHERE tx_out.tx_id > _last_account_tx_id
       GROUP BY awdp.stake_address_id
     ),
+
     account_delta_rewards AS (
-      SELECT awdp.stake_address_id, COALESCE(SUM(reward.amount), 0) AS REWARDS
-      FROM REWARD
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = reward.addr_id
+      SELECT
+        awdp.stake_address_id,
+        COALESCE(SUM(reward.amount), 0) AS rewards
+      FROM reward
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = reward.addr_id
       WHERE
-        ( REWARD.SPENDABLE_EPOCH >= (_active_stake_epoch + 2) AND REWARD.SPENDABLE_EPOCH <= _latest_epoch )
-        OR ( REWARD.TYPE = 'refund' AND REWARD.SPENDABLE_EPOCH >= (_active_stake_epoch + 1) AND REWARD.SPENDABLE_EPOCH <= _latest_epoch )
+        (reward.spendable_epoch >= (_active_stake_epoch + 2) AND reward.spendable_epoch <= _latest_epoch )
+        OR (reward.TYPE = 'refund' AND reward.spendable_epoch >= (_active_stake_epoch + 1) AND reward.spendable_epoch <= _latest_epoch )
       GROUP BY awdp.stake_address_id
     ),
+
     account_delta_withdrawals AS (
-      SELECT accounts_with_delegated_pools.stake_address_id, COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
+      SELECT
+        accounts_with_delegated_pools.stake_address_id,
+        COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
       FROM withdrawal
-        INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = withdrawal.addr_id
+      INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = withdrawal.addr_id
       WHERE withdrawal.tx_id > _last_account_tx_id
       GROUP BY accounts_with_delegated_pools.stake_address_id
     ),
-    account_total_rewards as (
-      SELECT accounts_with_delegated_pools.stake_address_id,
-        COALESCE(SUM(REWARD.AMOUNT), 0) AS REWARDS
-      FROM REWARD
-        INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = reward.addr_id
-      WHERE REWARD.SPENDABLE_EPOCH <= _latest_epoch
+
+    account_total_rewards AS (
+      SELECT
+        accounts_with_delegated_pools.stake_address_id,
+        COALESCE(SUM(reward.amount), 0) AS rewards
+      FROM reward
+      INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = reward.addr_id
+      WHERE reward.spendable_epoch <= _latest_epoch
       GROUP BY accounts_with_delegated_pools.stake_address_id
     ),
-    account_total_withdrawals as (
-      SELECT accounts_with_delegated_pools.stake_address_id,
-        COALESCE(SUM(WITHDRAWAL.AMOUNT), 0) AS WITHDRAWALS
-      FROM WITHDRAWAL
-        INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = WITHDRAWAL.addr_id
+
+    account_total_withdrawals AS (
+      SELECT
+        accounts_with_delegated_pools.stake_address_id,
+        COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
+      FROM withdrawal
+      INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = withdrawal.addr_id
       GROUP BY accounts_with_delegated_pools.stake_address_id
     )
 
   -- INSERT QUERY START
-  INSERT INTO GREST.STAKE_DISTRIBUTION_CACHE
+  INSERT INTO grest.stake_distribution_cache
     SELECT
       awdp.stake_address,
       pi.pool_id,
-      COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) AS TOTAL_BALANCE,
+      COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) AS total_balance,
       CASE
-        WHEN ( COALESCE(atrew.REWARDS, 0) - COALESCE(atw.WITHDRAWALS, 0) ) <= 0 THEN
+        WHEN ( COALESCE(atrew.rewards, 0) - COALESCE(atw.withdrawals, 0) ) <= 0 THEN
           COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0)
         ELSE
-          COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) - (COALESCE(atrew.REWARDS, 0) - COALESCE(atw.WITHDRAWALS, 0))
-      END AS UTXO,
-      COALESCE(atrew.REWARDS, 0) AS REWARDS,
-      COALESCE(atw.WITHDRAWALS, 0) AS WITHDRAWALS,
+          COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) - (COALESCE(atrew.rewards, 0) - COALESCE(atw.withdrawals, 0))
+      END AS utxo,
+      COALESCE(atrew.rewards, 0) AS rewards,
+      COALESCE(atw.withdrawals, 0) AS withdrawals,
       CASE
-        WHEN ( COALESCE(atrew.REWARDS, 0) - COALESCE(atw.WITHDRAWALS, 0) ) <= 0 THEN 0
-        ELSE COALESCE(atrew.REWARDS, 0) - COALESCE(atw.WITHDRAWALS, 0)
-      END AS REWARDS_AVAILABLE
-    from accounts_with_delegated_pools awdp
-      INNER JOIN pool_ids pi ON pi.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_active_stake aas ON aas.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_total_rewards atrew ON atrew.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_total_withdrawals atw ON atw.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_delta_input adi ON adi.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_delta_output ado ON ado.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_delta_rewards adr ON adr.stake_address_id = awdp.stake_address_id
-      LEFT JOIN account_delta_withdrawals adw ON adw.stake_address_id = awdp.stake_address_id
-    ON CONFLICT (STAKE_ADDRESS) DO
+        WHEN ( COALESCE(atrew.rewards, 0) - COALESCE(atw.withdrawals, 0) ) <= 0 THEN 0
+        ELSE COALESCE(atrew.rewards, 0) - COALESCE(atw.withdrawals, 0)
+      END AS rewards_available
+    FROM accounts_with_delegated_pools AS awdp
+    INNER JOIN pool_ids AS pi ON pi.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_active_stake AS aas ON aas.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_total_rewards AS atrew ON atrew.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_total_withdrawals AS atw ON atw.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_delta_input AS adi ON adi.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_delta_output AS ado ON ado.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_delta_rewards AS adr ON adr.stake_address_id = awdp.stake_address_id
+    LEFT JOIN account_delta_withdrawals AS adw ON adw.stake_address_id = awdp.stake_address_id
+    ON CONFLICT (stake_address) DO
       UPDATE
-        SET POOL_ID = EXCLUDED.POOL_ID,
-          TOTAL_BALANCE = EXCLUDED.TOTAL_BALANCE,
-          UTXO = EXCLUDED.UTXO,
-          REWARDS = EXCLUDED.REWARDS,
-          WITHDRAWALS = EXCLUDED.WITHDRAWALS,
-          REWARDS_AVAILABLE = EXCLUDED.REWARDS_AVAILABLE
+        SET pool_id = excluded.pool_id,
+          total_balance = excluded.total_balance,
+          utxo = excluded.utxo,
+          rewards = excluded.rewards,
+          withdrawals = excluded.withdrawals,
+          rewards_available = excluded.rewards_available
   ;
 
-  INSERT INTO GREST.CONTROL_TABLE (key, last_value)
+  INSERT INTO grest.control_table (key, last_value)
     VALUES (
         'stake_distribution_lbh',
         _last_accounted_block_height
       ) ON CONFLICT (key) DO
     UPDATE
     SET last_value = _last_accounted_block_height;
-
 END;
 $$;
 
--- HELPER FUNCTION: GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK
+-- HELPER FUNCTION: grest.stake_distribution_cache_update_check
 -- Determines whether or not the stake distribution cache should be updated
--- based on the time rule (max once in 60 mins), and ensures previous run completed.
+-- based ON the time rule (max once in 60 mins), and ensures previous run completed.
 
-CREATE OR REPLACE FUNCTION GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK () RETURNS VOID LANGUAGE PLPGSQL AS $$
-  DECLARE
-    _last_update_block_height bigint DEFAULT NULL;
-    _current_block_height bigint DEFAULT NULL;
-    _last_update_block_diff bigint DEFAULT NULL;
-  BEGIN IF (
+CREATE OR REPLACE FUNCTION grest.stake_distribution_cache_update_check()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _last_update_block_height bigint DEFAULT NULL;
+  _current_block_height bigint DEFAULT NULL;
+  _last_update_block_diff bigint DEFAULT NULL;
+BEGIN
+  IF (
     -- If checking query with the same name there will be 2 results
     SELECT COUNT(pid) > 1
-      FROM pg_stat_activity
-      WHERE state = 'active'
-        AND query ILIKE '%GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK(%'
-        AND datname = (
-          SELECT current_database()
-        )
+    FROM pg_stat_activity
+    WHERE state = 'active'
+      AND query ILIKE '%grest.stake_distribution_cache_update_check(%'
+      AND datname = (
+        SELECT current_database()
+      )
     ) THEN
       RAISE EXCEPTION 'Previous query still running but should have completed! Exiting...';
-    ELSIF (
-      -- If checking query with a different name there will be 1 result
-      SELECT COUNT(pid) > 0
-        FROM pg_stat_activity
-        WHERE state = 'active'
-          AND query ILIKE '%GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE(%'
-          AND datname = (
-            SELECT current_database()
-          )
-    ) THEN
-      RAISE EXCEPTION 'New accounts query running! Exiting...';
   ELSIF (
-      SELECT count(last_value) = 0 FROM GREST.CONTROL_TABLE WHERE key = 'last_active_stake_validated_epoch'
+    -- If checking query with a different name there will be 1 result
+    SELECT COUNT(pid) > 0
+    FROM pg_stat_activity
+    WHERE state = 'active'
+      AND query ILIKE '%grest.update_newly_registered_accounts_stake_distribution_cache(%'
+      AND datname = (
+        SELECT current_database()
+      )
+  ) THEN
+    RAISE EXCEPTION 'New accounts query running! Exiting...';
+  ELSIF (
+    SELECT count(last_value) = 0
+    FROM grest.control_table
+    WHERE key = 'last_active_stake_validated_epoch'
     ) OR (
-      SELECT ((SELECT MAX(NO) FROM EPOCH) - COALESCE((last_value::integer - 2)::integer, 0 ))  > 3
-        FROM GREST.CONTROL_TABLE
-        WHERE key = 'last_active_stake_validated_epoch'
+      SELECT ((SELECT MAX(no) FROM epoch) - COALESCE((last_value::integer - 2)::integer, 0 ))  > 3
+      FROM grest.control_table
+      WHERE key = 'last_active_stake_validated_epoch'
     ) THEN
-      RAISE EXCEPTION 'Active Stake cache too far, skipping...';
+    RAISE EXCEPTION 'Active Stake cache too far, skipping...';
   END IF;
 
   -- QUERY START --
   SELECT COALESCE(
       (
         SELECT last_value::bigint
-        FROM GREST.control_table
+        FROM grest.control_table
         WHERE key = 'stake_distribution_lbh'
       ), 0
     ) INTO _last_update_block_height;
 
   SELECT MAX(block_no)
-    FROM PUBLIC.BLOCK
+    FROM public.block
     WHERE BLOCK_NO IS NOT NULL INTO _current_block_height;
 
-  SELECT (
-      _current_block_height - _last_update_block_height
-    ) INTO _last_update_block_diff;
+  SELECT (_current_block_height - _last_update_block_height) INTO _last_update_block_diff;
   -- Do nothing until there is a 180 blocks difference in height - 60 minutes theoretical time
   -- 185 in check because last block height considered is 5 blocks behind tip
   
@@ -235,7 +273,7 @@ CREATE OR REPLACE FUNCTION GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK () RETURN
         OR _last_update_block_diff < 0 -- Special case for db-sync restart rollback to epoch start
       ) THEN
       RAISE NOTICE 'Re-running...';
-      CALL GREST.UPDATE_STAKE_DISTRIBUTION_CACHE ();
+      CALL grest.update_stake_distribution_cache ();
     ELSE
       RAISE NOTICE 'Minimum block height difference(180) for update not reached, skipping...';
     END IF;
@@ -244,6 +282,6 @@ CREATE OR REPLACE FUNCTION GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK () RETURN
   END;
 $$;
 
-DROP INDEX IF EXISTS GREST.idx_pool_id;
-CREATE INDEX idx_pool_id ON GREST.STAKE_DISTRIBUTION_CACHE (POOL_ID);
+DROP INDEX IF EXISTS grest.idx_pool_id;
+CREATE INDEX idx_pool_id ON grest.stake_distribution_cache (pool_id);
 -- Populated by first crontab execution

--- a/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
@@ -1,91 +1,97 @@
-CREATE OR REPLACE PROCEDURE GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE() LANGUAGE PLPGSQL AS $$
+CREATE OR REPLACE PROCEDURE grest.update_newly_registered_accounts_stake_distribution_cache()
+LANGUAGE plpgsql
+AS $$
 BEGIN
   IF (
       -- If checking query with a different name there will be 1 result
       SELECT COUNT(pid) > 1
-        FROM pg_stat_activity
-        WHERE state = 'active'
-          AND query ILIKE '%GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE(%'
-          AND query NOT ILIKE '%pg_stat_activity%'
-          AND datname = (
-            SELECT current_database()
-          )
+      FROM pg_stat_activity
+      WHERE state = 'active'
+        AND query ILIKE '%grest.update_newly_registered_accounts_stake_distribution_cache(%'
+        AND query NOT ILIKE '%pg_stat_activity%'
+        AND datname = (
+          SELECT current_database()
+        )
     ) THEN
       RAISE EXCEPTION 'New accounts query already running! Exiting...';
   ELSIF (
     -- If checking query with a different name there will be 1 result
     SELECT COUNT(pid) > 0
-      FROM pg_stat_activity
+    FROM pg_stat_activity
     WHERE state = 'active'
-      AND query ILIKE '%GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK(%'
+      AND query ILIKE '%grest.stake_distribution_cache_update_check(%'
       AND datname = (
         SELECT current_database()
       )
   ) THEN
     RAISE NOTICE 'Stake distribution query running! Killing it and running new accounts update...';
-    CALL grest.kill_queries_partial_match('GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK(');
+    CALL grest.kill_queries_partial_match('grest.stake_distribution_cache_update_check(');
   END IF;
 
   WITH
     newly_registered_accounts AS (
-      SELECT DISTINCT ON (STAKE_ADDRESS.ID)
-        stake_address.id as stake_address_id,
-        stake_address.view as stake_address,
+      SELECT DISTINCT ON (stake_address.id)
+        stake_address.id AS stake_address_id,
+        stake_address.view AS stake_address,
         pool_hash_id
-      FROM STAKE_ADDRESS
-        INNER JOIN DELEGATION ON DELEGATION.ADDR_ID = STAKE_ADDRESS.ID
-        WHERE
-          NOT EXISTS (
-            SELECT TRUE FROM DELEGATION D
-              WHERE D.ADDR_ID = DELEGATION.ADDR_ID AND D.ID > DELEGATION.ID
-          )
-          AND NOT EXISTS (
-            SELECT TRUE FROM STAKE_DEREGISTRATION
-              WHERE STAKE_DEREGISTRATION.ADDR_ID = DELEGATION.ADDR_ID
-                AND STAKE_DEREGISTRATION.TX_ID > DELEGATION.TX_ID
-          )
-          AND NOT EXISTS (
-            SELECT TRUE FROM EPOCH_STAKE
-              WHERE EPOCH_STAKE.EPOCH_NO = (
-                SELECT last_value::integer FROM GREST.CONTROL_TABLE
-                  WHERE key = 'last_active_stake_validated_epoch'
-                )
-                AND EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
-          )
+      FROM stake_address
+      INNER JOIN delegation ON delegation.addr_id = stake_address.id
+      WHERE
+        NOT EXISTS (
+          SELECT TRUE
+          FROM delegation AS d
+          WHERE d.addr_id = delegation.addr_id AND d.id > delegation.id
+        )
+        AND NOT EXISTS (
+          SELECT TRUE
+          FROM stake_deregistration
+          WHERE stake_deregistration.addr_id = delegation.addr_id
+            AND stake_deregistration.tx_id > delegation.tx_id
+        )
+        AND NOT EXISTS (
+          SELECT TRUE
+          FROM epoch_stake
+          WHERE epoch_stake.epoch_no = (
+            SELECT last_value::integer FROM grest.control_table
+              WHERE key = 'last_active_stake_validated_epoch'
+            )
+            AND epoch_stake.addr_id = stake_address.id
+        )
     )
   -- INSERT QUERY START
-  INSERT INTO GREST.STAKE_DISTRIBUTION_CACHE
+  INSERT INTO grest.stake_distribution_cache
     SELECT
       nra.stake_address,
-      ai.delegated_pool as pool_id,
+      ai.delegated_pool AS pool_id,
       ai.total_balance::lovelace,
       ai.utxo::lovelace,
       ai.rewards::lovelace,
       ai.withdrawals::lovelace,
       ai.rewards_available::lovelace
-    FROM newly_registered_accounts nra,
-      LATERAL grest.account_info(array[nra.stake_address]) ai
-    ON CONFLICT (STAKE_ADDRESS) DO
+    FROM newly_registered_accounts AS nra,
+      LATERAL grest.account_info(array[nra.stake_address]) AS ai
+    ON CONFLICT (stake_address) DO
       UPDATE
         SET
-          POOL_ID = EXCLUDED.POOL_ID,
-          TOTAL_BALANCE = EXCLUDED.total_balance,
-          UTXO = EXCLUDED.utxo,
-          REWARDS = EXCLUDED.rewards,
-          WITHDRAWALS = EXCLUDED.withdrawals,
-          REWARDS_AVAILABLE = EXCLUDED.rewards_available;
+          pool_id = EXCLUDED.pool_id,
+          total_balance = EXCLUDED.total_balance,
+          utxo = EXCLUDED.utxo,
+          rewards = EXCLUDED.rewards,
+          withdrawals = EXCLUDED.withdrawals,
+          rewards_available = EXCLUDED.rewards_available;
 
     -- Clean up de-registered accounts
     DELETE FROM grest.stake_distribution_cache
       WHERE stake_address IN (
-        SELECT DISTINCT ON (SA.id)
-          SA.view
-        FROM STAKE_ADDRESS SA
-        INNER JOIN STAKE_DEREGISTRATION SD ON SA.ID = SD.ADDR_ID
+        SELECT DISTINCT ON (sa.id)
+          sa.view
+        FROM stake_address AS sa
+        INNER JOIN stake_deregistration AS sd ON sa.id = sd.addr_id
           WHERE NOT EXISTS (
-            SELECT TRUE FROM STAKE_REGISTRATION SR
-              WHERE SR.ADDR_ID = SD.ADDR_ID
-                AND SR.TX_ID >= SD.TX_ID
+            SELECT TRUE
+            FROM stake_registration AS sr
+            WHERE sr.addr_id = sd.addr_id
+              AND sr.tx_id >= sd.tx_id
           )
       );
 END;

--- a/files/grest/rpc/01_cached_tables/stake_snapshot_cache.sql
+++ b/files/grest/rpc/01_cached_tables/stake_snapshot_cache.sql
@@ -1,5 +1,5 @@
 /* Keeps track of stake snapshots taken at the end of epochs n - 1 and n - 2 */
-CREATE TABLE IF NOT EXISTS GREST.stake_snapshot_cache (
+CREATE TABLE IF NOT EXISTS grest.stake_snapshot_cache (
   addr_id integer,
   pool_id integer,
   amount numeric,
@@ -10,8 +10,8 @@ CREATE TABLE IF NOT EXISTS GREST.stake_snapshot_cache (
 CREATE INDEX IF NOT EXISTS _idx_pool_id ON grest.stake_snapshot_cache (pool_id);
 CREATE INDEX IF NOT EXISTS _idx_addr_id ON grest.stake_snapshot_cache (addr_id);
 
-CREATE OR REPLACE PROCEDURE GREST.CAPTURE_LAST_EPOCH_SNAPSHOT ()
-LANGUAGE PLPGSQL
+CREATE OR REPLACE PROCEDURE grest.capture_last_epoch_snapshot()
+LANGUAGE plpgsql
 AS $$
 DECLARE
   _previous_epoch_no bigint;
@@ -24,7 +24,7 @@ BEGIN
     SELECT COUNT(pid) > 1
       FROM pg_stat_activity
       WHERE state = 'active'
-        AND query ILIKE '%GREST.CAPTURE_LAST_EPOCH_SNAPSHOT(%'
+        AND query ILIKE '%grest.capture_last_epoch_snapshot(%'
         AND datname = (
           SELECT current_database()
         )
@@ -32,10 +32,10 @@ BEGIN
       RAISE EXCEPTION 'Previous query still running but should have completed! Exiting...';
   END IF;
 
-  SELECT MAX(NO) - 1 INTO _previous_epoch_no FROM PUBLIC.EPOCH;
+  SELECT MAX(no) - 1 INTO _previous_epoch_no FROM public.epoch;
 
   IF NOT EXISTS (
-    SELECT i_last_tx_id from grest.epoch_info_cache
+    SELECT i_last_tx_id FROM grest.epoch_info_cache
       WHERE epoch_no = _previous_epoch_no
       AND i_last_tx_id IS NOT NULL
   ) THEN
@@ -52,15 +52,15 @@ BEGIN
 
   -- Set-up interval limits for previous epoch
   SELECT MAX(tx.id) INTO _lower_bound_account_tx_id
-  FROM PUBLIC.TX
-  INNER JOIN BLOCK b ON b.id = tx.block_id
+  FROM public.tx
+  INNER JOIN BLOCK AS b ON b.id = tx.block_id
     WHERE b.epoch_no <= _previous_epoch_no - 2
     AND b.block_no IS NOT NULL
     AND b.tx_count != 0;
 
   SELECT MAX(tx.id) INTO _upper_bound_account_tx_id
-  FROM PUBLIC.TX
-  INNER JOIN BLOCK b ON b.id = tx.block_id
+  FROM public.tx
+  INNER JOIN BLOCK AS b ON b.id = tx.block_id
     WHERE b.epoch_no <= _previous_epoch_no
     AND b.block_no IS NOT NULL
     AND b.tx_count != 0;
@@ -88,7 +88,7 @@ BEGIN
     spendable_epoch bigint,
     amount lovelace
   );
-  
+
   INSERT INTO rewards_subset
     SELECT addr_id, type, spendable_epoch, amount
     FROM reward
@@ -96,18 +96,18 @@ BEGIN
 
 /* Registered and delegated accounts to be captured (have epoch_stake entries for baseline) */
   WITH
-    latest_non_cancelled_pool_retire as (
+    latest_non_cancelled_pool_retire AS (
       SELECT DISTINCT ON (pr.hash_id)
         pr.hash_id,
         pr.retiring_epoch
-      FROM pool_retire pr
+      FROM pool_retire AS pr
       WHERE
         pr.announced_tx_id <= _upper_bound_account_tx_id
         AND pr.retiring_epoch <= _previous_epoch_no
         AND NOT EXISTS (
           SELECT TRUE
-          FROM pool_update pu
-          WHERE pu.hash_id = pr.hash_id 
+          FROM pool_update AS pu
+          WHERE pu.hash_id = pr.hash_id
             AND (
               pu.registered_tx_id > pr.announced_tx_id
                 OR (
@@ -118,14 +118,14 @@ BEGIN
             AND pu.registered_tx_id <= _upper_bound_account_tx_id
             AND pu.registered_tx_id <= (
               SELECT i_last_tx_id
-              FROM grest.epoch_info_cache eic
+              FROM grest.epoch_info_cache AS eic
               WHERE eic.epoch_no = pr.retiring_epoch - 1
             )
         )
         AND NOT EXISTS (
           SELECT TRUE
-          FROM pool_retire sub_pr
-          WHERE pr.hash_id = sub_pr.hash_id 
+          FROM pool_retire AS sub_pr
+          WHERE pr.hash_id = sub_pr.hash_id
             AND (
               sub_pr.announced_tx_id > pr.announced_tx_id
                 OR (
@@ -136,7 +136,7 @@ BEGIN
             AND sub_pr.announced_tx_id <= _upper_bound_account_tx_id
             AND sub_pr.announced_tx_id <= (
               SELECT i_last_tx_id
-              FROM grest.epoch_info_cache eic
+              FROM grest.epoch_info_cache AS eic
               WHERE eic.epoch_no = pr.retiring_epoch - 1
             )
         )
@@ -147,17 +147,17 @@ BEGIN
     INSERT INTO minimum_pool_delegation_tx_ids
       SELECT DISTINCT ON (pu.hash_id)
         pu.hash_id,
-        pu.registered_tx_id as min_tx_id,
+        pu.registered_tx_id AS min_tx_id,
         pu.cert_index
-      FROM pool_update pu
-        LEFT JOIN latest_non_cancelled_pool_retire lncpr ON lncpr.hash_id = pu.hash_id
+      FROM pool_update AS pu
+        LEFT JOIN latest_non_cancelled_pool_retire AS lncpr ON lncpr.hash_id = pu.hash_id
       WHERE pu.registered_tx_id <= _upper_bound_account_tx_id
         AND
         CASE WHEN lncpr.retiring_epoch IS NOT NULL
           THEN
             pu.registered_tx_id > (
               SELECT i_last_tx_id
-              FROM grest.epoch_info_cache eic
+              FROM grest.epoch_info_cache AS eic
               WHERE eic.epoch_no = lncpr.retiring_epoch - 1
             )
           ELSE TRUE
@@ -166,40 +166,37 @@ BEGIN
         pu.hash_id, pu.registered_tx_id ASC;
 
     INSERT INTO latest_accounts_delegation_txs
-      SELECT distinct on (d.addr_id)
+      SELECT distinct ON (d.addr_id)
         d.addr_id,
         d.tx_id,
         d.cert_index,
         d.pool_hash_id
-      FROM DELEGATION D
+      FROM delegation AS d
       WHERE
         d.tx_id <= _upper_bound_account_tx_id
         AND NOT EXISTS (
-          SELECT TRUE FROM STAKE_DEREGISTRATION
-            WHERE STAKE_DEREGISTRATION.ADDR_ID = D.ADDR_ID
+          SELECT TRUE FROM stake_deregistration
+            WHERE stake_deregistration.addr_id = d.addr_id
             AND (
-                STAKE_DEREGISTRATION.TX_ID > D.TX_ID
+                stake_deregistration.tx_id > d.tx_id
                 OR (
-                    STAKE_DEREGISTRATION.TX_ID = D.TX_ID
-                        AND STAKE_DEREGISTRATION.CERT_INDEX > D.CERT_INDEX
+                    stake_deregistration.tx_id = d.tx_id
+                        AND stake_deregistration.cert_index > d.cert_index
                 )
             )
-            AND STAKE_DEREGISTRATION.TX_ID <= _upper_bound_account_tx_id
+            AND stake_deregistration.tx_id <= _upper_bound_account_tx_id
         )
       ORDER BY
         d.addr_id, d.tx_id DESC;
-    
     CREATE INDEX _idx_pool_hash_id ON latest_accounts_delegation_txs (pool_hash_id);
-
-
   /* Registered and delegated accounts to be captured (have epoch_stake entries for baseline) */
   WITH
     accounts_with_delegated_pools AS (
       SELECT DISTINCT ON (ladt.addr_id)
-        ladt.addr_id as stake_address_id,
+        ladt.addr_id AS stake_address_id,
         ladt.pool_hash_id
-      FROM latest_accounts_delegation_txs ladt
-        INNER JOIN minimum_pool_delegation_tx_ids mpdtx ON mpdtx.pool_hash_id = ladt.pool_hash_id
+      FROM latest_accounts_delegation_txs AS ladt
+      INNER JOIN minimum_pool_delegation_tx_ids AS mpdtx ON mpdtx.pool_hash_id = ladt.pool_hash_id
       WHERE
         (
           ladt.tx_id > mpdtx.latest_registered_tx_id
@@ -210,43 +207,55 @@ BEGIN
         )
         -- Account must be present in epoch_stake table for the previous epoch
         AND EXISTS (
-          SELECT TRUE FROM epoch_stake es
+          SELECT TRUE FROM epoch_stake AS es
             WHERE es.epoch_no = _previous_epoch_no
               AND es.addr_id = ladt.addr_id
         )
     ),
     account_active_stake AS (
-      SELECT awdp.stake_address_id, es.amount
-      FROM public.epoch_stake es
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = es.addr_id
-        WHERE epoch_no = _previous_epoch_no
+      SELECT
+        awdp.stake_address_id,
+        es.amount
+      FROM public.epoch_stake AS es
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = es.addr_id
+      WHERE epoch_no = _previous_epoch_no
     ),
     account_delta_tx_ins AS (
-      SELECT awdp.stake_address_id, tx_in.tx_out_id AS txoid, tx_in.tx_out_index AS txoidx FROM tx_in
-        LEFT JOIN tx_out ON tx_in.tx_out_id = tx_out.tx_id AND tx_in.tx_out_index::smallint = tx_out.index::smallint
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-        WHERE tx_in.tx_in_id > _lower_bound_account_tx_id
+      SELECT
+        awdp.stake_address_id,
+        tx_in.tx_out_id AS txoid,
+        tx_in.tx_out_index AS txoidx
+      FROM tx_in
+      LEFT JOIN tx_out ON tx_in.tx_out_id = tx_out.tx_id AND tx_in.tx_out_index::smallint = tx_out.index::smallint
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      WHERE tx_in.tx_in_id > _lower_bound_account_tx_id
           AND tx_in.tx_in_id <= _upper_bound_account_tx_id
     ),
     account_delta_input AS (
-      SELECT tx_out.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        tx_out.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM account_delta_tx_ins
-        LEFT JOIN tx_out ON account_delta_tx_ins.txoid=tx_out.tx_id AND account_delta_tx_ins.txoidx = tx_out.index
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-        GROUP BY tx_out.stake_address_id
+      LEFT JOIN tx_out ON account_delta_tx_ins.txoid=tx_out.tx_id AND account_delta_tx_ins.txoidx = tx_out.index
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      GROUP BY tx_out.stake_address_id
     ),
     account_delta_output AS (
-      SELECT awdp.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        awdp.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM tx_out
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = tx_out.stake_address_id
-      WHERE TX_OUT.TX_ID > _lower_bound_account_tx_id
-        AND TX_OUT.TX_ID <= _upper_bound_account_tx_id
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = tx_out.stake_address_id
+      WHERE tx_out.tx_id > _lower_bound_account_tx_id
+        AND tx_out.tx_id <= _upper_bound_account_tx_id
       GROUP BY awdp.stake_address_id
     ),
     account_delta_rewards AS (
-      SELECT awdp.stake_address_id, COALESCE(SUM(rs.amount), 0) AS REWARDS
-      FROM rewards_subset rs
-        INNER JOIN accounts_with_delegated_pools awdp ON awdp.stake_address_id = rs.stake_address_id
+      SELECT
+        awdp.stake_address_id,
+        COALESCE(SUM(rs.amount), 0) AS rewards
+      FROM rewards_subset AS rs
+      INNER JOIN accounts_with_delegated_pools AS awdp ON awdp.stake_address_id = rs.stake_address_id
       WHERE
         CASE WHEN rs.type = 'refund'
           THEN rs.spendable_epoch IN (_previous_epoch_no - 1, _previous_epoch_no)
@@ -255,7 +264,9 @@ BEGIN
       GROUP BY awdp.stake_address_id
     ),
     account_delta_withdrawals AS (
-      SELECT accounts_with_delegated_pools.stake_address_id, COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
+      SELECT
+        accounts_with_delegated_pools.stake_address_id,
+        COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
       FROM withdrawal
         INNER JOIN accounts_with_delegated_pools ON accounts_with_delegated_pools.stake_address_id = withdrawal.addr_id
       WHERE withdrawal.tx_id > _lower_bound_account_tx_id
@@ -263,30 +274,30 @@ BEGIN
       GROUP BY accounts_with_delegated_pools.stake_address_id
     )
 
-      INSERT INTO GREST.stake_snapshot_cache
-        SELECT
-          awdp.stake_address_id as addr_id,
-          awdp.pool_hash_id,
-          COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) as AMOUNT,
-          _previous_epoch_no as epoch_no
-        from accounts_with_delegated_pools awdp
-          LEFT JOIN account_active_stake aas ON aas.stake_address_id = awdp.stake_address_id
-          LEFT JOIN account_delta_input adi ON adi.stake_address_id = awdp.stake_address_id
-          LEFT JOIN account_delta_output ado ON ado.stake_address_id = awdp.stake_address_id
-          LEFT JOIN account_delta_rewards adr ON adr.stake_address_id = awdp.stake_address_id
-          LEFT JOIN account_delta_withdrawals adw ON adw.stake_address_id = awdp.stake_address_id
-        ON CONFLICT (addr_id, EPOCH_NO) DO
-          UPDATE
-            SET
-              POOL_ID = EXCLUDED.POOL_ID,
-              AMOUNT = EXCLUDED.AMOUNT;
+    INSERT INTO grest.stake_snapshot_cache
+      SELECT
+        awdp.stake_address_id AS addr_id,
+        awdp.pool_hash_id,
+        COALESCE(aas.amount, 0) + COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) AS amount,
+        _previous_epoch_no AS epoch_no
+      FROM accounts_with_delegated_pools AS awdp
+        LEFT JOIN account_active_stake AS aas ON aas.stake_address_id = awdp.stake_address_id
+        LEFT JOIN account_delta_input AS adi ON adi.stake_address_id = awdp.stake_address_id
+        LEFT JOIN account_delta_output AS ado ON ado.stake_address_id = awdp.stake_address_id
+        LEFT JOIN account_delta_rewards AS adr ON adr.stake_address_id = awdp.stake_address_id
+        LEFT JOIN account_delta_withdrawals AS adw ON adw.stake_address_id = awdp.stake_address_id
+      ON CONFLICT (addr_id, epoch_no) DO
+        UPDATE
+          SET
+            pool_id = excluded.pool_id,
+            amount = excluded.amount;
 
   /* Newly registered accounts to be captured (they don't have epoch_stake entries for baseline) */
   SELECT INTO _newly_registered_account_ids ARRAY_AGG(addr_id)
   FROM (
     SELECT DISTINCT ladt.addr_id
-    FROM latest_accounts_delegation_txs ladt
-      INNER JOIN minimum_pool_delegation_tx_ids mpdtx ON mpdtx.pool_hash_id = ladt.pool_hash_id
+    FROM latest_accounts_delegation_txs AS ladt
+    INNER JOIN minimum_pool_delegation_tx_ids AS mpdtx ON mpdtx.pool_hash_id = ladt.pool_hash_id
     WHERE
       (
         ladt.tx_id > mpdtx.latest_registered_tx_id
@@ -297,36 +308,49 @@ BEGIN
       )
       -- Account must NOT be present in epoch_stake table for the previous epoch
       AND NOT EXISTS (
-        SELECT TRUE FROM epoch_stake es
+        SELECT TRUE FROM epoch_stake AS es
           WHERE es.epoch_no = _previous_epoch_no
             AND es.addr_id = ladt.addr_id
       )
   ) AS tmp;
+
   WITH
     account_delta_tx_ins AS (
-      SELECT tx_out.stake_address_id, tx_in.tx_out_id AS txoid, tx_in.tx_out_index AS txoidx 
+      SELECT
+        tx_out.stake_address_id,
+        tx_in.tx_out_id AS txoid,
+        tx_in.tx_out_index AS txoidx
       FROM tx_in
-        LEFT JOIN tx_out ON tx_in.tx_out_id = tx_out.tx_id AND tx_in.tx_out_index::smallint = tx_out.index::smallint
+      LEFT JOIN tx_out ON tx_in.tx_out_id = tx_out.tx_id AND tx_in.tx_out_index::smallint = tx_out.index::smallint
       WHERE tx_in.tx_in_id <= _upper_bound_account_tx_id
         AND tx_out.stake_address_id = ANY(_newly_registered_account_ids)
     ),
+
     account_delta_input AS (
-      SELECT tx_out.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        tx_out.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM account_delta_tx_ins
-        LEFT JOIN tx_out ON account_delta_tx_ins.txoid=tx_out.tx_id AND account_delta_tx_ins.txoidx = tx_out.index
+      LEFT JOIN tx_out ON account_delta_tx_ins.txoid=tx_out.tx_id AND account_delta_tx_ins.txoidx = tx_out.index
       WHERE tx_out.stake_address_id = ANY(_newly_registered_account_ids)
       GROUP BY tx_out.stake_address_id
     ),
+
     account_delta_output AS (
-      SELECT tx_out.stake_address_id, COALESCE(SUM(tx_out.value), 0) AS amount
+      SELECT
+        tx_out.stake_address_id,
+        COALESCE(SUM(tx_out.value), 0) AS amount
       FROM tx_out
-      WHERE TX_OUT.TX_ID <= _upper_bound_account_tx_id
+      WHERE tx_out.tx_id <= _upper_bound_account_tx_id
         AND tx_out.stake_address_id = ANY(_newly_registered_account_ids)
       GROUP BY tx_out.stake_address_id
     ),
+
     account_delta_rewards AS (
-      SELECT r.addr_id as stake_address_id, COALESCE(SUM(r.amount), 0) AS REWARDS
-      FROM REWARD r
+      SELECT
+        r.addr_id AS stake_address_id,
+        COALESCE(SUM(r.amount), 0) AS rewards
+      FROM REWARD AS r
       WHERE r.addr_id = ANY(_newly_registered_account_ids)
         AND
         CASE WHEN r.type = 'refund'
@@ -335,34 +359,37 @@ BEGIN
         END
       GROUP BY r.addr_id
     ),
+
     account_delta_withdrawals AS (
-      SELECT withdrawal.addr_id as stake_address_id, COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
+      SELECT
+        withdrawal.addr_id AS stake_address_id,
+        COALESCE(SUM(withdrawal.amount), 0) AS withdrawals
       FROM withdrawal
       WHERE withdrawal.tx_id <= _upper_bound_account_tx_id
         AND withdrawal.addr_id = ANY(_newly_registered_account_ids)
       GROUP BY withdrawal.addr_id
     )
 
-      INSERT INTO GREST.stake_snapshot_cache
-        SELECT
-          ladt.addr_id,
-          ladt.pool_hash_id,
-          COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) as amount,
-          _previous_epoch_no as epoch_no
-        FROM latest_accounts_delegation_txs ladt
-          LEFT JOIN account_delta_input adi ON adi.stake_address_id = ladt.addr_id
-          LEFT JOIN account_delta_output ado ON ado.stake_address_id = ladt.addr_id
-          LEFT JOIN account_delta_rewards adr ON adr.stake_address_id = ladt.addr_id
-          LEFT JOIN account_delta_withdrawals adw ON adw.stake_address_id = ladt.addr_id
-        WHERE
-          ladt.addr_id = ANY(_newly_registered_account_ids)
-      ON CONFLICT (addr_id, epoch_no) DO
-        UPDATE
-          SET
-            pool_id = EXCLUDED.pool_id,
-            amount = EXCLUDED.amount;
+    INSERT INTO grest.stake_snapshot_cache
+      SELECT
+        ladt.addr_id,
+        ladt.pool_hash_id,
+        COALESCE(ado.amount, 0) - COALESCE(adi.amount, 0) + COALESCE(adr.rewards, 0) - COALESCE(adw.withdrawals, 0) AS amount,
+        _previous_epoch_no AS epoch_no
+      FROM latest_accounts_delegation_txs AS ladt
+        LEFT JOIN account_delta_input AS adi ON adi.stake_address_id = ladt.addr_id
+        LEFT JOIN account_delta_output AS ado ON ado.stake_address_id = ladt.addr_id
+        LEFT JOIN account_delta_rewards AS adr ON adr.stake_address_id = ladt.addr_id
+        LEFT JOIN account_delta_withdrawals AS adw ON adw.stake_address_id = ladt.addr_id
+      WHERE
+        ladt.addr_id = ANY(_newly_registered_account_ids)
+    ON CONFLICT (addr_id, epoch_no) DO
+      UPDATE
+        SET
+          pool_id = excluded.pool_id,
+          amount = excluded.amount;
 
-  INSERT INTO GREST.CONTROL_TABLE (key, last_value)
+  INSERT INTO grest.control_table (key, last_value)
     VALUES (
       'last_stake_snapshot_epoch',
       _previous_epoch_no
@@ -385,8 +412,8 @@ BEGIN
       ph.view,
       _previous_epoch_no + 2,
       SUM(ssc.amount)
-    FROM grest.stake_snapshot_cache ssc
-      INNER JOIN pool_hash ph ON ph.id = ssc.pool_id
+    FROM grest.stake_snapshot_cache AS ssc
+      INNER JOIN pool_hash AS ph ON ph.id = ssc.pool_id
     WHERE epoch_no = _previous_epoch_no
     GROUP BY
       ssc.pool_id, ph.view

--- a/files/grest/rpc/02_indexes/13_1_00.sql
+++ b/files/grest/rpc/02_indexes/13_1_00.sql
@@ -23,4 +23,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS unique_txin ON tx_in USING btree (tx_out_id, t
 CREATE UNIQUE INDEX IF NOT EXISTS unique_withdrawal ON public.withdrawal USING btree (addr_id, tx_id);
 
 /* Help multi asset queries */
-CREATE INDEX IF NOT EXISTS idx_ma_tx_out_ident ON ma_tx_out (ident) ;
+CREATE INDEX IF NOT EXISTS idx_ma_tx_out_ident ON ma_tx_out (ident);

--- a/files/grest/rpc/account/account_addresses.sql
+++ b/files/grest/rpc/account/account_addresses.sql
@@ -1,79 +1,80 @@
-CREATE OR REPLACE FUNCTION grest.account_addresses (_stake_addresses text[], _first_only boolean default false, _empty boolean default false)
-  RETURNS TABLE (
-    stake_address varchar,
-    addresses jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.account_addresses(_stake_addresses text [], _first_only boolean DEFAULT FALSE, _empty boolean DEFAULT FALSE)
+RETURNS TABLE (
+  stake_address varchar,
+  addresses jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   sa_id_list integer[];
 BEGIN
   SELECT INTO sa_id_list
-    ARRAY_AGG(STAKE_ADDRESS.ID)
+    ARRAY_AGG(stake_address.ID)
   FROM
-    STAKE_ADDRESS
+    stake_address
   WHERE
-    STAKE_ADDRESS.VIEW = ANY(_stake_addresses);
+    stake_address.VIEW = ANY(_stake_addresses);
 
   IF _first_only IS NOT TRUE AND _empty IS NOT TRUE THEN
     RETURN QUERY
       WITH txo_addr AS (
-        SELECT 
-          DISTINCT ON (address) address,
-          stake_address_id 
+        SELECT DISTINCT ON (address)
+          address,
+          stake_address_id
         FROM
           (
             SELECT
-              txo.address, 
-              txo.stake_address_id, 
+              txo.address,
+              txo.stake_address_id,
               txo.id
             FROM
-              tx_out txo
+              tx_out AS txo
               LEFT JOIN tx_in ON txo.tx_id = tx_in.tx_out_id
               AND txo.index::smallint = tx_in.tx_out_index::smallint
-            WHERE 
+            WHERE
               txo.stake_address_id = ANY(sa_id_list)
-              AND TX_IN.TX_OUT_ID IS NULL
-          ) x
+              AND tx_in.tx_out_id IS NULL
+          ) AS x
       )
+
       SELECT
-        sa.view as stake_address,
-        JSONB_AGG(txo_addr.address) as addresses
+        sa.view AS stake_address,
+        JSONB_AGG(txo_addr.address) AS addresses
       FROM
         txo_addr
-        INNER JOIN STAKE_ADDRESS sa ON sa.id = txo_addr.stake_address_id
+        INNER JOIN stake_address AS sa ON sa.id = txo_addr.stake_address_id
       GROUP BY
         sa.id;
   ELSE
     RETURN QUERY
       WITH txo_addr AS (
-        SELECT 
-          DISTINCT ON (address) address,
-          stake_address_id 
+        SELECT DISTINCT ON (address)
+          address,
+          stake_address_id
         FROM
           (
             SELECT
-              txo.address, 
-              txo.stake_address_id, 
+              txo.address,
+              txo.stake_address_id,
               txo.id
             FROM
-              tx_out txo
-            WHERE 
+              tx_out AS txo
+            WHERE
               txo.stake_address_id = ANY(sa_id_list)
             LIMIT (CASE WHEN _first_only IS TRUE THEN 1 ELSE NULL END)
-          ) x
+          ) AS x
       )
+
       SELECT
-        sa.view as stake_address,
-        JSONB_AGG(txo_addr.address) as addresses
+        sa.view AS stake_address,
+        JSONB_AGG(txo_addr.address) AS addresses
       FROM
         txo_addr
-        INNER JOIN STAKE_ADDRESS sa ON sa.id = txo_addr.stake_address_id
+        INNER JOIN stake_address AS sa ON sa.id = txo_addr.stake_address_id
       GROUP BY
         sa.id;
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.account_addresses IS 'Get all addresses associated with given accounts, optionally filtered by first used address only or inclusion of used but empty(no utxo) addresses.';
-
+COMMENT ON FUNCTION grest.account_addresses IS 'Get all addresses associated with given accounts, optionally filtered by first used address only or inclusion of used but empty(no utxo) addresses.'; -- noqa: LT01

--- a/files/grest/rpc/account/account_info_cached.sql
+++ b/files/grest/rpc/account/account_info_cached.sql
@@ -1,113 +1,114 @@
-CREATE OR REPLACE FUNCTION grest.account_info_cached (_stake_addresses text[])
-  RETURNS TABLE (
-    stake_address varchar,
-    STATUS text,
-    DELEGATED_POOL varchar,
-    TOTAL_BALANCE text,
-    UTXO text,
-    REWARDS text,
-    WITHDRAWALS text,
-    REWARDS_AVAILABLE text,
-    RESERVES text,
-    TREASURY text)
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.account_info_cached(_stake_addresses text [])
+RETURNS TABLE (
+  stake_address varchar,
+  status text,
+  delegated_pool varchar,
+  total_balance text,
+  utxo text,
+  rewards text,
+  withdrawals text,
+  rewards_available text,
+  reserves text,
+  treasury text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   sa_id_list integer[] DEFAULT NULL;
 BEGIN
   SELECT INTO sa_id_list
-    array_agg(ID)
+    array_agg(id)
   FROM
-    STAKE_ADDRESS
+    stake_address
   WHERE
-    STAKE_ADDRESS.VIEW = ANY(_stake_addresses);
+    stake_address.view = ANY(_stake_addresses);
 
   RETURN QUERY
     WITH latest_withdrawal_txs AS (
       SELECT DISTINCT ON (addr_id)
         addr_id,
         tx_id
-      FROM WITHDRAWAL
-      WHERE ADDR_ID = ANY(sa_id_list)
-      ORDER BY addr_id, TX_ID DESC
+      FROM withdrawal
+      WHERE addr_id = ANY(sa_id_list)
+      ORDER BY addr_id, tx_id DESC
     ),
     latest_withdrawal_epochs AS (
       SELECT
         lwt.addr_id,
         b.epoch_no
-      FROM BLOCK b
-        INNER JOIN TX ON TX.BLOCK_ID = b.ID
-        INNER JOIN latest_withdrawal_txs lwt ON tx.id = lwt.tx_id
+      FROM block AS b
+        INNER JOIN tx ON tx.block_id = b.id
+        INNER JOIN latest_withdrawal_txs AS lwt ON tx.id = lwt.tx_id
     )
 
     SELECT
       sdc.stake_address,
-      CASE  WHEN STATUS_T.REGISTERED = TRUE THEN
+      CASE  WHEN status_t.registered = TRUE THEN
         'registered'
       ELSE
         'not registered'
       END AS status,
-      sdc.pool_id as pool_id,
+      sdc.pool_id AS pool_id,
       sdc.total_balance::text,
       sdc.utxo::text,
       sdc.rewards::text,
       sdc.withdrawals::text,
       sdc.rewards_available::text,
-      COALESCE(RESERVES_T.RESERVES, 0)::text AS RESERVES,
-      COALESCE(TREASURY_T.TREASURY, 0)::text AS TREASURY
+      COALESCE(reserves_t.reserves, 0)::text AS reserves,
+      COALESCE(treasury_t.treasury, 0)::text AS treasury
     FROM
-      grest.stake_distribution_cache sdc
+      grest.stake_distribution_cache AS sdc
       LEFT JOIN (
         SELECT
           sas.id,
           sas.view,
           EXISTS (
-            SELECT TRUE FROM STAKE_REGISTRATION
+            SELECT TRUE FROM stake_registration
             WHERE
-              STAKE_REGISTRATION.ADDR_ID = sas.id
+              stake_registration.addr_id = sas.id
               AND NOT EXISTS (
                 SELECT TRUE
-                FROM STAKE_DEREGISTRATION
+                FROM stake_deregistration
                 WHERE
-                  STAKE_DEREGISTRATION.ADDR_ID = STAKE_REGISTRATION.ADDR_ID
-                  AND STAKE_DEREGISTRATION.TX_ID > STAKE_REGISTRATION.TX_ID
+                  stake_deregistration.addr_id = stake_registration.addr_id
+                  AND stake_deregistration.tx_id > stake_registration.tx_id
               )
-          ) AS REGISTERED
-        FROM public.stake_address sas
+          ) AS registered
+        FROM public.stake_address AS sas
         WHERE sas.id = ANY(sa_id_list)
-        ) STATUS_T ON sdc.stake_address = STATUS_T.view
+        ) AS status_t ON sdc.stake_address = status_t.view
       LEFT JOIN (
         SELECT
-          RESERVE.ADDR_ID,
-          COALESCE(SUM(RESERVE.AMOUNT), 0) AS RESERVES
+          reserve.addr_id,
+          COALESCE(SUM(reserve.amount), 0) AS reserves
         FROM
-          RESERVE
-          INNER JOIN TX ON TX.ID = RESERVE.TX_ID
-          INNER JOIN BLOCK ON BLOCK.ID = TX.BLOCK_ID
-          INNER JOIN latest_withdrawal_epochs lwe ON lwe.addr_id = reserve.addr_id
+          reserve
+          INNER JOIN tx ON tx.id = reserve.tx_id
+          INNER JOIN block ON block.id = tx.block_id
+          INNER JOIN latest_withdrawal_epochs AS lwe ON lwe.addr_id = reserve.addr_id
         WHERE
-          RESERVE.ADDR_ID = ANY(sa_id_list)
-          AND BLOCK.EPOCH_NO >= lwe.epoch_no
+          reserve.addr_id = ANY(sa_id_list)
+          AND block.epoch_no >= lwe.epoch_no
         GROUP BY
-          RESERVE.ADDR_ID
-      ) RESERVES_T ON RESERVES_T.addr_id = status_t.id
+          reserve.addr_id
+      ) AS reserves_t ON reserves_t.addr_id = status_t.id
       LEFT JOIN (
         SELECT
-          TREASURY.ADDR_ID,
-          COALESCE(SUM(TREASURY.AMOUNT), 0) AS TREASURY
+          treasury.addr_id,
+          COALESCE(SUM(treasury.amount), 0) AS treasury
         FROM
-          TREASURY
-          INNER JOIN TX ON TX.ID = TREASURY.TX_ID
-          INNER JOIN BLOCK ON BLOCK.ID = TX.BLOCK_ID
-          INNER JOIN latest_withdrawal_epochs lwe ON lwe.addr_id = TREASURY.addr_id
+          treasury
+          INNER JOIN tx ON tx.id = treasury.tx_id
+          INNER JOIN block ON block.id = tx.block_id
+          INNER JOIN latest_withdrawal_epochs AS lwe ON lwe.addr_id = treasury.addr_id
         WHERE
-          TREASURY.ADDR_ID = ANY(sa_id_list)
-          AND BLOCK.EPOCH_NO >= lwe.epoch_no
+          treasury.addr_id = ANY(sa_id_list)
+          AND block.epoch_no >= lwe.epoch_no
         GROUP BY
-          TREASURY.ADDR_ID
-      ) TREASURY_T ON TREASURY_T.addr_id = status_t.id
+          treasury.addr_id
+      ) AS treasury_t ON treasury_t.addr_id = status_t.id
     WHERE sdc.stake_address = ANY(_stake_addresses);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.account_info IS 'Get the cached account information for given stake addresses';
+COMMENT ON FUNCTION grest.account_info IS 'Get the cached account information for given stake addresses'; -- noqa: LT01

--- a/files/grest/rpc/account/account_updates.sql
+++ b/files/grest/rpc/account/account_updates.sql
@@ -1,31 +1,31 @@
-CREATE FUNCTION grest.account_updates (_stake_addresses text[])
-  RETURNS TABLE (
-    stake_address varchar,
-    updates jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.account_updates(_stake_addresses text [])
+RETURNS TABLE (
+  stake_address varchar,
+  updates jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   sa_id_list integer[] DEFAULT NULL;
 BEGIN
   SELECT INTO sa_id_list
-    ARRAY_AGG(STAKE_ADDRESS.ID) 
+    ARRAY_AGG(stake_address.id) 
   FROM
-    STAKE_ADDRESS
+    stake_address
   WHERE
-    STAKE_ADDRESS.VIEW = ANY(_stake_addresses);
+    stake_address.VIEW = ANY(_stake_addresses);
 
   RETURN QUERY
     SELECT
-      SA.view as stake_address,
+      sa.view AS stake_address,
       JSONB_AGG(
         JSONB_BUILD_OBJECT(
-          'action_type', ACTIONS.action_type,
-          'tx_hash', ENCODE(TX.HASH, 'hex'),
+          'action_type', actions.action_type,
+          'tx_hash', ENCODE(tx.hash, 'hex'),
           'epoch_no', b.epoch_no,
           'epoch_slot', b.epoch_slot_no,
           'absolute_slot', b.slot_no,
-          'block_time', EXTRACT(epoch from b.time)::integer
+          'block_time', EXTRACT(EPOCH FROM b.time)::integer
         )
       )
     FROM (
@@ -35,45 +35,46 @@ BEGIN
           tx_id,
           addr_id
         FROM
-          STAKE_REGISTRATION
+          stake_registration
         WHERE
           addr_id = ANY(sa_id_list)
-      ) UNION (
+      )
+    UNION (
         SELECT
           'deregistration' AS action_type,
           tx_id,
           addr_id
         FROM
-          STAKE_DEREGISTRATION
+          stake_deregistration
         WHERE
           addr_id = ANY(sa_id_list)
-      ) UNION (
+      )
+    UNION (
         SELECT
           'delegation' AS action_type,
           tx_id,
           addr_id
         FROM
-          DELEGATION
+          delegation
         WHERE
           addr_id = ANY(sa_id_list)
-        ) UNION (
+      )
+    UNION (
         SELECT
           'withdrawal' AS action_type,
           tx_id,
           addr_id
         FROM
-          WITHDRAWAL
+          withdrawal
         WHERE
           addr_id = ANY(sa_id_list)
-        )
-    ) ACTIONS
-      INNER JOIN TX ON TX.ID = ACTIONS.TX_ID
-      INNER JOIN STAKE_ADDRESS sa ON sa.id = actions.addr_id
-      INNER JOIN BLOCK b ON b.id = tx.block_id
-    GROUP BY
-      sa.id;
+      )
+    ) AS actions
+      INNER JOIN tx ON tx.id = actions.tx_id
+      INNER JOIN stake_address AS sa ON sa.id = actions.addr_id
+      INNER JOIN block AS b ON b.id = tx.block_id
+    GROUP BY sa.id;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.account_updates IS 'Get updates (registration, deregistration, delegation and withdrawals) for given stake addresses';
-
+COMMENT ON FUNCTION grest.account_updates IS 'Get updates (registration, deregistration, delegation and withdrawals) for given stake addresses'; -- noqa: LT01

--- a/files/grest/rpc/account/account_utxos.sql
+++ b/files/grest/rpc/account/account_utxos.sql
@@ -1,36 +1,34 @@
-CREATE OR REPLACE FUNCTION grest.account_utxos (_stake_address text)
-  RETURNS TABLE (
-    tx_hash text,
-    tx_index smallint,
-    address varchar,
-    value text,
-    block_height word31type,
-    block_time integer
-  )
-  LANGUAGE PLPGSQL
-  AS $$
-
+CREATE OR REPLACE FUNCTION grest.account_utxos(_stake_address text)
+RETURNS TABLE (
+  tx_hash text,
+  tx_index smallint,
+  address varchar,
+  value text,
+  block_height word31type,
+  block_time integer
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   SELECT
-    ENCODE(tx.hash,'hex') as tx_hash,
-    tx_out.index::smallint as tx_index,
+    ENCODE(tx.hash,'hex') AS tx_hash,
+    tx_out.index::smallint AS tx_index,
     tx_out.address,
-    tx_out.value::text as value,
-    b.block_no as block_height,
-    EXTRACT(epoch from b.time)::integer as block_time
+    tx_out.value::text AS value,
+    b.block_no AS block_height,
+    EXTRACT(EPOCH FROM b.time)::integer AS block_time
   FROM
     tx_out
     LEFT JOIN tx_in ON tx_in.tx_out_id = tx_out.tx_id
       AND tx_in.tx_out_index = tx_out.index
     INNER JOIN tx ON tx.id = tx_out.tx_id
-    LEFT JOIN block b ON b.id = tx.block_id
+    LEFT JOIN block AS b ON b.id = tx.block_id
   WHERE
     tx_in.tx_out_id IS NULL
     AND
-    tx_out.stake_address_id = (select id from stake_address where view = _stake_address);
-
+    tx_out.stake_address_id = (SELECT id FROM stake_address WHERE view = _stake_address);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.account_utxos IS 'Get non-empty UTxOs associated with a given stake address';
+COMMENT ON FUNCTION grest.account_utxos IS 'Get non-empty UTxOs associated with a given stake address'; -- noqa: LT01

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -1,35 +1,33 @@
-CREATE OR REPLACE FUNCTION grest.address_info (_addresses text[])
-  RETURNS TABLE (
-    address varchar,
-    balance text,
-    stake_address character varying,
-    script_address boolean,
-    utxo_set jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.address_info(_addresses text [])
+RETURNS TABLE (
+  address varchar,
+  balance text,
+  stake_address character varying,
+  script_address boolean,
+  utxo_set jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   known_addresses varchar[];
 BEGIN
-
   CREATE TEMPORARY TABLE _known_addresses AS
     SELECT
       DISTINCT ON (tx_out.address) tx_out.address,
-      sa.view as stake_address,
-      COALESCE(tx_out.address_has_script, 'false') as script_address
+      sa.view AS stake_address,
+      COALESCE(tx_out.address_has_script, 'false') AS script_address
     FROM
       tx_out
-      LEFT JOIN stake_address SA on sa.id = tx_out.stake_address_id
+      LEFT JOIN stake_address sa ON sa.id = tx_out.stake_address_id
     WHERE
-      tx_out.address = ANY(_addresses)
-  ;
+      tx_out.address = ANY(_addresses);
 
   RETURN QUERY
     WITH _all_utxos AS (
       SELECT
         tx.id,
         tx.hash,
-        tx_out.id as txo_id,
+        tx_out.id AS txo_id,
         tx_out.address,
         tx_out.value,
         tx_out.index,
@@ -48,12 +46,13 @@ BEGIN
         tx_out.address = ANY(_addresses)
     )
 
-      SELECT
-        ka.address,
-        COALESCE(SUM(au.value), '0')::text AS balance,
-        ka.stake_address,
-        ka.script_address,
-        CASE WHEN EXISTS (
+    SELECT
+      ka.address,
+      COALESCE(SUM(au.value), '0')::text AS balance,
+      ka.stake_address,
+      ka.script_address,
+      CASE
+        WHEN EXISTS (
           SELECT TRUE FROM _all_utxos aus WHERE aus.address = ka.address
         ) THEN
           JSONB_AGG(
@@ -61,44 +60,50 @@ BEGIN
               'tx_hash', ENCODE(au.hash, 'hex'), 
               'tx_index', au.index,
               'block_height', block.block_no,
-              'block_time', EXTRACT(epoch from block.time)::integer,
+              'block_time', EXTRACT(EPOCH FROM block.time)::integer,
               'value', au.value::text,
               'datum_hash', ENCODE(au.data_hash, 'hex'),
-              'inline_datum', ( CASE WHEN au.inline_datum_id IS NULL THEN NULL
-                ELSE
-                  JSONB_BUILD_OBJECT(
-                    'bytes', ENCODE(datum.bytes, 'hex'),
-                    'value', datum.value
-                  )
+              'inline_datum',(
+                CASE
+                  WHEN au.inline_datum_id IS NULL THEN
+                    NULL
+                  ELSE
+                    JSONB_BUILD_OBJECT(
+                      'bytes', ENCODE(datum.bytes, 'hex'),
+                      'value', datum.value
+                    )
                 END
               ),
-              'reference_script', ( CASE WHEN au.reference_script_id IS NULL THEN NULL
-                ELSE
-                  JSONB_BUILD_OBJECT(
-                    'hash', ENCODE(script.hash, 'hex'),
-                    'bytes', ENCODE(script.bytes, 'hex'),
-                    'value', script.json,
-                    'type', script.type::text,
-                    'size', script.serialised_size
-                  )
+              'reference_script',(
+                CASE
+                  WHEN au.reference_script_id IS NULL THEN
+                    NULL
+                  ELSE
+                    JSONB_BUILD_OBJECT(
+                      'hash', ENCODE(script.hash, 'hex'),
+                      'bytes', ENCODE(script.bytes, 'hex'),
+                      'value', script.json,
+                      'type', script.type::text,
+                      'size', script.serialised_size
+                    )
                 END
               ),
               'asset_list', COALESCE(
                 (
                   SELECT
                     JSONB_AGG(JSONB_BUILD_OBJECT(
-                      'policy_id', ENCODE(MA.policy, 'hex'),
-                      'asset_name', ENCODE(MA.name, 'hex'),
-                      'fingerprint', MA.fingerprint,
+                      'policy_id', ENCODE(ma.policy, 'hex'),
+                      'asset_name', ENCODE(ma.name, 'hex'),
+                      'fingerprint', ma.fingerprint,
                       'decimals', COALESCE(aic.decimals, 0),
-                      'quantity', MTX.quantity::text
-                      ))
+                      'quantity', mtx.quantity::text
+                    ))
                   FROM
-                      ma_tx_out MTX
-                      INNER JOIN multi_asset MA ON MA.id = MTX.ident
-                      LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+                    ma_tx_out AS mtx
+                    INNER JOIN multi_asset AS ma ON ma.id = mtx.ident
+                    LEFT JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
                   WHERE
-                      MTX.tx_out_id = au.txo_id
+                    mtx.tx_out_id = au.txo_id
                 ),
                 JSONB_BUILD_ARRAY()
               )
@@ -106,18 +111,17 @@ BEGIN
           )
         ELSE
           '[]'::jsonb
-        END as utxo_set
+        END AS utxo_set
       FROM
-        _known_addresses ka
-        LEFT OUTER JOIN _all_utxos au ON au.address = ka.address
+        _known_addresses AS ka
+        LEFT OUTER JOIN _all_utxos AS au ON au.address = ka.address
         LEFT JOIN public.block ON block.id = au.block_id
         LEFT JOIN datum ON datum.id = au.inline_datum_id
         LEFT JOIN script ON script.id = au.reference_script_id
       GROUP BY
-        ka.address, ka.stake_address, ka.script_address
-      ;
+        ka.address, ka.stake_address, ka.script_address;
     DROP TABLE _known_addresses;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.address_info IS 'Get bulk address info - balance, associated stake address (if any) and UTXO set';
+COMMENT ON FUNCTION grest.address_info IS 'Get bulk address info - balance, associated stake address (if any) and UTXO set'; -- noqa: LT01

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,12 +1,12 @@
-CREATE OR REPLACE FUNCTION grest.address_txs (_addresses text[], _after_block_height integer DEFAULT 0)
-  RETURNS TABLE (
-    tx_hash text,
-    epoch_no word31type,
-    block_height word31type,
-    block_time integer
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.address_txs(_addresses text [], _after_block_height integer DEFAULT 0)
+RETURNS TABLE (
+  tx_hash text,
+  epoch_no word31type,
+  block_height word31type,
+  block_time integer
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _tx_id_min bigint;
   _tx_id_list bigint[];
@@ -24,7 +24,7 @@ BEGIN
     FROM
       tx_out
     WHERE
-      address = ANY (_addresses)
+      address = ANY(_addresses)
       AND tx_id >= _tx_id_min
     --
     UNION
@@ -37,26 +37,25 @@ BEGIN
         AND tx_out.index = tx_in.tx_out_index
     WHERE
       tx_in.tx_in_id IS NOT NULL
-      AND tx_out.address = ANY (_addresses)
+      AND tx_out.address = ANY(_addresses)
       AND tx_in.tx_in_id >= _tx_id_min
   ) AS tmp;
 
   RETURN QUERY
     SELECT
-      DISTINCT(ENCODE(tx.hash, 'hex')) as tx_hash,
+      DISTINCT(ENCODE(tx.hash, 'hex')) AS tx_hash,
       block.epoch_no,
       block.block_no,
-      EXTRACT(epoch from block.time)::integer
+      EXTRACT(EPOCH FROM block.time)::integer
     FROM
       public.tx
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
-      tx.id = ANY (_tx_id_list)
+      tx.id = ANY(_tx_id_list)
       AND block.block_no >= _after_block_height
     ORDER BY
       block.block_no DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.address_txs IS 'Get the transaction hash list of a Cardano address array, optionally filtering after specified block height (inclusive).';
-
+COMMENT ON FUNCTION grest.address_txs IS 'Get the transaction hash list of a Cardano address array, optionally filtering after specified block height (inclusive).'; -- noqa: LT01

--- a/files/grest/rpc/address/credential_txs.sql
+++ b/files/grest/rpc/address/credential_txs.sql
@@ -1,12 +1,12 @@
-CREATE OR REPLACE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_height integer DEFAULT 0)
-  RETURNS TABLE (
-    tx_hash text,
-    epoch_no word31type,
-    block_height word31type,
-    block_time integer
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.credential_txs(_payment_credentials text [], _after_block_height integer DEFAULT 0)
+RETURNS TABLE (
+  tx_hash text,
+  epoch_no word31type,
+  block_height word31type,
+  block_time integer
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _payment_cred_bytea  bytea[];
   _tx_id_min bigint;
@@ -15,8 +15,7 @@ BEGIN
   -- convert input _payment_credentials array into bytea array
   SELECT INTO _payment_cred_bytea ARRAY_AGG(cred_bytea)
   FROM (
-    SELECT
-      DECODE(cred_hex, 'hex') AS cred_bytea
+    SELECT DECODE(cred_hex, 'hex') AS cred_bytea
     FROM
       UNNEST(_payment_credentials) AS cred_hex
   ) AS tmp;
@@ -29,44 +28,41 @@ BEGIN
   -- all tx_out & tx_in tx ids
   SELECT INTO _tx_id_list ARRAY_AGG(tx_id)
   FROM (
-    SELECT
-      tx_id
+    SELECT tx_id
     FROM
       tx_out
     WHERE
-      payment_cred = ANY (_payment_cred_bytea)
+      payment_cred = ANY(_payment_cred_bytea)
       AND tx_id >= _tx_id_min
     --
     UNION
     --
-    SELECT
-      tx_in_id AS tx_id
+    SELECT tx_in_id AS tx_id
     FROM
       tx_out
       LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id
         AND tx_out.index = tx_in.tx_out_index
     WHERE
       tx_in.tx_in_id IS NOT NULL
-      AND tx_out.payment_cred = ANY (_payment_cred_bytea)
+      AND tx_out.payment_cred = ANY(_payment_cred_bytea)
       AND tx_in.tx_in_id >= _tx_id_min
   ) AS tmp;
 
   RETURN QUERY
     SELECT
-      DISTINCT(ENCODE(tx.hash, 'hex')) as tx_hash,
+      DISTINCT(ENCODE(tx.hash, 'hex')) AS tx_hash,
       block.epoch_no,
       block.block_no,
-      EXTRACT(epoch from block.time)::integer
+      EXTRACT(EPOCH FROM block.time)::integer
     FROM
       public.tx
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
-      tx.id = ANY (_tx_id_list)
+      tx.id = ANY(_tx_id_list)
       AND block.block_no >= _after_block_height
     ORDER BY
       block.block_no DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.address_txs IS 'Get the transaction hash list of a payment credentials array, optionally filtering after specified block height (inclusive).';
-
+COMMENT ON FUNCTION grest.address_txs IS 'Get the transaction hash list of a payment credentials array, optionally filtering after specified block height (inclusive).'; --noqa: LT01

--- a/files/grest/rpc/address/credential_utxos.sql
+++ b/files/grest/rpc/address/credential_utxos.sql
@@ -1,11 +1,11 @@
-CREATE OR REPLACE FUNCTION grest.credential_utxos (_payment_credentials text[])
-  RETURNS TABLE (
-    tx_hash text,
-    tx_index smallint,
-    value text
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.credential_utxos(_payment_credentials text [])
+RETURNS TABLE (
+  tx_hash text,
+  tx_index smallint,
+  value text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _payment_cred_bytea  bytea[];
 
@@ -20,7 +20,7 @@ BEGIN
 
   RETURN QUERY
     SELECT
-      ENCODE(tx.hash, 'hex')::text as tx_hash,
+      ENCODE(tx.hash, 'hex')::text AS tx_hash,
       tx_out.index::smallint,
       tx_out.value::text AS balance
     FROM tx_out
@@ -28,8 +28,7 @@ BEGIN
       LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id
         AND tx_out.index = tx_in.tx_out_index
     WHERE
-      payment_cred = any(_payment_cred_bytea)
-      AND
-        tx_in.tx_out_id IS NULL;
+      payment_cred = ANY(_payment_cred_bytea)
+      AND tx_in.tx_out_id IS NULL;
 END;
 $$;

--- a/files/grest/rpc/assets/asset_addresses.sql
+++ b/files/grest/rpc/assets/asset_addresses.sql
@@ -1,21 +1,23 @@
-CREATE OR REPLACE FUNCTION grest.asset_address_list (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    payment_address varchar,
-    quantity text
-  ) LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_address_list(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  payment_address varchar,
+  quantity text
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
     SELECT * FROM grest.asset_addresses(_asset_policy, _asset_name);
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION grest.asset_addresses (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    payment_address varchar,
-    quantity text
-  ) LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_addresses(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  payment_address varchar,
+  quantity text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
   _asset_name_decoded bytea;
@@ -30,8 +32,7 @@ BEGIN
     END,
     'hex'
   ) INTO _asset_name_decoded;
-  SELECT id INTO _asset_id FROM multi_asset ma WHERE ma.policy = _asset_policy_decoded AND ma.name = _asset_name_decoded;
-
+  SELECT id INTO _asset_id FROM multi_asset AS ma WHERE ma.policy = _asset_policy_decoded AND ma.name = _asset_name_decoded;
   RETURN QUERY
     SELECT
       x.address,
@@ -42,18 +43,18 @@ BEGIN
           txo.address,
           mto.quantity
         FROM
-          ma_tx_out mto
-          INNER JOIN tx_out txo ON txo.id = mto.tx_out_id
+          ma_tx_out AS mto
+          INNER JOIN tx_out AS txo ON txo.id = mto.tx_out_id
           LEFT JOIN tx_in ON txo.tx_id = tx_in.tx_out_id
             AND txo.index::smallint = tx_in.tx_out_index::smallint
         WHERE
           mto.ident = _asset_id
           AND tx_in.tx_out_id IS NULL
-      ) x
+      ) AS x
     GROUP BY
       x.address;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_address_list IS 'DEPRECATED!! Use asset_addresses instead.';
-COMMENT ON FUNCTION grest.asset_addresses IS 'Returns a list of addresses with quantity holding the specified asset';
+COMMENT ON FUNCTION grest.asset_address_list IS 'DEPRECATED!! Use asset_addresses instead.'; -- noqa: LT01
+COMMENT ON FUNCTION grest.asset_addresses IS 'Returns a list of addresses with quantity holding the specified asset'; -- noqa: LT01

--- a/files/grest/rpc/assets/asset_history.sql
+++ b/files/grest/rpc/assets/asset_history.sql
@@ -1,19 +1,17 @@
-CREATE OR REPLACE FUNCTION grest.asset_history (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    policy_id text,
-    asset_name text,
-    fingerprint character varying,
-    minting_txs jsonb[]
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_history(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  policy_id text,
+  asset_name text,
+  fingerprint character varying,
+  minting_txs jsonb []
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
   _asset_name_decoded bytea;
 BEGIN
-
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-
   SELECT DECODE(
     CASE WHEN _asset_name IS NULL
       THEN ''
@@ -22,7 +20,6 @@ BEGIN
     END,
     'hex'
   ) INTO _asset_name_decoded;
-
   RETURN QUERY
     SELECT
       _asset_policy,
@@ -42,36 +39,36 @@ BEGIN
         ma.fingerprint,
         tx.id,
         ENCODE(tx.hash, 'hex') AS tx_hash,
-        EXTRACT(epoch from b.time)::integer as block_time,
+        EXTRACT(EPOCH FROM b.time)::integer AS block_time,
         mtm.quantity::text,
-        ( CASE WHEN TM.key IS NULL THEN JSONB_BUILD_ARRAY()
+        ( CASE WHEN tm.key IS NULL THEN JSONB_BUILD_ARRAY()
           ELSE
             JSONB_AGG(
               JSONB_BUILD_OBJECT(
-                'key', TM.key::text,
-                'json', TM.json
+                'key', tm.key::text,
+                'json', tm.json
               )
             ) 
           END
         ) AS metadata
       FROM
-        ma_tx_mint mtm
-        INNER JOIN multi_asset ma ON ma.id = mtm.ident
+        ma_tx_mint AS mtm
+        INNER JOIN multi_asset AS ma ON ma.id = mtm.ident
         INNER JOIN tx ON tx.id = MTM.tx_id
-        INNER JOIN block b ON b.id = tx.block_id
-        LEFT JOIN tx_metadata TM ON TM.tx_id = tx.id
-      WHERE MA.policy = _asset_policy_decoded 
-        AND MA.name = _asset_name_decoded
+        INNER JOIN block AS b ON b.id = tx.block_id
+        LEFT JOIN tx_metadata AS tm ON tm.tx_id = tx.id
+      WHERE ma.policy = _asset_policy_decoded 
+        AND ma.name = _asset_name_decoded
       GROUP BY
         ma.fingerprint,
         tx.id,
         b.time,
         mtm.quantity,
-        TM.key
-    ) minting_data
+        tm.key
+    ) AS minting_data
     GROUP BY
       minting_data.fingerprint;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_history IS 'Get the mint/burn history of an asset';
+COMMENT ON FUNCTION grest.asset_history IS 'Get the mint/burn history of an asset'; -- noqa: LT01

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -1,35 +1,32 @@
-CREATE OR REPLACE FUNCTION grest.asset_info (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    policy_id text,
-    asset_name text,
-    asset_name_ascii text,
-    fingerprint character varying,
-    minting_tx_hash text,
-    total_supply text,
-    mint_cnt bigint,
-    burn_cnt bigint,
-    creation_time integer,
-    minting_tx_metadata jsonb,
-    token_registry_metadata jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_info(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  policy_id text,
+  asset_name text,
+  asset_name_ascii text,
+  fingerprint character varying,
+  minting_tx_hash text,
+  total_supply text,
+  mint_cnt bigint,
+  burn_cnt bigint,
+  creation_time integer,
+  minting_tx_metadata jsonb,
+  token_registry_metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_id_list      bigint[];
 BEGIN
-
-  -- find all asset id's based on nested array input
+  -- find all asset id's based ON nested array input
   SELECT INTO _asset_id_list ARRAY_AGG(id)
   FROM (
     SELECT DISTINCT mu.id
     FROM
-       multi_asset mu
+       multi_asset AS mu
     WHERE
       mu.policy = DECODE(_asset_policy, 'hex') AND mu.name = DECODE(_asset_name, 'hex')
   ) AS tmp;
-
   RETURN QUERY
-
     SELECT
       ENCODE(ma.policy, 'hex'),
       ENCODE(ma.name, 'hex'),
@@ -39,7 +36,7 @@ BEGIN
       aic.total_supply::text,
       aic.mint_cnt,
       aic.burn_cnt,
-      EXTRACT(epoch from aic.creation_time)::integer,
+      EXTRACT(EPOCH FROM aic.creation_time)::integer,
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
@@ -53,10 +50,10 @@ BEGIN
         )
       END
     FROM
-      multi_asset ma
-      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      multi_asset AS ma
+      INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
       INNER JOIN tx ON tx.id = aic.last_mint_tx_id
-      LEFT JOIN grest.asset_registry_cache arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
+      LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
       LEFT JOIN LATERAL (
         SELECT
           JSONB_OBJECT_AGG(
@@ -64,13 +61,12 @@ BEGIN
             json
           ) AS minting_tx_metadata
         FROM
-          tx_metadata tm
+          tx_metadata AS tm
         WHERE
           tm.tx_id = tx.id
       ) metadata ON TRUE
     WHERE
-      ma.id = any (_asset_id_list);
+      ma.id = ANY(_asset_id_list);
 
 END;
 $$;
-

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -1,24 +1,23 @@
-CREATE OR REPLACE FUNCTION grest.asset_info (_asset_list text[][])
-  RETURNS TABLE (
-    policy_id text,
-    asset_name text,
-    asset_name_ascii text,
-    fingerprint character varying,
-    minting_tx_hash text,
-    total_supply text,
-    mint_cnt bigint,
-    burn_cnt bigint,
-    creation_time integer,
-    minting_tx_metadata jsonb,
-    token_registry_metadata jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_info(_asset_list text [] [])
+RETURNS TABLE (
+  policy_id text,
+  asset_name text,
+  asset_name_ascii text,
+  fingerprint character varying,
+  minting_tx_hash text,
+  total_supply text,
+  mint_cnt bigint,
+  burn_cnt bigint,
+  creation_time integer,
+  minting_tx_metadata jsonb,
+  token_registry_metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
-  _asset_id_list      bigint[];
+  _asset_id_list bigint[];
 BEGIN
-
-  -- find all asset id's based on nested array input
+  -- find all asset id's based ON nested array input
   SELECT INTO _asset_id_list ARRAY_AGG(id)
   FROM (
     SELECT DISTINCT mu.id
@@ -27,13 +26,11 @@ BEGIN
         DECODE(asset_list->>0, 'hex') AS policy,
         DECODE(asset_list->>1, 'hex') AS name
       FROM
-      JSONB_ARRAY_ELEMENTS(TO_JSONB(_asset_list)) asset_list
-    ) ald
-    INNER JOIN multi_asset mu ON mu.policy = ald.policy AND mu.name = ald.name
+      JSONB_ARRAY_ELEMENTS(TO_JSONB(_asset_list)) AS asset_list
+    ) AS ald
+    INNER JOIN multi_asset AS mu ON mu.policy = ald.policy AND mu.name = ald.name
   ) AS tmp;
-
   RETURN QUERY
-
     SELECT
       ENCODE(ma.policy, 'hex'),
       ENCODE(ma.name, 'hex'),
@@ -43,7 +40,7 @@ BEGIN
       aic.total_supply::text,
       aic.mint_cnt,
       aic.burn_cnt,
-      EXTRACT(epoch from aic.creation_time)::integer,
+      EXTRACT(EPOCH FROM aic.creation_time)::integer,
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
@@ -57,10 +54,10 @@ BEGIN
         )
       END
     FROM
-      multi_asset ma
-      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      multi_asset AS ma
+      INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
       INNER JOIN tx ON tx.id = aic.last_mint_tx_id
-      LEFT JOIN grest.asset_registry_cache arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
+      LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
       LEFT JOIN LATERAL (
         SELECT
           JSONB_OBJECT_AGG(
@@ -68,12 +65,12 @@ BEGIN
             json
           ) AS minting_tx_metadata
         FROM
-          tx_metadata tm
+          tx_metadata AS tm
         WHERE
           tm.tx_id = tx.id
       ) metadata ON TRUE
     WHERE
-      ma.id = any (_asset_id_list);
+      ma.id = ANY(_asset_id_list);
 
 END;
 $$;

--- a/files/grest/rpc/assets/asset_nft_address.sql
+++ b/files/grest/rpc/assets/asset_nft_address.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE FUNCTION grest.asset_nft_address (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    payment_address varchar
-  ) LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_nft_address(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  payment_address varchar
+) LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
   _asset_name_decoded bytea;
@@ -20,21 +20,18 @@ BEGIN
 
   SELECT id INTO _asset_id 
   FROM 
-    multi_asset ma 
-    INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+    multi_asset AS ma 
+    INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
   WHERE
     ma.policy = _asset_policy_decoded 
     AND ma.name = _asset_name_decoded
     AND aic.total_supply = 1;
 
   RETURN QUERY
-    SELECT
-      address
-    FROM
-      tx_out
-    WHERE
-      id = (SELECT MAX(tx_out_id) FROM ma_tx_out WHERE ident = _asset_id);
+    SELECT address
+    FROM tx_out
+    WHERE id = (SELECT MAX(tx_out_id) FROM ma_tx_out WHERE ident = _asset_id);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_nft_address IS 'Returns the current address holding the specified NFT';
+COMMENT ON FUNCTION grest.asset_nft_address IS 'Returns the current address holding the specified NFT'; -- noqa: LT01

--- a/files/grest/rpc/assets/asset_summary.sql
+++ b/files/grest/rpc/assets/asset_summary.sql
@@ -1,14 +1,14 @@
-CREATE FUNCTION grest.asset_summary (_asset_policy text, _asset_name text default '')
-  RETURNS TABLE (
-    policy_id text,
-    asset_name text,
-    fingerprint character varying,
-    total_transactions bigint,
-    staked_wallets bigint,
-    unstaked_addresses bigint
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_summary(_asset_policy text, _asset_name text DEFAULT '')
+RETURNS TABLE (
+  policy_id text,
+  asset_name text,
+  fingerprint character varying,
+  total_transactions bigint,
+  staked_wallets bigint,
+  unstaked_addresses bigint
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
   _asset_name_decoded bytea;
@@ -23,59 +23,58 @@ BEGIN
     END,
     'hex'
   ) INTO _asset_name_decoded;
-  SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
-
-RETURN QUERY
-  with _asset_utxos as (
+  SELECT id INTO _asset_id FROM multi_asset AS ma WHERE ma.policy = _asset_policy_decoded AND ma.name = _asset_name_decoded;
+  RETURN QUERY
+    with _asset_utxos AS (
+      SELECT
+        txo.tx_id AS tx_id,
+        txo.id AS tx_out_id,
+        txo.index AS tx_out_idx,
+        txo.address AS address,
+        txo.stake_address_id AS sa_id
+      FROM
+        ma_tx_out AS mto
+        INNER JOIN tx_out AS txo ON txo.id = mto.tx_out_id
+        LEFT JOIN tx_in AS txi ON txi.tx_out_id = txo.tx_id
+      WHERE
+        mto.ident = _asset_id
+        AND
+        txi.tx_out_id IS NULL)
+  
     SELECT
-      TXO.tx_id AS tx_id,
-      TXO.id AS tx_out_id,
-      TXO.index AS tx_out_idx,
-      TXO.address AS address,
-      TXO.stake_address_id AS sa_id
-    FROM
-      ma_tx_out MTO
-      INNER JOIN tx_out TXO ON TXO.id = MTO.tx_out_id
-      LEFT JOIN tx_in TXI ON TXI.tx_out_id = TXO.tx_id
+      _asset_policy,
+      _asset_name,
+      ma.fingerprint,
+      (
+        SELECT
+          COUNT(DISTINCT(txo.tx_id))
+        FROM
+          ma_tx_out mto
+          INNER JOIN tx_out txo ON txo.id = mto.tx_out_id
+        WHERE
+          ident = _asset_id
+      ) AS total_transactions,
+      (
+        SELECT
+          COUNT(DISTINCT(_asset_utxos.sa_id))
+        FROM
+          _asset_utxos
+        WHERE
+          _asset_utxos.sa_id IS NOT NULL
+      ) AS staked_wallets,
+      (
+        SELECT
+          COUNT(DISTINCT(_asset_utxos.address))
+        FROM
+          _asset_utxos
+        WHERE
+          _asset_utxos.sa_id IS NULL
+      ) AS unstaked_addresses
+    FROM 
+      multi_asset AS ma
     WHERE
-      MTO.ident = _asset_id
-      AND
-      TXI.tx_out_id IS NULL)
-
-  SELECT
-    _asset_policy,
-    _asset_name,
-    MA.fingerprint,
-    (
-      SELECT
-        COUNT(DISTINCT(TXO.tx_id))
-      FROM
-        ma_tx_out MTO
-        INNER JOIN tx_out TXO ON TXO.id = MTO.tx_out_id
-      WHERE
-        ident = _asset_id
-    ) AS total_transactions,
-    (
-      SELECT
-        COUNT(DISTINCT(_asset_utxos.sa_id))
-      FROM
-        _asset_utxos
-      WHERE
-        _asset_utxos.sa_id IS NOT NULL
-    ) AS staked_wallets,
-    (
-      SELECT
-        COUNT(DISTINCT(_asset_utxos.address))
-      FROM
-        _asset_utxos
-      WHERE
-        _asset_utxos.sa_id IS NULL
-    ) AS unstaked_addresses
-  FROM 
-    multi_asset MA
-  WHERE
-    MA.id = _asset_id;
-END;
+      ma.id = _asset_id;
+  END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_summary IS 'Get the summary of an asset (total transactions exclude minting/total wallets include only wallets with asset balance)';
+COMMENT ON FUNCTION grest.asset_summary IS 'Get the summary of an asset (total transactions exclude minting/total wallets include only wallets with asset balance)'; -- noqa: LT01

--- a/files/grest/rpc/assets/policy_asset_addresses.sql
+++ b/files/grest/rpc/assets/policy_asset_addresses.sql
@@ -1,15 +1,15 @@
-CREATE OR REPLACE FUNCTION grest.policy_asset_addresses (_asset_policy text)
-  RETURNS TABLE (
-    asset_name text,
-    payment_address varchar,
-    quantity text
-  ) LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.policy_asset_addresses(_asset_policy text)
+RETURNS TABLE (
+  asset_name text,
+  payment_address varchar,
+  quantity text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-
   RETURN QUERY
     WITH
       _all_assets AS (
@@ -17,7 +17,7 @@ BEGIN
           id,
           ENCODE(name, 'hex') AS asset_name
         FROM
-          multi_asset ma
+          multi_asset AS ma
         WHERE ma.policy = _asset_policy_decoded
       )
 
@@ -32,17 +32,17 @@ BEGIN
           txo.address,
           mto.quantity
         FROM
-          _all_assets aa
-          INNER JOIN ma_tx_out mto ON mto.ident = aa.id
-          INNER JOIN tx_out txo ON txo.id = mto.tx_out_id
+          _all_assets AS aa
+          INNER JOIN ma_tx_out AS mto ON mto.ident = aa.id
+          INNER JOIN tx_out AS txo ON txo.id = mto.tx_out_id
           LEFT JOIN tx_in ON txo.tx_id = tx_in.tx_out_id
             AND txo.index::smallint = tx_in.tx_out_index::smallint
         WHERE
           tx_in.tx_out_id IS NULL
-      ) x
+      ) AS x
     GROUP BY
       x.asset_name, x.address;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.policy_asset_addresses IS 'Returns a list of addresses with quantity for each asset on a given policy';
+COMMENT ON FUNCTION grest.policy_asset_addresses IS 'Returns a list of addresses with quantity for each asset ON a given policy'; -- noqa: LT01

--- a/files/grest/rpc/assets/policy_asset_info.sql
+++ b/files/grest/rpc/assets/policy_asset_info.sql
@@ -1,45 +1,44 @@
-CREATE OR REPLACE FUNCTION grest.asset_policy_info (_asset_policy text)
-  RETURNS TABLE (
-    asset_name text,
-    asset_name_ascii text,
-    fingerprint varchar,
-    minting_tx_hash text,
-    total_supply text,
-    mint_cnt bigint,
-    burn_cnt bigint,
-    creation_time integer,
-    minting_tx_metadata jsonb,
-    token_registry_metadata jsonb
-  ) 
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.asset_policy_info(_asset_policy text)
+RETURNS TABLE (
+  asset_name text,
+  asset_name_ascii text,
+  fingerprint varchar,
+  minting_tx_hash text,
+  total_supply text,
+  mint_cnt bigint,
+  burn_cnt bigint,
+  creation_time integer,
+  minting_tx_metadata jsonb,
+  token_registry_metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
     SELECT * FROM grest.policy_asset_info(_asset_policy);
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION grest.policy_asset_info (_asset_policy text)
-  RETURNS TABLE (
-    asset_name text,
-    asset_name_ascii text,
-    fingerprint varchar,
-    minting_tx_hash text,
-    total_supply text,
-    mint_cnt bigint,
-    burn_cnt bigint,
-    creation_time integer,
-    minting_tx_metadata jsonb,
-    token_registry_metadata jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.policy_asset_info(_asset_policy text)
+RETURNS TABLE (
+  asset_name text,
+  asset_name_ascii text,
+  fingerprint varchar,
+  minting_tx_hash text,
+  total_supply text,
+  mint_cnt bigint,
+  burn_cnt bigint,
+  creation_time integer,
+  minting_tx_metadata jsonb,
+  token_registry_metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
   _policy_asset_ids bigint[];
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  
   RETURN QUERY 
     SELECT
       ENCODE(ma.name, 'hex') AS asset_name,
@@ -49,7 +48,7 @@ BEGIN
       aic.total_supply::text,
       aic.mint_cnt,
       aic.burn_cnt,
-      EXTRACT(epoch FROM aic.creation_time)::integer,
+      EXTRACT(EPOCH FROM aic.creation_time)::integer,
       metadata.minting_tx_metadata,
       CASE WHEN arc.name IS NULL THEN NULL
       ELSE
@@ -63,10 +62,10 @@ BEGIN
         )
       END
     FROM 
-      multi_asset ma
-      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      multi_asset AS ma
+      INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
       INNER JOIN tx ON tx.id = aic.last_mint_tx_id
-      LEFT JOIN grest.asset_registry_cache arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name, 'hex')
+      LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name, 'hex')
       LEFT JOIN LATERAL (
         SELECT
           JSONB_OBJECT_AGG(
@@ -74,7 +73,7 @@ BEGIN
             json
           ) AS minting_tx_metadata
         FROM
-          tx_metadata tm
+          tx_metadata AS tm
         WHERE
           tm.tx_id = tx.id
       ) metadata ON TRUE
@@ -83,5 +82,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_policy_info IS 'Get the asset information of all assets under a policy';
-
+COMMENT ON FUNCTION grest.asset_policy_info IS 'Get the asset information of all assets under a policy'; -- noqa: LT01

--- a/files/grest/rpc/assets/policy_asset_list.sql
+++ b/files/grest/rpc/assets/policy_asset_list.sql
@@ -1,32 +1,28 @@
-CREATE OR REPLACE FUNCTION grest.policy_asset_list (_asset_policy text)
-  RETURNS TABLE (
-    asset_name text,
-    fingerprint varchar,
-    total_supply text,
-    decimals integer
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.policy_asset_list(_asset_policy text)
+RETURNS TABLE (
+  asset_name text,
+  fingerprint varchar,
+  total_supply text,
+  decimals integer
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _asset_policy_decoded bytea;
 BEGIN
-
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-
   RETURN QUERY
-    
     SELECT
       ENCODE(ma.name, 'hex') AS asset_name,
       ma.fingerprint AS fingerprint,
       aic.total_supply::text,
       aic.decimals
     FROM 
-      multi_asset ma
-      INNER JOIN grest.asset_info_cache aic ON aic.asset_id = ma.id
+      multi_asset AS ma
+      INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
     WHERE
       ma.policy = _asset_policy_decoded;
-
 END;
 $$;
 
-COMMENT ON FUNCTION grest.asset_policy_info IS 'Get a list of all asset under a policy';
+COMMENT ON FUNCTION grest.asset_policy_info IS 'Get a list of all asset under a policy'; -- noqa: LT01

--- a/files/grest/rpc/blocks/block_info.sql
+++ b/files/grest/rpc/blocks/block_info.sql
@@ -1,39 +1,39 @@
-CREATE FUNCTION grest.block_info (_block_hashes text[])
-  RETURNS TABLE (
-    hash text,
-    epoch_no word31type,
-    abs_slot word63type,
-    epoch_slot word31type,
-    block_height word31type,
-    block_size word31type,
-    block_time integer,
-    tx_count bigint,
-    vrf_key varchar,
-    op_cert text,
-    op_cert_counter word63type,
-    pool varchar,
-    proto_major word31type,
-    proto_minor word31type,
-    total_output text,
-    total_fees text,
-    num_confirmations integer,
-    parent_hash text,
-    child_hash text
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.block_info(_block_hashes text [])
+RETURNS TABLE (
+  hash text,
+  epoch_no word31type,
+  abs_slot word63type,
+  epoch_slot word31type,
+  block_height word31type,
+  block_size word31type,
+  block_time integer,
+  tx_count bigint,
+  vrf_key varchar,
+  op_cert text,
+  op_cert_counter word63type,
+  pool varchar,
+  proto_major word31type,
+  proto_minor word31type,
+  total_output text,
+  total_fees text,
+  num_confirmations integer,
+  parent_hash text,
+  child_hash text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _block_hashes_bytea   bytea[];
   _block_id_list        bigint[];
   _curr_block_no        word31type;
 BEGIN
-  SELECT max(block_no) INTO _curr_block_no FROM block b;
+  SELECT MAX(block_no) INTO _curr_block_no
+  FROM block AS b;
 
   -- convert input _block_hashes array into bytea array
   SELECT INTO _block_hashes_bytea ARRAY_AGG(hashes_bytea)
   FROM (
-    SELECT
-      DECODE(hashes_hex, 'hex') AS hashes_bytea
+    SELECT DECODE(hashes_hex, 'hex') AS hashes_bytea
     FROM
       UNNEST(_block_hashes) AS hashes_hex
   ) AS tmp;
@@ -41,52 +41,44 @@ BEGIN
   -- all block ids
   SELECT INTO _block_id_list ARRAY_AGG(id)
   FROM (
-    SELECT
-      id
-    FROM 
-      block
-    WHERE block.hash = ANY (_block_hashes_bytea)
+    SELECT id
+    FROM block
+    WHERE block.hash = ANY(_block_hashes_bytea)
   ) AS tmp;
 
   RETURN QUERY
   SELECT
-    ENCODE(B.hash, 'hex') AS hash,
-    B.epoch_no AS epoch,
-    B.slot_no AS abs_slot,
-    B.epoch_slot_no AS epoch_slot,
-    B.block_no AS block_height,
-    B.size AS block_size,
-    EXTRACT(epoch from B.time)::integer AS block_time,
-    B.tx_count,
-    B.vrf_key,
-    ENCODE(B.op_cert::bytea, 'hex') as op_cert,
-    B.op_cert_counter,
-    PH.view AS pool,
-    B.proto_major,
-    B.proto_minor,
+    ENCODE(b.hash, 'hex') AS hash,
+    b.epoch_no AS epoch,
+    b.slot_no AS abs_slot,
+    b.epoch_slot_no AS epoch_slot,
+    b.block_no AS block_height,
+    b.size AS block_size,
+    EXTRACT(EPOCH FROM b.time)::integer AS block_time,
+    b.tx_count,
+    b.vrf_key,
+    ENCODE(b.op_cert::bytea, 'hex') AS op_cert,
+    b.op_cert_counter,
+    ph.view AS pool,
+    b.proto_major,
+    b.proto_minor,
     block_data.total_output::text,
     block_data.total_fees::text,
-    (_curr_block_no - B.block_no) AS num_confirmations,
+    (_curr_block_no - b.block_no) AS num_confirmations,
     (
-      SELECT
-        ENCODE(tB.hash::bytea, 'hex')
-      FROM
-        block tB
-      WHERE
-        id = b.previous_id
+      SELECT ENCODE(tb.hash::bytea, 'hex')
+      FROM block tb
+      WHERE id = b.previous_id
     ) AS parent_hash,
     (
-      SELECT
-        ENCODE(tB.hash::bytea, 'hex')
-      FROM
-        block tB
-      WHERE
-        previous_id = b.id
+      SELECT ENCODE(tb.hash::bytea, 'hex')
+      FROM block tb
+      WHERE previous_id = b.id
     ) AS child_hash
   FROM
-    block B
-    LEFT JOIN slot_leader SL ON SL.id = B.slot_leader_id
-    LEFT JOIN pool_hash PH ON PH.id = SL.pool_hash_id
+    block AS b
+    LEFT JOIN slot_leader AS sl ON sl.id = b.slot_leader_id
+    LEFT JOIN pool_hash AS ph ON ph.id = sl.pool_hash_id
     LEFT JOIN LATERAL (
       SELECT
         SUM(tx_data.total_output) AS total_output,
@@ -94,19 +86,16 @@ BEGIN
       FROM
         tx
         JOIN LATERAL (
-          SELECT
-            SUM(tx_out.value) AS total_output
-          FROM
-            tx_out
-          WHERE
-            tx_out.tx_id = tx.id
+          SELECT SUM(tx_out.value) AS total_output
+          FROM tx_out
+          WHERE tx_out.tx_id = tx.id
         ) tx_data ON TRUE
       WHERE
         tx.block_id = b.id
     ) block_data ON TRUE
   WHERE
-    B.id = ANY (_block_id_list);
+    b.id = ANY(_block_id_list);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.block_info IS 'Get detailed information about list of block hashes';
+COMMENT ON FUNCTION grest.block_info IS 'Get detailed information about list of block hashes'; --noqa: LT01

--- a/files/grest/rpc/epoch/epoch_block_protocols.sql
+++ b/files/grest/rpc/epoch/epoch_block_protocols.sql
@@ -1,11 +1,11 @@
-CREATE FUNCTION grest.epoch_block_protocols (_epoch_no numeric DEFAULT NULL)
-  RETURNS TABLE (
-    proto_major word31type,
-    proto_minor word31type,
-    blocks bigint
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.epoch_block_protocols(_epoch_no numeric DEFAULT NULL)
+RETURNS TABLE (
+  proto_major word31type,
+  proto_minor word31type,
+  blocks bigint
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   IF _epoch_no IS NOT NULL THEN
     RETURN QUERY
@@ -26,7 +26,7 @@ BEGIN
         b.proto_minor,
         count(b.*)
       FROM
-        block b
+        block AS b
       WHERE
         b.epoch_no = (SELECT MAX(no) FROM epoch)
       GROUP BY
@@ -35,4 +35,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.epoch_block_protocols IS 'Get the information about block protocol distribution in epoch';
+COMMENT ON FUNCTION grest.epoch_block_protocols IS 'Get the information about block protocol distribution in epoch'; -- noqa: LT01

--- a/files/grest/rpc/epoch/epoch_info.sql
+++ b/files/grest/rpc/epoch/epoch_info.sql
@@ -1,24 +1,24 @@
-CREATE OR REPLACE FUNCTION grest.epoch_info (_epoch_no numeric DEFAULT NULL, _include_next_epoch boolean DEFAULT false)
-  RETURNS TABLE (
-    epoch_no word31type,
-    out_sum text,
-    fees text,
-    tx_count word31type,
-    blk_count word31type,
-    start_time integer,
-    end_time integer,
-    first_block_time integer,
-    last_block_time integer,
-    active_stake text,
-    total_rewards text,
-    avg_blk_reward text
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.epoch_info(_epoch_no numeric DEFAULT NULL, _include_next_epoch boolean DEFAULT FALSE)
+RETURNS TABLE (
+  epoch_no word31type,
+  out_sum text,
+  fees text,
+  tx_count word31type,
+  blk_count word31type,
+  start_time integer,
+  end_time integer,
+  first_block_time integer,
+  last_block_time integer,
+  active_stake text,
+  total_rewards text,
+  avg_blk_reward text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
-  shelley_epoch_duration numeric := (select epochlength::numeric * slotlength::numeric as epochduration from grest.genesis);
-  shelley_ref_epoch numeric := (select (ep.epoch_no::numeric + 1) from epoch_param ep ORDER BY ep.epoch_no LIMIT 1);
-  shelley_ref_time numeric := (select ei.i_first_block_time from grest.epoch_info_cache ei where ei.epoch_no = shelley_ref_epoch);
+  shelley_epoch_duration numeric := (select epochlength::numeric * slotlength::numeric AS epochduration FROM grest.genesis);
+  shelley_ref_epoch numeric := (select (ep.epoch_no::numeric + 1) FROM epoch_param ep ORDER BY ep.epoch_no LIMIT 1);
+  shelley_ref_time numeric := (select ei.i_first_block_time FROM grest.epoch_info_cache ei where ei.epoch_no = shelley_ref_epoch);
 BEGIN
   RETURN QUERY
   SELECT
@@ -27,15 +27,17 @@ BEGIN
     ei.i_fees::text AS tx_fees_sum,
     ei.i_tx_count AS tx_count,
     ei.i_blk_count AS blk_count,
-    CASE WHEN ei.epoch_no < shelley_ref_epoch THEN
+    CASE
+      WHEN ei.epoch_no < shelley_ref_epoch THEN
         ei.i_first_block_time::integer
-    ELSE
+      ELSE
         (shelley_ref_time + (ei.epoch_no - shelley_ref_epoch) * shelley_epoch_duration)::integer
     END AS start_time,
-    CASE WHEN ei.epoch_no < shelley_ref_epoch THEN
-      (ei.i_first_block_time + shelley_epoch_duration)::integer
-    ELSE
-      (shelley_ref_time + ((ei.epoch_no + 1) - shelley_ref_epoch) * shelley_epoch_duration)::integer
+    CASE
+      WHEN ei.epoch_no < shelley_ref_epoch THEN
+        (ei.i_first_block_time + shelley_epoch_duration)::integer
+      ELSE
+        (shelley_ref_time + ((ei.epoch_no + 1) - shelley_ref_epoch) * shelley_epoch_duration)::integer
     END AS end_time,
     ei.i_first_block_time::integer AS first_block_time,
     ei.i_last_block_time::integer AS last_block_time,
@@ -43,8 +45,8 @@ BEGIN
     ei.i_total_rewards::text AS total_rewards,
     ei.i_avg_blk_reward::text AS avg_blk_reward
   FROM
-    grest.epoch_info_cache ei
-    LEFT JOIN grest.EPOCH_ACTIVE_STAKE_CACHE eas ON eas.epoch_no = ei.epoch_no
+    grest.epoch_info_cache AS ei
+    LEFT JOIN grest.epoch_active_stake_cache AS eas ON eas.epoch_no = ei.epoch_no
   WHERE
     CASE WHEN _epoch_no IS NULL THEN
       ei.epoch_no <= (SELECT MAX(epoch.no) FROM public.epoch)
@@ -56,4 +58,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.epoch_info IS 'Get the epoch information, all epochs if no epoch specified. If _include_next_epoch is set to true, also return active stake calculation for next epoch if available';
+COMMENT ON FUNCTION grest.epoch_info IS 'Get the epoch information, all epochs if no epoch specified. If _include_next_epoch is set to true, also return active stake calculation for next epoch if available'; -- noqa: LT01

--- a/files/grest/rpc/epoch/epoch_params.sql
+++ b/files/grest/rpc/epoch/epoch_params.sql
@@ -1,39 +1,40 @@
-CREATE FUNCTION grest.epoch_params (_epoch_no numeric DEFAULT NULL)
-  RETURNS TABLE (
-    epoch_no word31type,
-    min_fee_a word31type,
-    min_fee_b word31type,
-    max_block_size word31type,
-    max_tx_size word31type,
-    max_bh_size word31type,
-    key_deposit text,
-    pool_deposit text,
-    max_epoch word31type,
-    optimal_pool_count word31type,
-    influence double precision,
-    monetary_expand_rate double precision,
-    treasury_growth_rate double precision,
-    decentralisation double precision,
-    extra_entropy text,
-    protocol_major word31type,
-    protocol_minor word31type,
-    min_utxo_value text,
-    min_pool_cost text,
-    nonce text,
-    block_hash text,
-    cost_models character varying,
-    price_mem double precision,
-    price_step double precision,
-    max_tx_ex_mem word64type,
-    max_tx_ex_steps word64type,
-    max_block_ex_mem word64type,
-    max_block_ex_steps word64type,
-    max_val_size word64type,
-    collateral_percent word31type,
-    max_collateral_inputs word31type,
-    coins_per_utxo_size text)
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.epoch_params(_epoch_no numeric DEFAULT NULL)
+RETURNS TABLE (
+  epoch_no word31type,
+  min_fee_a word31type,
+  min_fee_b word31type,
+  max_block_size word31type,
+  max_tx_size word31type,
+  max_bh_size word31type,
+  key_deposit text,
+  pool_deposit text,
+  max_epoch word31type,
+  optimal_pool_count word31type,
+  influence double precision,
+  monetary_expand_rate double precision,
+  treasury_growth_rate double precision,
+  decentralisation double precision,
+  extra_entropy text,
+  protocol_major word31type,
+  protocol_minor word31type,
+  min_utxo_value text,
+  min_pool_cost text,
+  nonce text,
+  block_hash text,
+  cost_models character varying,
+  price_mem double precision,
+  price_step double precision,
+  max_tx_ex_mem word64type,
+  max_tx_ex_steps word64type,
+  max_block_ex_mem word64type,
+  max_block_ex_steps word64type,
+  max_val_size word64type,
+  collateral_percent word31type,
+  max_collateral_inputs word31type,
+  coins_per_utxo_size text
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   IF _epoch_no IS NULL THEN
     RETURN QUERY
@@ -71,7 +72,7 @@ BEGIN
       ei.p_max_collateral_inputs AS max_collateral_inputs,
       ei.p_coins_per_utxo_size::text AS coins_per_utxo_size
     FROM
-      grest.epoch_info_cache ei
+      grest.epoch_info_cache AS ei
     WHERE
       ei.epoch_no <= (SELECT MAX(epoch.no) FROM public.epoch)
     ORDER BY
@@ -112,12 +113,11 @@ BEGIN
       ei.p_max_collateral_inputs AS max_collateral_inputs,
       ei.p_coins_per_utxo_size::text AS coins_per_utxo_size
     FROM
-      grest.epoch_info_cache ei
+      grest.epoch_info_cache AS ei
     WHERE
       ei.epoch_no = _epoch_no;
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.epoch_params IS 'Get the epoch parameters, all epochs if no epoch specified';
-
+COMMENT ON FUNCTION grest.epoch_params IS 'Get the epoch parameters, all epochs if no epoch specified'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_blocks.sql
+++ b/files/grest/rpc/pool/pool_blocks.sql
@@ -1,36 +1,36 @@
-CREATE FUNCTION grest.pool_blocks (_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
-    RETURNS TABLE (
-        epoch_no word31type,
-        epoch_slot word31type,
-        abs_slot word63type,
-        block_height word31type,
-        block_hash text,
-        block_time integer
-    )
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION grest.pool_blocks(_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
+RETURNS TABLE (
+  epoch_no word31type,
+  epoch_slot word31type,
+  abs_slot word63type,
+  block_height word31type,
+  block_hash text,
+  block_time integer
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
-    RETURN query
-    SELECT
-        b.epoch_no,
-        b.epoch_slot_no as epoch_slot,
-        b.slot_no as abs_slot,
-        b.block_no as block_height,
-        encode(b.hash::bytea, 'hex'),
-        EXTRACT(epoch from b.time)::integer
-    FROM
-        public.block b
-    INNER JOIN
-        public.slot_leader AS sl ON b.slot_leader_id = sl.id
-    WHERE
-        sl.pool_hash_id = (SELECT pool_hash_id FROM grest.pool_info_cache WHERE pool_id_bech32 = _pool_bech32 ORDER BY tx_id DESC LIMIT 1)
-        AND
-        (
-            _epoch_no IS NULL
-            OR
-            b.epoch_no = _epoch_no
-        );
+  RETURN query
+  SELECT
+    b.epoch_no,
+    b.epoch_slot_no AS epoch_slot,
+    b.slot_no AS abs_slot,
+    b.block_no AS block_height,
+    encode(b.hash::bytea, 'hex'),
+    EXTRACT(EPOCH FROM b.time)::integer
+  FROM
+    public.block AS b
+  INNER JOIN
+    public.slot_leader AS sl ON b.slot_leader_id = sl.id
+  WHERE
+    sl.pool_hash_id = (SELECT pool_hash_id FROM grest.pool_info_cache WHERE pool_id_bech32 = _pool_bech32 ORDER BY tx_id DESC LIMIT 1)
+    AND
+    (
+      _epoch_no IS NULL
+      OR
+      b.epoch_no = _epoch_no
+    );
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_blocks IS 'Return information about blocks minted by a given pool in current epoch (or epoch nbr if provided)';
+COMMENT ON FUNCTION grest.pool_blocks IS 'Return information about blocks minted by a given pool in current epoch (or epoch nbr if provided)'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_delegators.sql
+++ b/files/grest/rpc/pool/pool_delegators.sql
@@ -1,13 +1,13 @@
-CREATE FUNCTION grest.pool_delegators (_pool_bech32 text)
-  RETURNS TABLE (
-    stake_address character varying,
-    amount text,
-    active_epoch_no bigint,
-    latest_delegation_tx_hash text
-  )
-  LANGUAGE plpgsql
-  AS $$
-  #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_delegators(_pool_bech32 text)
+RETURNS TABLE (
+  stake_address character varying,
+  amount text,
+  active_epoch_no bigint,
+  latest_delegation_tx_hash text
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 DECLARE
   _pool_id bigint;
 BEGIN
@@ -15,33 +15,31 @@ BEGIN
     WITH 
       _all_delegations AS (
         SELECT
-          SA.id AS stake_address_id,
-          SDC.stake_address,
+          sa.id AS stake_address_id,
+          sdc.stake_address,
           (
-            CASE WHEN SDC.total_balance >= 0
-              THEN SDC.total_balance
+            CASE WHEN sdc.total_balance >= 0
+              THEN sdc.total_balance
               ELSE 0
             END
           ) AS total_balance
-        FROM
-          grest.stake_distribution_cache AS SDC
-          INNER JOIN public.stake_address SA ON SA.view = SDC.stake_address
+        FROM grest.stake_distribution_cache AS sdc
+        INNER JOIN public.stake_address AS sa ON sa.view = sdc.stake_address
         WHERE
-          SDC.pool_id = _pool_bech32
+          sdc.pool_id = _pool_bech32
       )
 
-    SELECT DISTINCT ON (AD.stake_address)
-      AD.stake_address,
-      AD.total_balance::text,
-      D.active_epoch_no,
+    SELECT DISTINCT ON (ad.stake_address)
+      ad.stake_address,
+      ad.total_balance::text,
+      d.active_epoch_no,
       ENCODE(tx.hash, 'hex')
-    FROM
-      _all_delegations AS AD
-      INNER JOIN public.delegation D ON D.addr_id = AD.stake_address_id
-      INNER JOIN public.tx ON tx.id = D.tx_id
+    FROM _all_delegations AS ad
+    INNER JOIN public.delegation AS d ON d.addr_id = ad.stake_address_id
+    INNER JOIN public.tx ON tx.id = d.tx_id
     ORDER BY
-      AD.stake_address, D.tx_id DESC;
+      ad.stake_address, d.tx_id DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_delegators IS 'Return information about live delegators for a given pool.';
+COMMENT ON FUNCTION grest.pool_delegators IS 'Return information about live delegators for a given pool.'; --noqa: LT01

--- a/files/grest/rpc/pool/pool_delegators_history.sql
+++ b/files/grest/rpc/pool/pool_delegators_history.sql
@@ -1,47 +1,46 @@
-CREATE FUNCTION grest.pool_delegators_history (_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
-  RETURNS TABLE (
-    stake_address character varying,
-    amount text,
-    epoch_no word31type
-  )
-  LANGUAGE plpgsql
-  AS $$
-  #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_delegators_history(_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
+RETURNS TABLE (
+  stake_address character varying,
+  amount text,
+  epoch_no word31type
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 DECLARE
   _pool_id bigint;
 BEGIN
   SELECT id INTO _pool_id FROM pool_hash WHERE pool_hash.view = _pool_bech32;
-
   IF _epoch_no IS NULL THEN
     RETURN QUERY
       SELECT
-        SA.view,
-        ES.amount::text,
-        ES.epoch_no
+        sa.view,
+        es.amount::text,
+        es.epoch_no
       FROM
-        public.epoch_stake ES
-        INNER JOIN public.stake_address SA ON ES.addr_id = SA.id
+        public.epoch_stake AS es
+      INNER JOIN public.stake_address AS sa ON es.addr_id = sa.id
       WHERE
-        ES.pool_id = _pool_id
+        es.pool_id = _pool_id
       ORDER BY
-        ES.epoch_no DESC, ES.amount DESC;
+        es.epoch_no DESC, es.amount DESC;
   ELSE
     RETURN QUERY
       SELECT
-        SA.view,
-        ES.amount::text,
-        ES.epoch_no
+        sa.view,
+        es.amount::text,
+        es.epoch_no
       FROM
-        public.epoch_stake ES
-        INNER JOIN public.stake_address SA ON ES.addr_id = SA.id
+        public.epoch_stake AS es
+      INNER JOIN public.stake_address AS sa ON es.addr_id = sa.id
       WHERE
-        ES.pool_id = _pool_id
+        es.pool_id = _pool_id
         AND
-        ES.epoch_no = _epoch_no
+        es.epoch_no = _epoch_no
       ORDER BY
-        ES.amount DESC;
+        es.amount DESC;
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_delegators IS 'Return information about active delegators (incl. history) for a given pool and epoch number - current epoch if not provided.';
+COMMENT ON FUNCTION grest.pool_delegators IS 'Return information about active delegators (incl. history) for a given pool and epoch number - current epoch if not provided.'; --noqa: LT01

--- a/files/grest/rpc/pool/pool_history.sql
+++ b/files/grest/rpc/pool/pool_history.sql
@@ -1,36 +1,44 @@
-CREATE OR REPLACE FUNCTION grest.pool_history (_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
-  RETURNS TABLE (
-    epoch_no bigint,
-    active_stake text,
-    active_stake_pct numeric,
-    saturation_pct numeric,
-    block_cnt bigint,
-    delegator_cnt bigint,
-    margin double precision,
-    fixed_cost text,
-    pool_fees text,
-    deleg_rewards text,
-    member_rewards text,
-    epoch_ros numeric
-  )
-  LANGUAGE plpgsql
-  AS $$
-  #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_history(_pool_bech32 text, _epoch_no word31type DEFAULT NULL)
+RETURNS TABLE (
+  epoch_no bigint,
+  active_stake text,
+  active_stake_pct numeric,
+  saturation_pct numeric,
+  block_cnt bigint,
+  delegator_cnt bigint,
+  margin double precision,
+  fixed_cost text,
+  pool_fees text,
+  deleg_rewards text,
+  member_rewards text,
+  epoch_ros numeric
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 DECLARE
 
 BEGIN
-
   RETURN QUERY
-  SELECT    epoch_no, active_stake::text, active_stake_pct, saturation_pct, block_cnt,
-            delegator_cnt, pool_fee_variable as margin, coalesce(pool_fee_fixed, 0)::text as fixed_cost,
-            coalesce(pool_fees, 0)::text, coalesce(deleg_rewards, 0)::text, coalesce(member_rewards, 0)::text, coalesce(epoch_ros, 0)
-  FROM grest.pool_history_cache phc
+  SELECT
+    epoch_no,
+    active_stake::text,
+    active_stake_pct,
+    saturation_pct,
+    block_cnt,
+    delegator_cnt,
+    pool_fee_variable AS margin,
+    COALESCE(pool_fee_fixed, 0)::text AS fixed_cost,
+    COALESCE(pool_fees, 0)::text,
+    COALESCE(deleg_rewards, 0)::text,
+    COALESCE(member_rewards, 0)::text,
+    COALESCE(epoch_ros, 0)
+  FROM grest.pool_history_cache AS phc
   WHERE phc.pool_id = _pool_bech32 and 
-    (_epoch_no is null or 
+    (_epoch_no IS NULL OR 
         phc.epoch_no = _epoch_no)
    ORDER by phc.epoch_no desc;
-
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_history IS 'Pool block production and reward history for a given epoch (or all epochs if not specified)';
+COMMENT ON FUNCTION grest.pool_history IS 'Pool block production and reward history for a given epoch (or all epochs if not specified)'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -1,45 +1,43 @@
-CREATE FUNCTION grest.pool_info (_pool_bech32_ids text[])
-  RETURNS TABLE (
-    pool_id_bech32 character varying,
-    pool_id_hex text,
-    active_epoch_no bigint,
-    vrf_key_hash text,
-    margin double precision,
-    fixed_cost text,
-    pledge text,
-    reward_addr character varying,
-    owners character varying [],
-    relays jsonb [],
-    meta_url character varying,
-    meta_hash text,
-    meta_json jsonb,
-    pool_status text,
-    retiring_epoch word31type,
-    op_cert text,
-    op_cert_counter word63type,
-    active_stake text,
-    sigma numeric,
-    block_count numeric,
-    live_pledge text,
-    live_stake text,
-    live_delegators bigint,
-    live_saturation numeric
-  )
-  LANGUAGE plpgsql
-  AS $$
-  #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_info(_pool_bech32_ids text [])
+RETURNS TABLE (
+  pool_id_bech32 character varying,
+  pool_id_hex text,
+  active_epoch_no bigint,
+  vrf_key_hash text,
+  margin double precision,
+  fixed_cost text,
+  pledge text,
+  reward_addr character varying,
+  owners character varying [],
+  relays jsonb [],
+  meta_url character varying,
+  meta_hash text,
+  meta_json jsonb,
+  pool_status text,
+  retiring_epoch word31type,
+  op_cert text,
+  op_cert_counter word63type,
+  active_stake text,
+  sigma numeric,
+  block_count numeric,
+  live_pledge text,
+  live_stake text,
+  live_delegators bigint,
+  live_saturation numeric
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 DECLARE
   _epoch_no bigint;
   _saturation_limit bigint;
 BEGIN
   SELECT MAX(epoch.no) INTO _epoch_no FROM public.epoch;
-
   SELECT FLOOR(supply::bigint / (
       SELECT p_optimal_pool_count 
       FROM grest.epoch_info_cache
       WHERE epoch_no = _epoch_no
     ))::bigint INTO _saturation_limit FROM grest.totals(_epoch_no);
-
   RETURN QUERY
     WITH
       _all_pool_info AS (
@@ -82,8 +80,7 @@ BEGIN
       _all_pool_info AS api
     LEFT JOIN LATERAL (
       (
-        SELECT
-          pod.json
+        SELECT pod.json
         FROM
           public.pool_offline_data AS pod
         WHERE
@@ -93,8 +90,7 @@ BEGIN
       )
       UNION ALL
       (
-        SELECT
-          pod.json
+        SELECT pod.json
         FROM
           public.pool_offline_data AS pod
         WHERE
@@ -125,8 +121,7 @@ BEGIN
       LIMIT 1
     ) block_data ON TRUE
     LEFT JOIN LATERAL(
-      SELECT
-        amount::lovelace AS as_sum
+      SELECT amount::lovelace AS as_sum
       FROM
         grest.pool_active_stake_cache AS pasc
       WHERE 
@@ -135,8 +130,7 @@ BEGIN
         pasc.epoch_no = _epoch_no
     ) active_stake ON TRUE
     LEFT JOIN LATERAL(
-      SELECT
-        amount::lovelace AS es_sum
+      SELECT amount::lovelace AS es_sum
       FROM
         grest.epoch_active_stake_cache AS easc
       WHERE 
@@ -147,18 +141,18 @@ BEGIN
         CASE WHEN api.pool_status = 'retired'
           THEN NULL
         ELSE
-          SUM (
+          SUM(
             CASE WHEN total_balance >= 0
               THEN total_balance
               ELSE 0
             END
           )::lovelace
         END AS stake,
-        COUNT (stake_address) AS delegators,
+        COUNT(stake_address) AS delegators,
         CASE WHEN api.pool_status = 'retired'
           THEN NULL
         ELSE
-          SUM (CASE WHEN sdc.stake_address = ANY (api.owners) THEN total_balance ELSE 0 END)::lovelace
+          SUM(CASE WHEN sdc.stake_address = ANY(api.owners) THEN total_balance ELSE 0 END)::lovelace
         END AS pledge
       FROM
         grest.stake_distribution_cache AS sdc
@@ -168,4 +162,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_info IS 'Current pool status and details for a specified list of pool ids';
+COMMENT ON FUNCTION grest.pool_info IS 'Current pool status and details for a specified list of pool ids'; --noqa: LT01

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -1,12 +1,12 @@
-CREATE OR REPLACE FUNCTION grest.pool_list ()
-  RETURNS TABLE (
-    pool_id_bech32 character varying,
-    ticker character varying)
-  LANGUAGE plpgsql
-  AS $$
-  # variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_list()
+RETURNS TABLE (
+  pool_id_bech32 character varying,
+  ticker character varying
+)
+LANGUAGE plpgsql
+AS $$
+# variable_conflict use_column
 BEGIN
-
   RETURN QUERY (
     WITH
       -- Get last pool update for each pool
@@ -20,6 +20,7 @@ BEGIN
           pic.pool_id_bech32,
           pic.tx_id DESC
       ),
+
       _pool_meta AS (
         SELECT
           DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
@@ -41,8 +42,6 @@ BEGIN
       LEFT JOIN _pool_meta AS pm ON pl.pool_id_bech32 = pm.pool_id_bech32
     WHERE
       pool_status != 'retired'
-
   );
-
 END;
 $$;

--- a/files/grest/rpc/pool/pool_metadata.sql
+++ b/files/grest/rpc/pool/pool_metadata.sql
@@ -1,34 +1,34 @@
-CREATE FUNCTION grest.pool_metadata (_pool_bech32_ids text[] DEFAULT null)
-    RETURNS TABLE (
-        pool_id_bech32 character varying,
-        meta_url character varying,
-        meta_hash text,
-        meta_json jsonb 
-    )
-    LANGUAGE plpgsql
-    AS $$
-    #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_metadata(_pool_bech32_ids text [] DEFAULT null)
+RETURNS TABLE (
+  pool_id_bech32 character varying,
+  meta_url character varying,
+  meta_hash text,
+  meta_json jsonb
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 BEGIN
-    RETURN QUERY
-    SELECT
-        DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
-        pic.meta_url,
-        pic.meta_hash,
-        pod.json
-    FROM
-        grest.pool_info_cache AS pic
-    LEFT JOIN
-        public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
-    WHERE
-        pic.pool_status != 'retired'
-        AND
-        CASE
-            WHEN _pool_bech32_ids IS NULL THEN true
-            WHEN _pool_bech32_ids IS NOT NULL THEN pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
-        END
-    ORDER BY
-        pic.pool_id_bech32, pic.tx_id DESC;
+  RETURN QUERY
+  SELECT
+    DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
+    pic.meta_url,
+    pic.meta_hash,
+    pod.json
+  FROM
+    grest.pool_info_cache AS pic
+  LEFT JOIN
+    public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
+  WHERE
+    pic.pool_status != 'retired'
+    AND
+    CASE
+      WHEN _pool_bech32_ids IS NULL THEN TRUE
+      WHEN _pool_bech32_ids IS NOT NULL THEN pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
+    END
+  ORDER BY
+      pic.pool_id_bech32, pic.tx_id DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_metadata IS 'Metadata(on & off-chain) for all currently registered/retiring (not retired) pools';
+COMMENT ON FUNCTION grest.pool_metadata IS 'Metadata(on & off-chain) for all currently registered/retiring (not retired) pools'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_relays.sql
+++ b/files/grest/rpc/pool/pool_relays.sql
@@ -1,23 +1,23 @@
-CREATE FUNCTION grest.pool_relays ()
-    RETURNS TABLE (
-        pool_id_bech32 character varying,
-        relays jsonb []
-    )
-    LANGUAGE plpgsql
-    AS $$
-    #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_relays()
+RETURNS TABLE (
+  pool_id_bech32 character varying,
+  relays jsonb []
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 BEGIN
-    RETURN QUERY
-    SELECT
-        DISTINCT ON (pool_id_bech32) pool_id_bech32,
-        relays
-    FROM
-        grest.pool_info_cache
-    WHERE
-        pool_status != 'retired'
-    ORDER BY
-        pool_id_bech32, tx_id DESC;
+  RETURN QUERY
+  SELECT
+    DISTINCT ON (pool_id_bech32) pool_id_bech32,
+    relays
+  FROM
+    grest.pool_info_cache
+  WHERE
+    pool_status != 'retired'
+  ORDER BY
+    pool_id_bech32, tx_id DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_relays IS 'A list of registered relays for all currently registered/retiring (not retired) pools';
+COMMENT ON FUNCTION grest.pool_relays IS 'A list of registered relays for all currently registered/retiring (not retired) pools'; --noqa: LT01

--- a/files/grest/rpc/pool/pool_stake_snapshot.sql
+++ b/files/grest/rpc/pool/pool_stake_snapshot.sql
@@ -1,13 +1,13 @@
-CREATE FUNCTION grest.pool_stake_snapshot (_pool_bech32 text)
-  RETURNS TABLE (
-    snapshot text,
-    epoch_no bigint,
-    nonce text,
-    pool_stake text,
-    active_stake text
-  )
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION grest.pool_stake_snapshot(_pool_bech32 text)
+RETURNS TABLE (
+  snapshot text,
+  epoch_no bigint,
+  nonce text,
+  pool_stake text,
+  active_stake text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _epoch_no bigint;
   _mark     bigint;
@@ -31,9 +31,9 @@ BEGIN
     pasc.amount::text,
     easc.amount::text
   FROM
-    grest.pool_active_stake_cache pasc
-    INNER JOIN grest.epoch_active_stake_cache easc ON easc.epoch_no = pasc.epoch_no
-    LEFT JOIN grest.epoch_info_cache eic ON eic.epoch_no = pasc.epoch_no
+    grest.pool_active_stake_cache AS pasc
+    INNER JOIN grest.epoch_active_stake_cache AS easc ON easc.epoch_no = pasc.epoch_no
+    LEFT JOIN grest.epoch_info_cache AS eic ON eic.epoch_no = pasc.epoch_no
   WHERE
     pasc.pool_id = _pool_bech32
     AND pasc.epoch_no BETWEEN _go AND _mark
@@ -42,4 +42,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_stake_snapshot IS 'Returns Mark, Set and Go stake snapshots for the selected pool, useful for leaderlog calculation';
+COMMENT ON FUNCTION grest.pool_stake_snapshot IS 'Returns Mark, Set and Go stake snapshots for the selected pool, useful for leaderlog calculation'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_updates.sql
+++ b/files/grest/rpc/pool/pool_updates.sql
@@ -1,56 +1,56 @@
-CREATE FUNCTION grest.pool_updates (_pool_bech32 text DEFAULT NULL)
-    RETURNS TABLE (
-        tx_hash text,
-        block_time integer,
-        pool_id_bech32 character varying,
-        pool_id_hex text,
-        active_epoch_no bigint,
-        vrf_key_hash text,
-        margin double precision,
-        fixed_cost text,
-        pledge text,
-        reward_addr character varying,
-        owners character varying [],
-        relays jsonb [],
-        meta_url character varying,
-        meta_hash text,
-        meta_json jsonb,
-        pool_status text,
-        retiring_epoch word31type
-    )
-    LANGUAGE plpgsql
-    AS $$
-    #variable_conflict use_column
+CREATE OR REPLACE FUNCTION grest.pool_updates(_pool_bech32 text DEFAULT NULL)
+RETURNS TABLE (
+  tx_hash text,
+  block_time integer,
+  pool_id_bech32 character varying,
+  pool_id_hex text,
+  active_epoch_no bigint,
+  vrf_key_hash text,
+  margin double precision,
+  fixed_cost text,
+  pledge text,
+  reward_addr character varying,
+  owners character varying [],
+  relays jsonb [],
+  meta_url character varying,
+  meta_hash text,
+  meta_json jsonb,
+  pool_status text,
+  retiring_epoch word31type
+)
+LANGUAGE plpgsql
+AS $$
+#variable_conflict use_column
 BEGIN
-    RETURN QUERY
-    SELECT
-        tx_hash,
-        block_time::integer,
-        pool_id_bech32,
-        pool_id_hex,
-        active_epoch_no,
-        vrf_key_hash,
-        margin,
-        fixed_cost::text,
-        pledge::text,
-        reward_addr,
-        owners,
-        relays,
-        meta_url,
-        meta_hash,
-        pod.json,
-        pool_status,
-        retiring_epoch
-    FROM
-        grest.pool_info_cache pic
-        LEFT JOIN public.pool_offline_data pod ON pod.pmr_id = pic.meta_id
-    WHERE
-        _pool_bech32 IS NULL
-        OR
-        pool_id_bech32 = _pool_bech32
-    ORDER BY
-        tx_id DESC;
+  RETURN QUERY
+  SELECT
+    tx_hash,
+    block_time::integer,
+    pool_id_bech32,
+    pool_id_hex,
+    active_epoch_no,
+    vrf_key_hash,
+    margin,
+    fixed_cost::text,
+    pledge::text,
+    reward_addr,
+    owners,
+    relays,
+    meta_url,
+    meta_hash,
+    pod.json,
+    pool_status,
+    retiring_epoch
+  FROM
+    grest.pool_info_cache AS pic
+    LEFT JOIN public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
+  WHERE
+    _pool_bech32 IS NULL
+    OR
+    pool_id_bech32 = _pool_bech32
+  ORDER BY
+    tx_id DESC;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.pool_updates IS 'Return all pool_updates for all pools or only updates for specific pool if specified';
+COMMENT ON FUNCTION grest.pool_updates IS 'Return all pool_updates for all pools or only updates for specific pool if specified'; -- noqa: LT01

--- a/files/grest/rpc/script/datum_info.sql
+++ b/files/grest/rpc/script/datum_info.sql
@@ -1,28 +1,26 @@
-CREATE FUNCTION grest.datum_info (_datum_hashes text[])
-  RETURNS TABLE (
-    hash text,
-    value jsonb,
-    bytes text
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.datum_info(_datum_hashes text [])
+RETURNS TABLE (
+  hash text,
+  value jsonb,
+  bytes text
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _datum_hashes_decoded bytea[];
 BEGIN
-  SELECT INTO _datum_hashes_decoded
-    ARRAY_AGG(DECODE(d_hash, 'hex'))
+  SELECT INTO _datum_hashes_decoded ARRAY_AGG(DECODE(d_hash, 'hex'))
   FROM UNNEST(_datum_hashes) AS d_hash;
-
   RETURN QUERY
     SELECT
       ENCODE(d.hash, 'hex'),
       d.value,
       ENCODE(d.bytes, 'hex')
     FROM 
-      datum d
+      datum AS d
     WHERE
       d.hash = ANY(_datum_hashes_decoded);
 END;
 $$;
 
-COMMENT ON FUNCTION grest.datum_info IS 'Get information about a given data from hashes.';
+COMMENT ON FUNCTION grest.datum_info IS 'Get information about a given data FROM hashes.'; -- noqa: LT01

--- a/files/grest/rpc/script/native_script_list.sql
+++ b/files/grest/rpc/script/native_script_list.sql
@@ -1,16 +1,16 @@
-CREATE FUNCTION grest.native_script_list ()
-  RETURNS TABLE (
-    script_hash text,
-    creation_tx_hash text,
-    type scripttype,
-    script jsonb
-  )
-LANGUAGE PLPGSQL AS
-$$
+CREATE OR REPLACE FUNCTION grest.native_script_list()
+RETURNS TABLE (
+  script_hash text,
+  creation_tx_hash text,
+  type scripttype,
+  script jsonb
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   SELECT
-    ENCODE(script.hash, 'hex'), 
+    ENCODE(script.hash, 'hex'),
     ENCODE(tx.hash, 'hex'),
     script.type,
     script.json
@@ -20,4 +20,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.native_script_list IS 'Get a list of all native(multisig/timelock) script hashes with creation tx hash, type and script in json format.';
+COMMENT ON FUNCTION grest.native_script_list IS 'Get a list of all native(multisig/timelock) script hashes with creation tx hash, type and script in json format.'; --noqa: LT01

--- a/files/grest/rpc/script/plutus_script_list.sql
+++ b/files/grest/rpc/script/plutus_script_list.sql
@@ -1,19 +1,19 @@
-CREATE FUNCTION grest.plutus_script_list ()
-  RETURNS TABLE (
-    script_hash text,
-    creation_tx_hash text
-  )
-LANGUAGE PLPGSQL AS
-$$
+CREATE OR REPLACE FUNCTION grest.plutus_script_list()
+RETURNS TABLE (
+  script_hash text,
+  creation_tx_hash text
+)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   SELECT
-    ENCODE(script.hash, 'hex') as script_hash, 
-    ENCODE(tx.hash, 'hex') as creation_tx_hash
+    ENCODE(script.hash, 'hex') AS script_hash,
+    ENCODE(tx.hash, 'hex') AS creation_tx_hash
   FROM script
     INNER JOIN tx ON tx.id = script.tx_id
   WHERE script.type IN ('plutusV1', 'plutusV2');
 END;
 $$;
 
-COMMENT ON FUNCTION grest.plutus_script_list IS 'Get a list of all plutus script hashes with creation tx hash.';
+COMMENT ON FUNCTION grest.plutus_script_list IS 'Get a list of all plutus script hashes with creation tx hash.'; --noqa: LT01

--- a/files/grest/rpc/script/script_redeemers.sql
+++ b/files/grest/rpc/script/script_redeemers.sql
@@ -1,42 +1,35 @@
-CREATE FUNCTION grest.script_redeemers (_script_hash text) 
-  RETURNS TABLE (
-    script_hash text,
-    redeemers jsonb
-  ) 
-LANGUAGE PLPGSQL AS
-$$
+CREATE OR REPLACE FUNCTION grest.script_redeemers(_script_hash text)
+RETURNS TABLE (
+  script_hash text,
+  redeemers jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE _script_hash_bytea bytea;
 BEGIN
-SELECT INTO _script_hash_bytea DECODE(_script_hash, 'hex');
-RETURN QUERY
-select _script_hash,
+  SELECT INTO _script_hash_bytea DECODE(_script_hash, 'hex');
+  RETURN QUERY
+  SELECT
+    _script_hash,
     JSONB_AGG(
-        JSONB_BUILD_OBJECT(
-            'tx_hash',
-            ENCODE(tx.hash, 'hex'),
-            'tx_index',
-            redeemer.index,
-            'unit_mem',
-            redeemer.unit_mem,
-            'unit_steps',
-            redeemer.unit_steps,
-            'fee',
-            redeemer.fee::text,
-            'purpose',
-            redeemer.purpose,
-            'datum_hash',
-            ENCODE(rd.hash, 'hex'),
-            'datum_value',
-            rd.value
-            -- extra bytes field available in rd. table here
-        )
-    ) as redeemers
-FROM redeemer
-    INNER JOIN TX ON tx.id = redeemer.tx_id
-    INNER JOIN REDEEMER_DATA rd on rd.id = redeemer.redeemer_data_id
-WHERE redeemer.script_hash = _script_hash_bytea
-GROUP BY redeemer.script_hash;
+      JSONB_BUILD_OBJECT(
+        'tx_hash', ENCODE(tx.hash, 'hex'),
+        'tx_index', redeemer.index,
+        'unit_mem', redeemer.unit_mem,
+        'unit_steps', redeemer.unit_steps,
+        'fee', redeemer.fee::text,
+        'purpose', redeemer.purpose,
+        'datum_hash', ENCODE(rd.hash, 'hex'),
+        'datum_value', rd.value
+        -- extra bytes field available in rd. table here
+      )
+    ) AS redeemers
+  FROM redeemer
+  INNER JOIN TX ON tx.id = redeemer.tx_id
+  INNER JOIN REDEEMER_DATA rd ON rd.id = redeemer.redeemer_data_id
+  WHERE redeemer.script_hash = _script_hash_bytea
+  GROUP BY redeemer.script_hash;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.script_redeemers IS 'Get all redeemers for a given script hash.';
+COMMENT ON FUNCTION grest.script_redeemers IS 'Get all redeemers for a given script hash.'; --noqa: LT01

--- a/files/grest/rpc/transactions/tx_metalabels.sql
+++ b/files/grest/rpc/transactions/tx_metalabels.sql
@@ -1,21 +1,26 @@
 DROP FUNCTION IF EXISTS grest.tx_metalabels;
-
-CREATE FUNCTION grest.tx_metalabels()
-  RETURNS TABLE (key text)
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.tx_metalabels()
+RETURNS TABLE (key text)
+LANGUAGE plpgsql
+AS $$
 BEGIN
   RETURN QUERY
   WITH RECURSIVE t AS (
-    (SELECT tm.key FROM public.tx_metadata tm ORDER BY key LIMIT 1)
+    (SELECT tm.key
+      FROM public.tx_metadata tm
+      ORDER BY key LIMIT 1)
     UNION ALL
-    SELECT (SELECT tm.key FROM tx_metadata tm WHERE tm.key > t.key ORDER BY key LIMIT 1)
+    SELECT (
+      SELECT tm.key
+      FROM tx_metadata tm
+      WHERE tm.key > t.key
+      ORDER BY key LIMIT 1)
     FROM t
       WHERE t.key IS NOT NULL
   )
+
   SELECT t.key::text FROM t WHERE t.key IS NOT NULL;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.tx_metalabels IS 'Get a list of all transaction metalabels';
-
+COMMENT ON FUNCTION grest.tx_metalabels IS 'Get a list of all transaction metalabels'; -- noqa: LT01

--- a/files/grest/rpc/transactions/tx_status.sql
+++ b/files/grest/rpc/transactions/tx_status.sql
@@ -1,26 +1,27 @@
-CREATE FUNCTION grest.tx_status (_tx_hashes text[])
-    RETURNS TABLE (
-        tx_hash text,
-        num_confirmations integer)
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION grest.tx_status(_tx_hashes text [])
+RETURNS TABLE (
+  tx_hash text,
+  num_confirmations integer
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
     _curr_block_no word31type;
 BEGIN
+  SELECT
+    max(block_no) INTO _curr_block_no
+  FROM
+    block b;
+  RETURN QUERY (
     SELECT
-        max(block_no) INTO _curr_block_no
-    FROM
-        block b;
-
-    RETURN QUERY (
-    	select HASHES, (_curr_block_no - b.block_no)
-    	from UNNEST(_tx_hashes) WITH ORDINALITY HASHES
-    	left outer join tx t on t.hash = DECODE(HASHES, 'hex')
-    	left outer join block b on t.block_id = b.id
-    	ORDER BY ordinality
-    	);
+      HASHES,
+      (_curr_block_no - b.block_no)
+    FROM UNNEST(_tx_hashes) WITH ORDINALITY HASHES
+    LEFT OUTER JOIN tx AS t ON t.hash = DECODE(HASHES, 'hex')
+    LEFT OUTER JOIN block AS b ON t.block_id = b.id
+    ORDER BY ordinality
+    );
 END;
 $$;
 
-COMMENT ON FUNCTION grest.tx_status IS 'Returns number of blocks that were created since the block containing a transactions with a given hash';
-
+COMMENT ON FUNCTION grest.tx_status IS 'Returns number of blocks that were created since the block containing a transactions with a given hash'; -- noqa: LT01

--- a/files/grest/rpc/transactions/tx_utxos.sql
+++ b/files/grest/rpc/transactions/tx_utxos.sql
@@ -1,11 +1,11 @@
-CREATE OR REPLACE FUNCTION grest.tx_utxos (_tx_hashes text[])
-  RETURNS TABLE (
-    tx_hash text,
-    inputs jsonb,
-    outputs jsonb
-  )
-  LANGUAGE PLPGSQL
-  AS $$
+CREATE OR REPLACE FUNCTION grest.tx_utxos(_tx_hashes text [])
+RETURNS TABLE (
+  tx_hash text,
+  inputs jsonb,
+  outputs jsonb
+)
+LANGUAGE plpgsql
+AS $$
 DECLARE
   _tx_hashes_bytea  bytea[];
   _tx_id_list       bigint[];
@@ -13,25 +13,20 @@ BEGIN
   -- convert input _tx_hashes array into bytea array
   SELECT INTO _tx_hashes_bytea ARRAY_AGG(hashes_bytea)
   FROM (
-    SELECT
-      DECODE(hashes_hex, 'hex') AS hashes_bytea
-    FROM
-      UNNEST(_tx_hashes) AS hashes_hex
+    SELECT DECODE(hashes_hex, 'hex') AS hashes_bytea
+    FROM UNNEST(_tx_hashes) AS hashes_hex
   ) AS tmp;
 
   -- all tx ids
   SELECT INTO _tx_id_list ARRAY_AGG(id)
   FROM (
-    SELECT
-      id
-    FROM 
-      tx
-    WHERE tx.hash = ANY (_tx_hashes_bytea)
+    SELECT id
+    FROM tx
+    WHERE tx.hash = ANY(_tx_hashes_bytea)
   ) AS tmp;
 
   RETURN QUERY (
     WITH
-
       -- tx id / hash mapping
       _all_tx AS (
         SELECT
@@ -39,7 +34,7 @@ BEGIN
           tx.hash AS tx_hash
         FROM
           tx
-        WHERE tx.id = ANY (_tx_id_list)
+        WHERE tx.id = ANY(_tx_id_list)
       ),
 
       _all_inputs AS (
@@ -47,18 +42,18 @@ BEGIN
           tx_in.tx_in_id                      AS tx_id,
           tx_out.address                      AS payment_addr_bech32,
           ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
-          SA.view                             AS stake_addr,
+          sa.view                             AS stake_addr,
           ENCODE(tx.hash, 'hex')              AS tx_hash,
           tx_out.index                        AS tx_index,
           tx_out.value::text                  AS value,
-          ( CASE WHEN MA.policy IS NULL THEN NULL
+          ( CASE WHEN ma.policy IS NULL THEN NULL
             ELSE
               JSONB_BUILD_OBJECT(
-                'policy_id', ENCODE(MA.policy, 'hex'),
-                'asset_name', ENCODE(MA.name, 'hex'),
-                'fingerprint', MA.fingerprint,
+                'policy_id', ENCODE(ma.policy, 'hex'),
+                'asset_name', ENCODE(ma.name, 'hex'),
+                'fingerprint', ma.fingerprint,
                 'decimals', aic.decimals,
-                'quantity', MTO.quantity::text
+                'quantity', mto.quantity::text
               )
             END
           )                                   AS asset_list
@@ -66,13 +61,13 @@ BEGIN
           tx_in
           INNER JOIN tx_out ON tx_out.tx_id = tx_in.tx_out_id
             AND tx_out.index = tx_in.tx_out_index
-          INNER JOIN tx on tx_out.tx_id = tx.id
-          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
-          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
-          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
-          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+          INNER JOIN tx ON tx_out.tx_id = tx.id
+          LEFT JOIN stake_address AS sa ON tx_out.stake_address_id = sa.id
+          LEFT JOIN ma_tx_out AS mto ON mto.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset AS ma ON ma.id = mto.ident
+          LEFT JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
         WHERE 
-          tx_in.tx_in_id = ANY (_tx_id_list)
+          tx_in.tx_in_id = ANY(_tx_id_list)
       ),
 
       _all_outputs AS (
@@ -80,34 +75,34 @@ BEGIN
           tx_out.tx_id,
           tx_out.address                      AS payment_addr_bech32,
           ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
-          SA.view                             AS stake_addr,
+          sa.view                             AS stake_addr,
           ENCODE(tx.hash, 'hex')              AS tx_hash,
           tx_out.index                        AS tx_index,
           tx_out.value::text                  AS value,
-          ( CASE WHEN MA.policy IS NULL THEN NULL
+          ( CASE WHEN ma.policy IS NULL THEN NULL
             ELSE
               JSONB_BUILD_OBJECT(
-                'policy_id', ENCODE(MA.policy, 'hex'),
-                'asset_name', ENCODE(MA.name, 'hex'),
-                'fingerprint', MA.fingerprint,
+                'policy_id', ENCODE(ma.policy, 'hex'),
+                'asset_name', ENCODE(ma.name, 'hex'),
+                'fingerprint', ma.fingerprint,
                 'decimals', aic.decimals,
-                'quantity', MTO.quantity::text
+                'quantity', mto.quantity::text
               )
             END
           )                                   AS asset_list
         FROM
           tx_out
           INNER JOIN tx ON tx_out.tx_id = tx.id
-          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
-          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
-          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
-          LEFT JOIN grest.asset_info_cache aic ON aic.asset_id = MA.id
+          LEFT JOIN stake_address AS sa ON tx_out.stake_address_id = sa.id
+          LEFT JOIN ma_tx_out AS mto ON mto.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset AS ma ON ma.id = mto.ident
+          LEFT JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
         WHERE 
-          tx_out.tx_id = ANY (_tx_id_list)
+          tx_out.tx_id = ANY(_tx_id_list)
       )
 
     SELECT
-      ENCODE(ATX.tx_hash, 'hex'),      
+      ENCODE(atx.tx_hash, 'hex'),      
       COALESCE((
         SELECT JSONB_AGG(tx_inputs)
         FROM (
@@ -118,14 +113,14 @@ BEGIN
                 'cred', payment_addr_cred
               ),
               'stake_addr', stake_addr,
-              'tx_hash', AI.tx_hash,
+              'tx_hash', ai.tx_hash,
               'tx_index', tx_index,
               'value', value,
               'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
             ) AS tx_inputs
-          FROM _all_inputs AI
-          WHERE AI.tx_id = ATX.tx_id
-          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AI.tx_hash, tx_index, value
+          FROM _all_inputs AS ai
+          WHERE ai.tx_id = atx.tx_id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ai.tx_hash, tx_index, value
         ) AS tmp
       ), JSONB_BUILD_ARRAY()),
       COALESCE((
@@ -138,23 +133,22 @@ BEGIN
                 'cred', payment_addr_cred
               ),
               'stake_addr', stake_addr,
-              'tx_hash', AO.tx_hash,
+              'tx_hash', ao.tx_hash,
               'tx_index', tx_index,
               'value', value,
               'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
             ) AS tx_outputs
-          FROM _all_outputs AO
-          WHERE AO.tx_id = ATX.tx_id
-          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AO.tx_hash, tx_index, value
+          FROM _all_outputs AS ao
+          WHERE ao.tx_id = atx.tx_id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ao.tx_hash, tx_index, value
         ) AS tmp
       ), JSONB_BUILD_ARRAY())
     FROM
-      _all_tx ATX
-    WHERE ATX.tx_hash = ANY (_tx_hashes_bytea)
+      _all_tx AS atx
+    WHERE atx.tx_hash = ANY(_tx_hashes_bytea)
 );
 
 END;
 $$;
 
-COMMENT ON FUNCTION grest.tx_utxos IS 'Get UTXO set (inputs/outputs) of transactions.';
-
+COMMENT ON FUNCTION grest.tx_utxos IS 'Get UTXO set (inputs/outputs) of transactions.'; -- noqa: LT01

--- a/files/grest/rpc/views/account_list.sql
+++ b/files/grest/rpc/views/account_list.sql
@@ -1,10 +1,8 @@
 DROP VIEW IF EXISTS grest.account_list;
 
 CREATE VIEW grest.account_list AS
-    SELECT
-        STAKE_ADDRESS.VIEW AS ID
-    FROM
-        STAKE_ADDRESS;
+SELECT stake_address.view AS id
+FROM
+  stake_address;
 
 COMMENT ON VIEW grest.account_list IS 'Get a list of all accounts';
-

--- a/files/grest/rpc/views/asset_list.sql
+++ b/files/grest/rpc/views/asset_list.sql
@@ -1,12 +1,12 @@
 DROP VIEW IF EXISTS grest.asset_list;
 
 CREATE VIEW grest.asset_list AS
-  SELECT
-      ENCODE(MA.policy, 'hex') AS policy_id,
-      ENCODE(MA.name, 'hex') AS asset_name,
-      MA.fingerprint
-  FROM 
-    public.multi_asset MA
-  ORDER BY MA.policy, MA.name;
+SELECT
+  ENCODE(ma.policy, 'hex') AS policy_id,
+  ENCODE(ma.name, 'hex') AS asset_name,
+  ma.fingerprint
+FROM
+  public.multi_asset AS ma
+ORDER BY ma.policy, ma.name;
 
 COMMENT ON VIEW grest.asset_list IS 'Get the list of all native assets';

--- a/files/grest/rpc/views/asset_token_registry.sql
+++ b/files/grest/rpc/views/asset_token_registry.sql
@@ -1,17 +1,16 @@
 DROP VIEW IF EXISTS grest.asset_token_registry;
 
 CREATE VIEW grest.asset_token_registry AS
-  SELECT
-    asset_policy AS policy_id,
-    asset_name,
-    name AS asset_name_ascii,
-    ticker,
-    description,
-    url,
-    decimals,
-    logo
-  FROM
-    grest.asset_registry_cache
-;
+SELECT
+  asset_policy AS policy_id,
+  asset_name,
+  name AS asset_name_ascii,
+  ticker,
+  description,
+  url,
+  decimals,
+  logo
+FROM
+  grest.asset_registry_cache;
 
 COMMENT ON VIEW grest.asset_token_registry IS 'Get a list of assets registered via token registry on github';

--- a/files/grest/rpc/views/blocks.sql
+++ b/files/grest/rpc/views/blocks.sql
@@ -1,25 +1,25 @@
 DROP VIEW IF EXISTS grest.blocks;
 
 CREATE VIEW grest.blocks AS
-  SELECT
-    ENCODE(B.HASH::bytea, 'hex') AS HASH,
-    b.EPOCH_NO AS EPOCH_NO,
-    b.SLOT_NO AS ABS_SLOT,
-    b.EPOCH_SLOT_NO AS EPOCH_SLOT,
-    b.BLOCK_NO AS BLOCK_HEIGHT,
-    b.SIZE AS BLOCK_SIZE,
-    EXTRACT(epoch from b.TIME)::integer AS BLOCK_TIME,
-    b.TX_COUNT,
-    b.VRF_KEY,
-    ph.VIEW AS POOL,
-    b.PROTO_MAJOR,
-    b.PROTO_MINOR,
-    b.OP_CERT_COUNTER
-  FROM
-    BLOCK B
-    LEFT JOIN SLOT_LEADER SL ON SL.ID = B.SLOT_LEADER_ID
-    LEFT JOIN POOL_HASH PH ON PH.ID = SL.POOL_HASH_ID
-  ORDER BY
-    B.ID DESC;
+SELECT
+  ENCODE(b.hash::bytea, 'hex') AS hash,
+  b.epoch_no AS epoch_no,
+  b.slot_no AS abs_slot,
+  b.epoch_slot_no AS epoch_slot,
+  b.block_no AS block_height,
+  b.size AS block_size,
+  EXTRACT(EPOCH FROM b.time)::integer AS block_time,
+  b.tx_count,
+  b.vrf_key,
+  ph.view AS pool,
+  b.proto_major,
+  b.proto_minor,
+  b.op_cert_counter
+FROM
+  block AS b
+LEFT JOIN slot_leader AS sl ON sl.id = b.slot_leader_id
+LEFT JOIN pool_hash AS ph ON ph.id = sl.pool_hash_id
+ORDER BY
+  b.id DESC;
 
 COMMENT ON VIEW grest.blocks IS 'Get detailed information about all blocks (paginated - latest first)';

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -137,26 +137,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
-
-    # FAQ
-
-    ### Is there a price attached to using services?
-    For most of the queries, there are no charges. But there are DDoS protection and strict timeout rules (see API Usage) that may prevent heavy consumers from using this *remotely* (for which, there should be an interaction to ensure the usage is proportional to sizing and traffic expected).
-
-    ### Who are the folks behind Koios?
-    It will be increasing list of community builders. But for initial think-tank and efforts, the work done is primarily by [guild-operators](https://cardano-community.github.io/guild-operators)
-    who are a well-recognised team of members behind Cardano tools like CNTools, gLiveView, topologyUpdater, etc. We also run a parallel a short (60-min) epoch blockchain, viz, guild used by many
-    for experiments.
-
-    ### I am only interested in collaborating on queries, where can I find the code and how to collaborate?
-    All the Postgres codebase against db-sync instance is available on [koios-artifacts](https://github.com/cardano-community/koios-artifacts/tree/main/files/grest/rpc) repo on github. Feel free to raise an issue/PR to discuss anything related to those queries.
-
-    ### I am not sure how to set up an instance. Is there an easy start guide?
-    Yes, there is a setup script (expect you to read carefully the help section) and instructions [here](https://cardano-community.github.io/guild-operators/Build/grest/). Should you need any assistance, feel free to hop in to the [discussion group](https://t.me/CardanoKoios).
-
-    ### Too much reading, I want to discuss in person
-    There are bi-weekly calls held that anyone is free to join - or you can drop in to the [telegram group](https://t.me/CardanoKoios) and start a discussion from there.
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/community.html)
 
   x-logo:
     url: "https://api.koios.rest/images/koios.png"

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -137,26 +137,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
-
-    # FAQ
-
-    ### Is there a price attached to using services?
-    For most of the queries, there are no charges. But there are DDoS protection and strict timeout rules (see API Usage) that may prevent heavy consumers from using this *remotely* (for which, there should be an interaction to ensure the usage is proportional to sizing and traffic expected).
-
-    ### Who are the folks behind Koios?
-    It will be increasing list of community builders. But for initial think-tank and efforts, the work done is primarily by [guild-operators](https://cardano-community.github.io/guild-operators)
-    who are a well-recognised team of members behind Cardano tools like CNTools, gLiveView, topologyUpdater, etc. We also run a parallel a short (60-min) epoch blockchain, viz, guild used by many
-    for experiments.
-
-    ### I am only interested in collaborating on queries, where can I find the code and how to collaborate?
-    All the Postgres codebase against db-sync instance is available on [koios-artifacts](https://github.com/cardano-community/koios-artifacts/tree/main/files/grest/rpc) repo on github. Feel free to raise an issue/PR to discuss anything related to those queries.
-
-    ### I am not sure how to set up an instance. Is there an easy start guide?
-    Yes, there is a setup script (expect you to read carefully the help section) and instructions [here](https://cardano-community.github.io/guild-operators/Build/grest/). Should you need any assistance, feel free to hop in to the [discussion group](https://t.me/CardanoKoios).
-
-    ### Too much reading, I want to discuss in person
-    There are bi-weekly calls held that anyone is free to join - or you can drop in to the [telegram group](https://t.me/CardanoKoios) and start a discussion from there.
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/community.html)
 
   x-logo:
     url: "https://api.koios.rest/images/koios.png"

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -137,26 +137,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
-
-    # FAQ
-
-    ### Is there a price attached to using services?
-    For most of the queries, there are no charges. But there are DDoS protection and strict timeout rules (see API Usage) that may prevent heavy consumers from using this *remotely* (for which, there should be an interaction to ensure the usage is proportional to sizing and traffic expected).
-
-    ### Who are the folks behind Koios?
-    It will be increasing list of community builders. But for initial think-tank and efforts, the work done is primarily by [guild-operators](https://cardano-community.github.io/guild-operators)
-    who are a well-recognised team of members behind Cardano tools like CNTools, gLiveView, topologyUpdater, etc. We also run a parallel a short (60-min) epoch blockchain, viz, guild used by many
-    for experiments.
-
-    ### I am only interested in collaborating on queries, where can I find the code and how to collaborate?
-    All the Postgres codebase against db-sync instance is available on [koios-artifacts](https://github.com/cardano-community/koios-artifacts/tree/main/files/grest/rpc) repo on github. Feel free to raise an issue/PR to discuss anything related to those queries.
-
-    ### I am not sure how to set up an instance. Is there an easy start guide?
-    Yes, there is a setup script (expect you to read carefully the help section) and instructions [here](https://cardano-community.github.io/guild-operators/Build/grest/). Should you need any assistance, feel free to hop in to the [discussion group](https://t.me/CardanoKoios).
-
-    ### Too much reading, I want to discuss in person
-    There are bi-weekly calls held that anyone is free to join - or you can drop in to the [telegram group](https://t.me/CardanoKoios) and start a discussion from there.
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/community.html)
 
   x-logo:
     url: "https://api.koios.rest/images/koios.png"

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -137,26 +137,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
-
-    # FAQ
-
-    ### Is there a price attached to using services?
-    For most of the queries, there are no charges. But there are DDoS protection and strict timeout rules (see API Usage) that may prevent heavy consumers from using this *remotely* (for which, there should be an interaction to ensure the usage is proportional to sizing and traffic expected).
-
-    ### Who are the folks behind Koios?
-    It will be increasing list of community builders. But for initial think-tank and efforts, the work done is primarily by [guild-operators](https://cardano-community.github.io/guild-operators)
-    who are a well-recognised team of members behind Cardano tools like CNTools, gLiveView, topologyUpdater, etc. We also run a parallel a short (60-min) epoch blockchain, viz, guild used by many
-    for experiments.
-
-    ### I am only interested in collaborating on queries, where can I find the code and how to collaborate?
-    All the Postgres codebase against db-sync instance is available on [koios-artifacts](https://github.com/cardano-community/koios-artifacts/tree/main/files/grest/rpc) repo on github. Feel free to raise an issue/PR to discuss anything related to those queries.
-
-    ### I am not sure how to set up an instance. Is there an easy start guide?
-    Yes, there is a setup script (expect you to read carefully the help section) and instructions [here](https://cardano-community.github.io/guild-operators/Build/grest/). Should you need any assistance, feel free to hop in to the [discussion group](https://t.me/CardanoKoios).
-
-    ### Too much reading, I want to discuss in person
-    There are bi-weekly calls held that anyone is free to join - or you can drop in to the [telegram group](https://t.me/CardanoKoios) and start a discussion from there.
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/community.html)
 
   x-logo:
     url: "https://api.koios.rest/images/koios.png"

--- a/specs/templates/1-api-info.yaml
+++ b/specs/templates/1-api-info.yaml
@@ -136,26 +136,7 @@ info:
 
     # Community projects
 
-    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/api-calls-tools-and-libraries)
-
-    # FAQ
-
-    ### Is there a price attached to using services?
-    For most of the queries, there are no charges. But there are DDoS protection and strict timeout rules (see API Usage) that may prevent heavy consumers from using this *remotely* (for which, there should be an interaction to ensure the usage is proportional to sizing and traffic expected).
-
-    ### Who are the folks behind Koios?
-    It will be increasing list of community builders. But for initial think-tank and efforts, the work done is primarily by [guild-operators](https://cardano-community.github.io/guild-operators)
-    who are a well-recognised team of members behind Cardano tools like CNTools, gLiveView, topologyUpdater, etc. We also run a parallel a short (60-min) epoch blockchain, viz, guild used by many
-    for experiments.
-
-    ### I am only interested in collaborating on queries, where can I find the code and how to collaborate?
-    All the Postgres codebase against db-sync instance is available on [koios-artifacts](https://github.com/cardano-community/koios-artifacts/tree/main/files/grest/rpc) repo on github. Feel free to raise an issue/PR to discuss anything related to those queries.
-
-    ### I am not sure how to set up an instance. Is there an easy start guide?
-    Yes, there is a setup script (expect you to read carefully the help section) and instructions [here](https://cardano-community.github.io/guild-operators/Build/grest/). Should you need any assistance, feel free to hop in to the [discussion group](https://t.me/CardanoKoios).
-
-    ### Too much reading, I want to discuss in person
-    There are bi-weekly calls held that anyone is free to join - or you can drop in to the [telegram group](https://t.me/CardanoKoios) and start a discussion from there.
+    A big thank you to the following projects who are already starting to use Koios from early days. A list of tools, libraries and projects utilising Koios (atleast those who'd like to be named) can be found [here](https://www.koios.rest/community.html)
 
   x-logo:
     url: "https://api.koios.rest/images/koios.png"


### PR DESCRIPTION
  ## Description
  <!--- Describe your changes -->
  1. Fix Asset Info Cache (include mint/burn tx rather than sum for meta consideration)
  2. Update SQLs as per SQLFluff linting guidelines:
  - [x] 00_blockchain
  - [x] 01_cached_tables
  - [x] 02_indexes
  - [x] account
  - [x] address
  - [x] assets
  - [x] blocks
  - [x] epoch
  - [x] pool
  - [x] script
  - [x] transactions
  - [x] views
  3. Fix `_last_active_stake_validated_epoch` in active_stake_cache (#222)
  4. Typo for `pool_history_cache.sql` as well as add a check to ensure epoch_info_cache has run at least once prior to pool_history_cache (#223)
  5. Move control_table entry in cache tables to the end (instead of start).
  
  ## Where should the reviewer start?
  <!--- Describe where reviewer should start testing -->
  Not really sure, too big to drill down 🙁 , we shouldnt have added any functional changes as part of linting. I expect us to cover review as part of tests itself
  
  ## Motivation and context
  <!--- Why is this change required? What problem does it solve? -->
  Across months, different folks added SQL updates using different patterns, making it difficult to align/scan/automate linting
  
  ## How has this been tested?
  <!--- Describe how you tested changes -->
  Was tested on guildnet as per below:
  - [x] Run `./setup-grest.sh -r -b lint`
  - [x] Wait for cache to be re-populated
  - [x] Run schemathesis tests