### PR TITLE
Vote endpoints now return proposal hash and voting hashes, added cert…

### DIFF
--- a/files/grest/rpc/governance/committee_votes.sql
+++ b/files/grest/rpc/governance/committee_votes.sql
@@ -1,25 +1,28 @@
 CREATE OR REPLACE FUNCTION grest.committee_votes(_committee_hash text)
 RETURNS TABLE (
-  tx_hash text,
+  proposal_tx_hash text,
   cert_index integer,
+  vote_tx_hash text,
   block_time integer,
   vote text
 )
 LANGUAGE sql STABLE
 AS $$
   SELECT
-    ENCODE(tx.hash, 'hex')::text AS tx_hash,
+    ENCODE(prop_tx.hash, 'hex')::text AS proposal_tx_hash,
     gap.index AS cert_index,
+    ENCODE(vote_tx.hash, 'hex')::text AS vote_tx_hash,
     EXTRACT(EPOCH FROM b.time)::integer AS block_time,
     vp.vote
   FROM public.committee_hash AS ch
     INNER JOIN public.voting_procedure AS vp ON ch.id = vp.committee_voter
     INNER JOIN public.gov_action_proposal AS gap ON vp.gov_action_proposal_id = gap.id
-    INNER JOIN public.tx ON gap.tx_id = tx.id
-    INNER JOIN public.block AS b ON tx.block_id = b.id
+    INNER JOIN public.tx prop_tx ON gap.tx_id = prop_tx.id
+    INNER JOIN public.tx vote_tx on vp.tx_id = vote_tx.id
+    INNER JOIN public.block AS b ON vote_tx.block_id = b.id
   WHERE ch.raw = DECODE(_committee_hash, 'hex')
   ORDER BY
-    block_time DESC;
+    vote_tx.id DESC;
 $$;
 
 COMMENT ON FUNCTION grest.committee_votes IS 'Get all committee votes cast by given committee member or collective'; -- noqa: LT01

