### PR TITLE
Make use of pool_stat instead of epoch_stake for pool_history_cache

### DIFF
--- a/files/grest/rpc/01_cached_tables/pool_history_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_history_cache.sql
@@ -26,8 +26,8 @@ RETURNS TABLE (
   active_stake lovelace,
   active_stake_pct numeric,
   saturation_pct numeric,
-  block_cnt bigint,
-  delegator_cnt bigint,
+  block_cnt numeric,
+  delegator_cnt numeric,
   margin double precision,
   fixed_cost lovelace,
   pool_fees double precision,
@@ -46,22 +46,6 @@ BEGIN
   RETURN QUERY
   
   WITH
-    blockcounts AS (
-      SELECT
-        sl.pool_hash_id,
-        b.epoch_no,
-        COUNT(*) AS block_cnt
-      FROM block AS b,
-        slot_leader AS sl
-      WHERE b.slot_leader_id = sl.id
-        AND (_pool_bech32 is null or sl.pool_hash_id = ANY(_pool_ids))
-        AND b.epoch_no >= _epoch_no_to_insert_from
-        AND (_epoch_no_until is null or b.epoch_no <= _epoch_no_until) 
-      GROUP BY
-        sl.pool_hash_id,
-        b.epoch_no
-    ),
-
     leadertotals AS (
       SELECT
         r.pool_id,
@@ -95,19 +79,18 @@ BEGIN
     activeandfees AS (
       SELECT
         ph.view AS pool_id,
-        es.epoch_no,
-        SUM(es.amount) AS active_stake,
-        COUNT(1) AS delegator_cnt,
+        ps.epoch_no,
+        ps.stake AS active_stake,
+        ps.number_of_blocks AS block_cnt,
+        COALESCE(ps.number_of_delegators, 0) AS delegator_cnt,
         (
           SELECT margin
-          FROM
-            pool_update
-          WHERE
-            id = (
+          FROM pool_update
+          WHERE id = (
               SELECT MAX(pup2.id)
               FROM pool_update AS pup2
-              WHERE pup2.hash_id = es.pool_id
-                AND pup2.active_epoch_no <= es.epoch_no
+              WHERE pup2.hash_id = ps.pool_hash_id
+                AND pup2.active_epoch_no <= ps.epoch_no
            )
         ) AS pool_fee_variable,
         (
@@ -116,32 +99,32 @@ BEGIN
           WHERE id = (
               SELECT MAX(pup2.id)
               FROM pool_update AS pup2
-              WHERE pup2.hash_id = es.pool_id
-                AND pup2.active_epoch_no <= es.epoch_no)
+              WHERE pup2.hash_id = ps.pool_hash_id
+                AND pup2.active_epoch_no <= ps.epoch_no)
         ) AS pool_fee_fixed,
-        (SUM(es.amount) / (
+        (ps.stake / (
           SELECT NULLIF(easc.amount, 0)
           FROM grest.epoch_active_stake_cache AS easc
-          WHERE easc.epoch_no = es.epoch_no
+          WHERE easc.epoch_no = ps.epoch_no
           )
         ) * 100 AS active_stake_pct,
         ROUND(
-          (SUM(es.amount) / (
+          (ps.stake / (
             SELECT supply::bigint / (
                 SELECT ep.optimal_pool_count
                 FROM epoch_param AS ep
-                WHERE ep.epoch_no = es.epoch_no
+                WHERE ep.epoch_no = ps.epoch_no
               )
-            FROM grest.totals (es.epoch_no)
+            FROM grest.totals (ps.epoch_no)
             ) * 100
           ), 2
         ) AS saturation_pct
-      FROM epoch_stake AS es
-        INNER JOIN pool_hash AS ph ON es.pool_id = ph.id
-      WHERE es.epoch_no >= _epoch_no_to_insert_from
-        AND (_epoch_no_until is null or es.epoch_no < _epoch_no_until)
+      FROM pool_stat AS ps
+        INNER JOIN pool_hash AS ph ON ps.pool_hash_id = ph.id
+      WHERE ps.epoch_no >= _epoch_no_to_insert_from
+        AND (_epoch_no_until is null or ps.epoch_no < _epoch_no_until)
         AND (_pool_bech32 is null or ph.view = ANY(_pool_bech32))
-      GROUP BY es.pool_id, ph.view, es.epoch_no
+      GROUP BY ps.pool_hash_id, ph.view, ps.epoch_no, ps.stake, ps.number_of_blocks, ps.number_of_delegators
     )
 
     SELECT
@@ -150,13 +133,13 @@ BEGIN
       actf.active_stake::lovelace,
       actf.active_stake_pct,
       actf.saturation_pct,
-      COALESCE(b.block_cnt, 0) AS block_cnt,
+      COALESCE(actf.block_cnt, 0) AS block_cnt,
       actf.delegator_cnt,
       actf.pool_fee_variable::double precision,
       actf.pool_fee_fixed,
       -- for debugging: m.memtotal,
       -- for debugging: l.leadertotal,
-      CASE COALESCE(b.block_cnt, 0)
+      CASE COALESCE(actf.block_cnt, 0)
       WHEN 0 THEN
         0
       ELSE
@@ -170,7 +153,7 @@ BEGIN
             END
         END
       END AS pool_fees,
-      CASE COALESCE(b.block_cnt, 0)
+      CASE COALESCE(actf.block_cnt, 0)
       WHEN 0 THEN
         0
       ELSE
@@ -184,7 +167,7 @@ BEGIN
           END
         END
       END AS deleg_rewards,
-      CASE COALESCE(b.block_cnt, 0)
+      CASE COALESCE(actf.block_cnt, 0)
         WHEN 0 THEN 0
       ELSE
         CASE COALESCE(m.memtotal, 0)
@@ -192,7 +175,7 @@ BEGIN
           ELSE COALESCE(m.memtotal, 0)
         END
       END::double precision AS member_rewards,
-      CASE COALESCE(b.block_cnt, 0)
+      CASE COALESCE(actf.block_cnt, 0)
         WHEN 0 THEN 0
       ELSE
         -- special CASE for WHEN reward information is not available yet
@@ -209,8 +192,6 @@ BEGIN
       END AS epoch_ros
     FROM pool_hash AS ph
     INNER JOIN activeandfees AS actf ON actf.pool_id = ph.view
-    LEFT JOIN blockcounts AS b ON ph.id = b.pool_hash_id
-      AND actf.epoch_no = b.epoch_no
     LEFT JOIN leadertotals AS l ON ph.id = l.pool_id
       AND actf.epoch_no = l.earned_epoch
     LEFT JOIN membertotals AS m ON ph.id = m.pool_id

--- a/files/grest/rpc/02_indexes/13_3_00.sql
+++ b/files/grest/rpc/02_indexes/13_3_00.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS pool_stat_pool_hash_id ON pool_stat(pool_hash_id);
+CREATE INDEX IF NOT EXISTS pool_stat_epoch_no ON pool_stat(epoch_no);


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
dbsync 13.3.0.0 introduces pool_stat table, which contains number of blocks/delegators/stake and voting power historically. This means we no longer need to create aggregate of these from block or epoch_stake table ourselves.