### PR TITLE
Patch for tx_info and block_tx_info (collateral_tx_out)

### DIFF
--- a/files/grest/rpc/blocks/block_tx_info.sql
+++ b/files/grest/rpc/blocks/block_tx_info.sql
@@ -260,17 +260,6 @@ BEGIN
           tx_out.index                        AS tx_index,
           tx_out.value::text                  AS value,
           ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
-          (CASE WHEN ma.policy IS NULL THEN NULL
-            ELSE
-              JSONB_BUILD_OBJECT(
-                'policy_id', ENCODE(ma.policy, 'hex'),
-                'asset_name', ENCODE(ma.name, 'hex'),
-                'fingerprint', ma.fingerprint,
-                'decimals', aic.decimals,
-                'quantity', mto.quantity::text
-              )
-            END
-          ) AS asset_list,
           (CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
             ELSE
               JSONB_BUILD_OBJECT(
@@ -289,14 +278,12 @@ BEGIN
                 'size', script.serialised_size
               )
             END
-          ) AS reference_script
+          ) AS reference_script,
+          REPLACE(multi_assets_descr,'fromList ','') AS asset_descr
         FROM
           collateral_tx_out AS tx_out
           INNER JOIN tx ON tx_out.tx_id = tx.id
           LEFT JOIN stake_address AS sa ON tx_out.stake_address_id = sa.id
-          LEFT JOIN ma_tx_out AS mto ON _assets IS TRUE AND mto.tx_out_id = tx_out.id
-          LEFT JOIN multi_asset AS ma ON _assets IS TRUE AND ma.id = mto.ident
-          LEFT JOIN grest.asset_info_cache AS aic ON _assets IS TRUE AND aic.asset_id = ma.id
           LEFT JOIN datum ON _scripts IS TRUE AND datum.id = tx_out.inline_datum_id
           LEFT JOIN script ON _scripts IS TRUE AND script.id = tx_out.reference_script_id
         WHERE _scripts IS TRUE
@@ -760,11 +747,11 @@ BEGIN
             'datum_hash', datum_hash,
             'inline_datum', inline_datum,
             'reference_script', reference_script,
-            'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
+            'asset_list', asset_descr
           ) AS tx_collateral_outputs
         FROM _all_collateral_outputs AS aco
         WHERE _scripts IS TRUE AND aco.tx_id = atx.id
-        GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, aco.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
+        GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, aco.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script, asset_descr
         LIMIT 1 -- there can only be one collateral output
       ),
       COALESCE((


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
The outputs for `collateral_tx_out` are never really created on chain - and thus, any assets involved are never committed to `ma_tx_out`. However, current references for `collateral_tx_out` in `tx_info` and `block_tx_info` endpoints does an incorrect join assuming `collateral_tx_out.id` can be joined against `ma_tx_out` -> `tx_out_id` (latter is strictly only to be mapped against `tx_out.id`) . This resulted in collateral_tx_out returning inconsistent and wrong results across instances due to invalid key to join.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
#284 

## How has this been tested?
<!--- Describe how you tested changes -->
Tested on local preprod instance using below (should be empty):
``` bash
curl -sX POST "http://127.0.0.1:18053/api/v1/tx_info?select=collateral_output->asset_list"  -H "accept: application/json" -H "content-type: application/json"  -d '{"_tx_hashes":["6fc9e482959befc6928d2691caa62c8a52a5abce167bd5fce8874cc315bb346d"]}'
# [{"asset_list":"[]"}]
```