### PR TITLE
Gov script fixes

### DIFF
--- a/files/grest/rpc/03_utilities/cip129.sql
+++ b/files/grest/rpc/03_utilities/cip129.sql
@@ -34,6 +34,19 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION grest.cip129_cc_hot_has_script(_cc_hot text)
+RETURNS boolean
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  IF LENGTH(_cc_hot) = 60 THEN
+    RETURN SUBSTRING(b32_decode(_cc_hot) from 2 for 1) = '3';
+  ELSE
+    RETURN STARTS_WITH(_cc_hot, 'cc_hot_script');
+  END IF;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION grest.cip129_hex_to_cc_hot(_raw bytea, _is_script boolean)
 RETURNS text
 LANGUAGE plpgsql STABLE
@@ -60,6 +73,19 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION grest.cip129_cc_cold_has_script(_cc_cold text)
+RETURNS boolean
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  IF LENGTH(_cc_cold) = 61 THEN
+    RETURN SUBSTRING(b32_decode(_cc_cold) from 2 for 1) = '3';
+  ELSE
+    RETURN STARTS_WITH(_cc_cold, 'cc_cold_script');
+  END IF;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION grest.cip129_hex_to_cc_cold(_raw bytea, _is_script boolean)
 RETURNS text
 LANGUAGE plpgsql STABLE
@@ -82,6 +108,19 @@ BEGIN
     RETURN SUBSTRING(b32_decode(_drep_id) from 3);
   ELSE
     RETURN b32_decode(_drep_id);
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION grest.cip129_drep_id_has_script(_drep_id text)
+RETURNS boolean
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  IF LENGTH(_drep_id) = 58 THEN
+    RETURN SUBSTRING(b32_decode(_drep_id) from 2 for 1) = '3';
+  ELSE
+    RETURN STARTS_WITH(_drep_id, 'drep_script');
   END IF;
 END;
 $$;
@@ -121,10 +160,13 @@ END;
 $$;
 
 COMMENT ON FUNCTION grest.cip129_cc_hot_to_hex IS 'Returns binary hex from Constitutional Committee Hot Credential ID in old or new (CIP-129) format'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip129_cc_hot_has_script IS 'Returns true if Constitutional Committee Hot Credential ID is of type script'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_hex_to_cc_hot IS 'Returns Constitutional Committee Hot Credential ID in CIP-129 format from raw binary hex'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_cc_cold_to_hex IS 'Returns binary hex from Constitutional Committee Cold Credential ID in old or new (CIP-129) format'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip129_cc_cold_has_script IS 'Returns true if Constitutional Committee Cold Credential ID is of type script'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_hex_to_cc_cold IS 'Returns Constitutional Committee Cold Credential ID in CIP-129 format from raw binary hex'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_drep_id_to_hex IS 'Returns binary hex from DRep Credential ID in old or new (CIP-129) format'; -- noqa: LT01
+COMMENT ON FUNCTION grest.cip129_drep_id_has_script IS 'Returns true if DRep Credential ID is of type script'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_hex_to_drep_id IS 'Returns DRep Credential ID in CIP-129 format from raw binary hex'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_from_gov_action_id IS 'Returns string array containing transaction hash and certificate index from Governance Action Proposal ID in CIP-129 format'; -- noqa: LT01
 COMMENT ON FUNCTION grest.cip129_to_gov_action_id IS 'Returns Governance Action Proposal ID in CIP-129 format from transaction hash appended by index of certificate within the transaction'; -- noqa: LT01

--- a/files/grest/rpc/governance/committee_votes.sql
+++ b/files/grest/rpc/governance/committee_votes.sql
@@ -31,6 +31,7 @@ AS $$
     CASE
       WHEN _cc_hot_id IS NULL THEN TRUE
       ELSE ch.raw = DECODE((SELECT grest.cip129_cc_hot_to_hex(_cc_hot_id)), 'hex')
