### PR TITLE
Script fix for cip5_hex_to_stake_addr

### DIFF
--- a/files/grest/rpc/000_utilities/cip5.sql
+++ b/files/grest/rpc/000_utilities/cip5.sql
@@ -14,7 +14,7 @@ BEGIN
       ''::bytea,
       FALSE,
       SUBSTRING(_raw FROM 2),
-      FALSE,
+      SUBSTRING(ENCODE(_raw, 'hex') from 1 for 1)::text = 'f',
       SUBSTRING(ENCODE(_raw, 'hex') from 2 for 1)::integer
       )::text;
   END IF;


### PR DESCRIPTION
## Description
Bech32 stake address generation using pg_cardano didn't set script flag correctly and instead creating all addresses as key addresses.
