### PR TITLE
fix for drep_info regarding active state

### DIFF
--- a/files/grest/rpc/governance/drep_info.sql
+++ b/files/grest/rpc/governance/drep_info.sql
@@ -97,7 +97,7 @@ BEGIN
         SELECT
           drep_state.drep,
           drep_state.deposit,
-          (CASE WHEN (curr_epoch - b.epoch_no) < drep_activity THEN TRUE ELSE FALSE END) AS active,
+          (CASE WHEN (curr_epoch - b.epoch_no) <= drep_activity THEN TRUE ELSE FALSE END) AS active,
           (b.epoch_no + drep_activity) AS expires_epoch_no
         FROM (
           SELECT


### PR DESCRIPTION
## Description
Marked as inactive 1 epoch before it should. 
