### PR TITLE
Asset Info Cache patch

### DIFF
--- a/files/grest/rpc/01_cached_tables/asset_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_info_cache.sql
@@ -5,14 +5,12 @@ CREATE TABLE IF NOT EXISTS grest.asset_info_cache (
   decimals integer,
   mint_cnt bigint,
   burn_cnt bigint,
-  first_mint_tx_id bigint,
-  first_mint_keys text [],
   last_mint_tx_id bigint,
-  last_mint_keys text []
+  last_mint_meta_tx_id bigint
 );
 
-CREATE INDEX IF NOT EXISTS idx_first_mint_tx_id ON grest.asset_info_cache (first_mint_tx_id);
 CREATE INDEX IF NOT EXISTS idx_last_mint_tx_id ON grest.asset_info_cache (last_mint_tx_id);
+CREATE INDEX IF NOT EXISTS idx_last_mint_meta_tx_id ON grest.asset_info_cache (last_mint_meta_tx_id);
 CREATE INDEX IF NOT EXISTS idx_creation_time ON grest.asset_info_cache (creation_time DESC);
 
 CREATE OR REPLACE FUNCTION grest.asset_info_cache_update()
@@ -58,88 +56,44 @@ BEGIN
     tx_mint_meta AS (
       SELECT
         mtm.ident,
-        MIN(mtm.tx_id) AS first_mint_tx_id,
-        MAX(mtm.tx_id) AS last_mint_tx_id
+        MAX(mtm.tx_id) AS last_mint_tx_id,
+        MAX(mtm.tx_id) FILTER(WHERE tm.tx_id IS NOT NULL) AS last_mint_meta_tx_id
       FROM ma_tx_mint AS mtm
-      INNER JOIN tx_metadata AS tm ON tm.tx_id = mtm.tx_id
+      LEFT JOIN tx_metadata AS tm ON tm.tx_id = mtm.tx_id
       WHERE
-        CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
-          THEN
+        CASE
+          WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL THEN
             mtm.ident = ANY(_asset_id_list)
             AND mtm.tx_id > _asset_info_cache_last_tx_id
           ELSE TRUE
         END
-        AND tm.json IS NOT NULL
         AND mtm.quantity > 0
       GROUP BY mtm.ident
-    ),
-
-    tx_mint_nometa AS (
-      SELECT
-        mtm.ident,
-        MIN(mtm.tx_id) AS first_mint_tx_id,
-        MAX(mtm.tx_id) AS last_mint_tx_id
-      FROM ma_tx_mint AS mtm
-      LEFT JOIN tx_mint_meta ON tx_mint_meta.ident = mtm.ident
-      WHERE
-        CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
-          THEN
-            mtm.ident = ANY(_asset_id_list)
-            AND mtm.tx_id > _asset_info_cache_last_tx_id
-          ELSE TRUE
-        END
-        AND tx_mint_meta IS NULL
-      GROUP BY mtm.ident
-    ),
-
-    tx_meta AS (
-      SELECT
-        tmm.ident,
-        tmm.first_mint_tx_id,
-        ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.first_mint_tx_id) AS first_mint_keys,
-        tmm.last_mint_tx_id,
-        ARRAY_AGG(tm.key) FILTER(WHERE tm.tx_id = tmm.last_mint_tx_id) AS last_mint_keys
-      FROM tx_mint_meta AS tmm
-      INNER JOIN tx_metadata AS tm ON tm.tx_id = tmm.first_mint_tx_id OR tm.tx_id = tmm.last_mint_tx_id
-      GROUP BY tmm.ident, tmm.first_mint_tx_id, tmm.last_mint_tx_id
-      --
-      UNION ALL
-      --
-      SELECT
-        tx_mint_nometa.ident,
-        tx_mint_nometa.first_mint_tx_id,
-        '{}',
-        tx_mint_nometa.last_mint_tx_id,
-        '{}'
-      FROM tx_mint_nometa
     )
 
   INSERT INTO grest.asset_info_cache
     SELECT
       ma.id,
-      MIN(B.time) AS creation_time,
+      MIN(b.time) AS creation_time,
       SUM(mtm.quantity) AS total_supply,
       COALESCE(arc.decimals, 0) AS decimals,
       SUM(CASE WHEN mtm.quantity > 0 THEN 1 ELSE 0 END) AS mint_cnt,
       SUM(CASE WHEN mtm.quantity < 0 THEN 1 ELSE 0 END) AS burn_cnt,
-      tm.first_mint_tx_id,
-      tm.first_mint_keys,
-      tm.last_mint_tx_id,
-      tm.last_mint_keys
-    FROM
-      multi_asset AS ma
+      tm.last_mint_tx_id AS last_mint_tx_id,
+      tm.last_mint_meta_tx_id AS last_mint_meta_tx_id
+    FROM multi_asset AS ma
       INNER JOIN ma_tx_mint AS mtm ON mtm.ident = ma.id
       INNER JOIN tx ON tx.id = mtm.tx_id
       INNER JOIN block AS b ON b.id = tx.block_id
