### PR TITLE
fea(rpc): Add treasure and reserve movements to /totals

### DIFF
--- a/files/grest/rpc/00_blockchain/totals.sql
+++ b/files/grest/rpc/00_blockchain/totals.sql
@@ -9,10 +9,26 @@ RETURNS TABLE (
   fees text,
   deposits_stake text,
   deposits_drep text,
-  deposits_proposal text
+  deposits_proposal text,
+  treasury_donation text,
+  treasury_withdrawal text,
+  reserves_withdrawal text
 )
 LANGUAGE sql STABLE
 AS $$
+  WITH treasury_reserve_withdrawals AS (
+      SELECT
+        b.epoch_no,
+        COALESCE(SUM(tx.treasury_donation), 0)::text AS treasury_donation,
+        COALESCE(SUM(r.amount), 0)::text AS reserve_withdrawal,
+        COALESCE(SUM(t.amount), 0)::text AS treasury_withdrawal
+      FROM public.tx AS tx
+        INNER JOIN public.block AS b ON b.id = tx.block_id
+        LEFT JOIN public.reserve AS r ON r.tx_id = tx.id
+        LEFT JOIN public.treasury AS t ON t.tx_id = tx.id
+      WHERE b.epoch_no = _epoch_no::word31type
+      GROUP BY b.epoch_no
+  )
   SELECT
     ap.epoch_no,
     ap.utxo::text,
@@ -23,11 +39,15 @@ AS $$
     ap.fees::text,
     ap.deposits_stake::text,
     ap.deposits_drep::text,
-    ap.deposits_proposal::text
+    ap.deposits_proposal::text,
+    trw.treasury_donation::text,
+    trw.treasury_withdrawal::text,
+    trw.reserve_withdrawal::text
   FROM public.ada_pots AS ap
+    INNER JOIN treasury_reserve_withdrawals trw ON TRUE
   WHERE (_epoch_no IS NOT NULL AND ap.epoch_no = _epoch_no)
     OR (_epoch_no IS NULL)
   ORDER BY ap.epoch_no DESC;
 $$;
 
-COMMENT ON FUNCTION grest.totals IS 'Get the circulating utxo, treasury, rewards, supply and reserves in lovelace for specified epoch, all epochs if empty'; -- noqa: LT01
+COMMENT ON FUNCTION grest.totals IS 'Get the circulating utxo, treasury, rewards, supply and reserves in lovelace for specified epoch, all epochs if empty';

--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -3244,6 +3244,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -3244,6 +3244,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -3244,6 +3244,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -3244,6 +3244,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -117,6 +117,18 @@ schemas:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Adds total `treasury_donation`, `treasury_withdrawal` and `reserve_withdrawal` to `/totals`.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
Closes #347 
