### PR TITLE
Add CIP-68 utility functions to be used by asset functions

### DIFF
--- a/files/grest/rpc/03_utilities/cip67.sql
+++ b/files/grest/rpc/03_utilities/cip67.sql
@@ -1,9 +1,9 @@
-CREATE OR REPLACE FUNCTION grest.cip68_label(_asset_name text)
+CREATE OR REPLACE FUNCTION grest.cip67_label(_asset_name text)
 RETURNS smallint
 LANGUAGE plpgsql STABLE
 AS $$
 BEGIN
-  -- CIP-68 supported labels
+  -- CIP-67 supported labels
   -- 100 = 000643b0 (ref, metadata)
   -- 222 = 000de140 (NFT)
   -- 333 = 0014df10 (FT)
@@ -26,12 +26,12 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION grest.cip68_strip_label(_asset_name text)
+CREATE OR REPLACE FUNCTION grest.cip67_strip_label(_asset_name text)
 RETURNS text
 LANGUAGE plpgsql STABLE
 AS $$
 BEGIN
-  IF (grest.cip68_label(_asset_name) != 0) THEN
+  IF (grest.cip67_label(_asset_name) != 0) THEN
     RETURN SUBSTRING(_asset_name FROM 9);
   ELSE
     RETURN _asset_name;
@@ -39,6 +39,6 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION grest.cip68_label IS 'Returns CIP-67 label for asset name or 0 if not a valid CIP-68 token'; -- noqa: LT01
-COMMENT ON FUNCTION grest.cip68_strip_label IS 'Strips prefix from asset name matching CIP-68 standard'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip67_label IS 'Returns CIP-67 label for asset name or 0 if not a valid CIP-68 token'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip67_strip_label IS 'Strips prefix from asset name matching CIP-67 standard'; -- noqa: LT01
 

--- a/files/grest/rpc/03_utilities/cip68.sql
+++ b/files/grest/rpc/03_utilities/cip68.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION grest.cip68_label(_asset_name text)
+RETURNS smallint
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  -- CIP-68 supported labels
+  -- 100 = 000643b0 (ref, metadata)
+  -- 222 = 000de140 (NFT)
+  -- 333 = 0014df10 (FT)
+  -- 444 = 001bc280 (RFT, rich-ft)
+  -- 500 = 001f4d70 (NFT, royalty)
+
+  IF (_asset_name like '000643b0%') THEN
+    RETURN 100;
+  ELSIF (_asset_name like '000de140%') THEN
+    RETURN 222;
+  ELSIF (_asset_name like '0014df10%') THEN
+    RETURN 333;
+  ELSIF (_asset_name like '001bc280%') THEN
+    RETURN 444;
+  ELSIF (_asset_name like '001f4d70%') THEN
+    RETURN 500;
+  ELSE
+    RETURN 0;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION grest.cip68_strip_label(_asset_name text)
+RETURNS text
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  IF (grest.cip68_label(_asset_name) != 0) THEN
+    RETURN SUBSTRING(_asset_name FROM 9);
+  ELSE
+    RETURN _asset_name;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.cip68_label IS 'Returns CIP-67 label for asset name or 0 if not a valid CIP-68 token'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip68_strip_label IS 'Strips prefix from asset name matching CIP-68 standard'; -- noqa: LT01
+

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -34,7 +34,7 @@ BEGIN
     SELECT
       ENCODE(ma.policy, 'hex'),
       ENCODE(ma.name, 'hex'),
-      ENCODE(grest.cip68_strip_label(ENCODE(ma.name, 'hex')), 'escape'),
+      ENCODE(grest.cip67_strip_label(ENCODE(ma.name, 'hex')), 'escape'),
       ma.fingerprint,
       ENCODE(tx.hash, 'hex'),
       aic.total_supply::text,
@@ -74,7 +74,7 @@ BEGIN
             WHEN datum.value IS NULL THEN NULL
           ELSE
             JSONB_BUILD_OBJECT(
-              grest.cip68_label(ENCODE(ma.name, 'hex')),
+              grest.cip67_label(ENCODE(ma.name, 'hex')),
               datum.value
             )
           END AS metadata
@@ -88,7 +88,7 @@ BEGIN
               AND _ma.name = (
                 SELECT
                   CASE
-                    WHEN grest.cip68_label(ENCODE(ma.name, 'hex')) != 0
+                    WHEN grest.cip67_label(ENCODE(ma.name, 'hex')) != 0
                     THEN CONCAT('\x000643b0', SUBSTRING(ENCODE(ma.name, 'hex'), 9))::bytea
                   ELSE null
                   END

--- a/files/grest/rpc/assets/policy_asset_info.sql
+++ b/files/grest/rpc/assets/policy_asset_info.sql
@@ -38,7 +38,7 @@ BEGIN
   RETURN QUERY
     SELECT
       ENCODE(ma.name, 'hex'),
-      ENCODE(grest.cip68_strip_label(ENCODE(ma.name, 'hex')), 'escape'),
+      ENCODE(grest.cip67_strip_label(ENCODE(ma.name, 'hex')), 'escape'),
       ma.fingerprint,
       ENCODE(tx.hash, 'hex'),
       aic.total_supply::text,

--- a/files/grest/rpc/assets/policy_asset_info.sql
+++ b/files/grest/rpc/assets/policy_asset_info.sql
@@ -37,8 +37,8 @@ AS $$
 BEGIN
   RETURN QUERY
     SELECT
-      ENCODE(ma.name, 'hex') AS asset_name,
-      ENCODE(ma.name, 'escape') AS asset_name_ascii,
+      ENCODE(ma.name, 'hex'),
+      ENCODE(grest.cip68_strip_label(ENCODE(ma.name, 'hex')), 'escape'),
       ma.fingerprint,
       ENCODE(tx.hash, 'hex'),
       aic.total_supply::text,


### PR DESCRIPTION
ASCII output now strips CIP-68 label from the hex string before trying to convert the name to ASCII.

Needs additional tests to verify result correctness. 

Closes #253 