-      INNER JOIN tx_meta AS tm ON tm.ident = ma.id
+      INNER JOIN tx_mint_meta AS tm ON tm.ident = ma.id
       LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = encode(ma.name,'hex')
     WHERE
-      CASE WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL
-        THEN
+      CASE
+        WHEN _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL THEN
           mtm.ident = ANY(_asset_id_list)
         ELSE TRUE
       END
-    GROUP BY ma.id, arc.decimals, tm.first_mint_tx_id, tm.first_mint_keys, tm.last_mint_tx_id, tm.last_mint_keys
+    GROUP BY ma.id, arc.decimals, tm.last_mint_tx_id, tm.last_mint_meta_tx_id
   ON CONFLICT (asset_id)
   DO UPDATE SET
     creation_time = excluded.creation_time,
@@ -148,7 +102,7 @@ BEGIN
     mint_cnt = excluded.mint_cnt,
     burn_cnt = excluded.burn_cnt,
     last_mint_tx_id = excluded.last_mint_tx_id,
-    last_mint_keys = excluded.last_mint_keys;
+    last_mint_meta_tx_id = COALESCE(excluded.last_mint_meta_tx_id,grest.asset_info_cache.last_mint_meta_tx_id);
 
   IF _asset_info_cache_last_tx_id IS NOT NULL AND _asset_id_list IS NOT NULL THEN
     RAISE NOTICE '% assets added or updated', ARRAY_LENGTH(_asset_id_list, 1);

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -50,7 +50,7 @@ BEGIN
       END
     FROM multi_asset AS ma
       INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
-      INNER JOIN tx ON tx.id = aic.last_mint_tx_id
+      INNER JOIN tx ON tx.id = COALESCE(aic.last_mint_meta_tx_id, aic.last_mint_tx_id)
       LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
       LEFT JOIN LATERAL (
         SELECT JSONB_OBJECT_AGG(key::text, json ) AS minting_tx_metadata

--- a/files/grest/rpc/assets/asset_info_bulk.sql
+++ b/files/grest/rpc/assets/asset_info_bulk.sql
@@ -58,7 +58,7 @@ BEGIN
     FROM
       multi_asset AS ma
       INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
-      INNER JOIN tx ON tx.id = aic.last_mint_tx_id
+      INNER JOIN tx ON tx.id = COALESCE(aic.last_mint_meta_tx_id, aic.last_mint_tx_id)
       LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name,'hex')
       LEFT JOIN LATERAL (
         SELECT JSONB_OBJECT_AGG(

--- a/files/grest/rpc/assets/policy_asset_info.sql
+++ b/files/grest/rpc/assets/policy_asset_info.sql
@@ -38,7 +38,7 @@ BEGIN
       END
     FROM multi_asset AS ma
     INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
-    INNER JOIN tx ON tx.id = aic.last_mint_tx_id
+    INNER JOIN tx ON tx.id = COALESCE(aic.last_mint_meta_tx_id, aic.last_mint_tx_id)
     LEFT JOIN grest.asset_registry_cache AS arc ON arc.asset_policy = ENCODE(ma.policy,'hex') AND arc.asset_name = ENCODE(ma.name, 'hex')
     LEFT JOIN LATERAL (
       SELECT JSONB_OBJECT_AGG(

--- a/files/grest/rpc/assets/policy_asset_mints.sql
+++ b/files/grest/rpc/assets/policy_asset_mints.sql
@@ -24,7 +24,7 @@ AS $$
     aic.decimals
   FROM public.multi_asset AS ma
   INNER JOIN grest.asset_info_cache AS aic ON aic.asset_id = ma.id
-  LEFT JOIN tx ON tx.id = aic.first_mint_tx_id
+  LEFT JOIN tx ON tx.id = COALESCE(aic.last_mint_meta_tx_id, aic.last_mint_tx_id)
   WHERE ma.policy = DECODE(_asset_policy, 'hex')
   ORDER BY tx.id;
 $$;

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -4291,7 +4291,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the latest mint transaction
+            description: Hash of the latest mint transaction (with metadata if found for asset)
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           total_supply:
             type: string

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -4291,7 +4291,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the latest mint transaction
+            description: Hash of the latest mint transaction (with metadata if found for asset)
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           total_supply:
             type: string

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -4291,7 +4291,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the latest mint transaction
+            description: Hash of the latest mint transaction (with metadata if found for asset)
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           total_supply:
             type: string

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -4291,7 +4291,7 @@ components:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the latest mint transaction
+            description: Hash of the latest mint transaction (with metadata if found for asset)
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           total_supply:
             type: string

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1926,7 +1926,7 @@ schemas:
             example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
           minting_tx_hash:
             type: string
-            description: Hash of the latest mint transaction
+            description: Hash of the latest mint transaction (with metadata if found for asset)
             example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
           total_supply:
             type: string


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

- asset_info_cache: Remove unused info from asset-info-cache
- asset_info_cache: Split out latest minting tx with metadata (vs overall latest)
- [policy_]asset_info: Use last_mint_meta_tx_id and fallback to last_mint_tx_id from asset info cache