+       AND ch.has_script = grest.cip129_cc_hot_has_script(_cc_hot_id)
     END
   ORDER BY
     vote_tx.id DESC;

--- a/files/grest/rpc/governance/drep_delegators.sql
+++ b/files/grest/rpc/governance/drep_delegators.sql
@@ -13,7 +13,7 @@ DECLARE
   last_reg_tx_id  bigint;
 BEGIN
 
-  IF STARTS_WITH(_drep_id,'drep_') THEN
+  IF STARTS_WITH(_drep_id,'drep_always') THEN
     -- predefined DRep roles
     SELECT INTO drep_idx id
     FROM public.drep_hash
@@ -23,7 +23,8 @@ BEGIN
   ELSE
     SELECT INTO drep_idx id
     FROM public.drep_hash
-    WHERE raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_drep_id)), 'hex');
+    WHERE raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_drep_id)), 'hex')
+      AND has_script = grest.cip129_drep_id_has_script(_drep_id);
 
     SELECT INTO last_reg_tx_id MAX(tx_id)
     FROM public.drep_registration

--- a/files/grest/rpc/governance/drep_info.sql
+++ b/files/grest/rpc/governance/drep_info.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION grest.drep_info2(_drep_ids text [])
+CREATE OR REPLACE FUNCTION grest.drep_info(_drep_ids text [])
 RETURNS TABLE (
   drep_id text,
   hex text,

--- a/files/grest/rpc/governance/drep_updates.sql
+++ b/files/grest/rpc/governance/drep_updates.sql
@@ -40,6 +40,7 @@ AS $$
     CASE
       WHEN _drep_id IS NULL THEN TRUE
       ELSE dh.raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_drep_id)), 'hex')
+       AND dh.has_script = grest.cip129_drep_id_has_script(_drep_id)
     END
   ORDER BY
     block_time DESC;

--- a/files/grest/rpc/governance/drep_votes.sql
+++ b/files/grest/rpc/governance/drep_votes.sql
@@ -28,6 +28,7 @@ AS $$
     INNER JOIN public.block AS b ON vote_tx.block_id = b.id
     LEFT JOIN public.voting_anchor AS va ON vp.voting_anchor_id = va.id
   WHERE dh.raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_drep_id)), 'hex')
+    AND dh.has_script = grest.cip129_drep_id_has_script(_drep_id)
   ORDER BY
     vote_tx.id DESC;
 $$;

--- a/files/grest/rpc/governance/voter_proposal_list.sql
+++ b/files/grest/rpc/governance/voter_proposal_list.sql
@@ -33,11 +33,11 @@ DECLARE
 BEGIN
 
   IF STARTS_WITH(_voter_id, 'drep') THEN
-    SELECT INTO _drep_id id FROM public.drep_hash WHERE raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_voter_id)), 'hex');
+    SELECT INTO _drep_id id FROM public.drep_hash WHERE raw = DECODE((SELECT grest.cip129_drep_id_to_hex(_voter_id)), 'hex') AND has_script = grest.cip129_drep_id_has_script(_voter_id);
   ELSIF STARTS_WITH(_voter_id, 'pool') THEN
     SELECT INTO _spo_id id FROM public.pool_hash WHERE view = _voter_id;
   ELSIF STARTS_WITH(_voter_id, 'cc_hot') THEN
-    SELECT INTO _committee_member_id id FROM public.committee_hash WHERE raw = DECODE((SELECT grest.cip129_cc_hot_to_hex(_voter_id)), 'hex');
+    SELECT INTO _committee_member_id id FROM public.committee_hash WHERE raw = DECODE((SELECT grest.cip129_cc_hot_to_hex(_voter_id)), 'hex') AND has_script = grest.cip129_cc_hot_has_script(_voter_id);
   END IF;
 
   SELECT INTO _gap_id_list ARRAY_AGG(gov_action_proposal_id)


### PR DESCRIPTION
- Fix for when both key and script has was registered with same hash
- Fix for drep_script format according to CIP-105, implementation was in conflict with pre-defined roles