--- a/files/grest/rpc/governance/drep_updates.sql
+++ b/files/grest/rpc/governance/drep_updates.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION grest.drep_updates(_drep_id text DEFAULT NULL)
 RETURNS TABLE (
   drep_id character varying,
   hex text,
-  tx_hash text,
+  update_tx_hash text,
   cert_index integer,
   block_time integer,
   action text,
@@ -16,7 +16,7 @@ AS $$
   SELECT
     dh.view AS drep_id,
     ENCODE(dh.raw, 'hex')::text AS hex,
-    ENCODE(tx.hash, 'hex')::text AS tx_hash,
+    ENCODE(tx.hash, 'hex')::text AS update_tx_hash,
     dr.cert_index,
     EXTRACT(EPOCH FROM b.time)::integer AS block_time,
     CASE

--- a/files/grest/rpc/governance/drep_votes.sql
+++ b/files/grest/rpc/governance/drep_votes.sql
@@ -1,25 +1,28 @@
 CREATE OR REPLACE FUNCTION grest.drep_votes(_drep_id text)
 RETURNS TABLE (
-  tx_hash text,
+  proposal_tx_hash text,
   cert_index integer,
+  vote_tx_hash text,
   block_time integer,
   vote text
 )
 LANGUAGE sql STABLE
 AS $$
   SELECT
-    ENCODE(tx.hash, 'hex')::text AS tx_hash,
+    ENCODE(prop_tx.hash, 'hex')::text AS proposal_tx_hash,
     gap.index AS cert_index,
+    ENCODE(vote_tx.hash, 'hex')::text AS vote_tx_hash,
     EXTRACT(EPOCH FROM b.time)::integer AS block_time,
     vp.vote
   FROM public.drep_hash AS dh
     INNER JOIN public.voting_procedure AS vp ON dh.id = vp.drep_voter
     INNER JOIN public.gov_action_proposal AS gap ON vp.gov_action_proposal_id = gap.id
-    INNER JOIN public.tx ON gap.tx_id = tx.id
-    INNER JOIN public.block AS b ON tx.block_id = b.id
+    INNER JOIN public.tx prop_tx ON gap.tx_id = prop_tx.id
+    INNER JOIN public.tx vote_tx on vp.tx_id = vote_tx.id
+    INNER JOIN public.block AS b ON vote_tx.block_id = b.id
   WHERE dh.view = _drep_id
   ORDER BY
-    block_time DESC;
+    vote_tx.id DESC;
 $$;
 
 COMMENT ON FUNCTION grest.drep_votes IS 'Get all DRep votes cast from specified DRep ID'; -- noqa: LT01

--- a/files/grest/rpc/governance/proposal_list.sql
+++ b/files/grest/rpc/governance/proposal_list.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION grest.proposal_list()
 RETURNS TABLE (
-  tx_hash text,
+  proposal_tx_hash text,
   cert_index integer,
   block_time integer,
   proposal_type text,
@@ -25,7 +25,7 @@ RETURNS TABLE (
 LANGUAGE sql STABLE
 AS $$
   SELECT
-    ENCODE(tx.hash, 'hex')::text AS tx_hash,
+    ENCODE(tx.hash, 'hex')::text AS proposal_tx_hash,
     gap.index AS cert_index,
     EXTRACT(EPOCH FROM b.time)::integer AS block_time,
     gap.type AS proposal_type,

--- a/files/grest/rpc/governance/proposal_votes.sql
+++ b/files/grest/rpc/governance/proposal_votes.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION grest.proposal_votes(_tx_hash text, _cert_index integer)
+CREATE OR REPLACE FUNCTION grest.proposal_votes(_proposal_tx_hash text, _cert_index integer)
 RETURNS TABLE (
   block_time integer,
   voter_role text,
@@ -25,7 +25,7 @@ AS $$
         LEFT JOIN public.drep_hash AS dh ON vp.drep_voter = dh.id 
         LEFT JOIN public.pool_hash AS ph ON vp.pool_voter = ph.id
         LEFT JOIN public.committee_hash AS ch ON vp.committee_voter = ch.id
-      WHERE tx.hash = DECODE(_tx_hash, 'hex')
+      WHERE tx.hash = DECODE(_proposal_tx_hash, 'hex')
         -- will we need a similar filters to the one below for pool and committee member retirements?
         AND (
           CASE

--- a/files/grest/rpc/pool/pool_votes.sql
+++ b/files/grest/rpc/pool/pool_votes.sql
@@ -1,25 +1,28 @@
 CREATE OR REPLACE FUNCTION grest.pool_votes(_pool_bech32 text)
 RETURNS TABLE (
-  tx_hash text,
+  proposal_tx_hash text,
   cert_index integer,
+  vote_tx_hash text,
   block_time integer,
   vote text
 )
 LANGUAGE sql STABLE
 AS $$
   SELECT
-    ENCODE(tx.hash, 'hex')::text AS tx_hash,
+    ENCODE(prop_tx.hash, 'hex')::text AS proposal_tx_hash,
     gap.index AS cert_index,
+    ENCODE(vote_tx.hash, 'hex')::text AS vote_tx_hash,
     EXTRACT(EPOCH FROM b.time)::integer AS block_time,
     vp.vote
   FROM public.pool_hash ph
     INNER JOIN public.voting_procedure AS vp ON ph.id = vp.pool_voter
     INNER JOIN public.gov_action_proposal AS gap ON vp.gov_action_proposal_id = gap.id
-    INNER JOIN public.tx ON gap.tx_id = tx.id
-    INNER JOIN public.block AS b ON tx.block_id = b.id
+    INNER JOIN public.tx prop_tx ON gap.tx_id = prop_tx.id
+    INNER JOIN public.tx vote_tx on vp.tx_id = vote_tx.id
+    INNER JOIN public.block AS b ON vote_tx.block_id = b.id
   WHERE ph.view = _pool_bech32
   ORDER BY
-    block_time DESC;
+    vote_tx.id DESC;
 $$;
 
 COMMENT ON FUNCTION grest.pool_votes IS 'Get all SPO votes cast for a given pool'; -- noqa: LT01

--- a/specs/templates/2-api-params.yaml
+++ b/specs/templates/2-api-params.yaml
@@ -179,3 +179,13 @@ parameters:
       in: query
       required: true
       allowEmptyValue: false
+    _proposal_tx_hash:
+      deprecated: false
+      name: _proposal_tx_hash
+      description: Transaction Hash of government proposal in hexadecimal format (hex)
+      example: "##_proposal_tx_hash_param##"
+      schema:
+        type: string
+      in: query
+      required: true
+      allowEmptyValue: false

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -2354,7 +2354,7 @@ schemas:
             $ref: "#/components/schemas/drep_info/items/properties/drep_id"
           hex:
             $ref: "#/components/schemas/drep_info/items/properties/hex"
-          tx_hash:
+          update_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           cert_index:
             type: string
@@ -2380,10 +2380,12 @@ schemas:
       type: array
       items:
         properties:
-          tx_hash:
+          proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           cert_index:
             $ref: "#/components/schemas/drep_updates/items/properties/cert_index"
+          vote_tx_hash:
+            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           block_time:
             $ref: "#/components/schemas/blocks/items/properties/block_time"
           vote:
@@ -2406,7 +2408,7 @@ schemas:
       type: array
       items:
         properties:
-          tx_hash:
+          proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           cert_index:
             $ref: "#/components/schemas/drep_updates/items/properties/cert_index"

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -1311,7 +1311,8 @@ paths:
       tags:
         - Governance
       parameters:
-        - $ref: "#/components/parameters/_tx_hash"
+        - $ref: "#/components/parameters/_proposal_tx_hash"
+        - $ref: "#/components/schemas/drep_updates/items/properties/cert_index"
       responses:
         "200":
           description: Success!!


### PR DESCRIPTION
…_index param to proposal votes endpoint, spec updates

## Description
Vote list endpoints now return proposal_tx_hash of the proposal and vote_tx_hash of the vote, and blocktime has been corrected to be that of the latter. One of the endpoints had cert_index parameter in implementation but was missing from API specs. Ordering changed from block time to tx id as can have multiple voting transactions within same block in theory.

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
