### PR TITLE
chore(specs): format API specs

### DIFF
--- a/specs/results/koiosapi-guild.yaml
+++ b/specs/results/koiosapi-guild.yaml
@@ -157,7 +157,6 @@ servers:
   - url: https://sancho.koios.rest/api/v1
     description: Sanchonet Network
 paths:
-
   /tip: #RPC
     get:
       tags:
@@ -490,7 +489,7 @@ paths:
       operationId: block_tx_info
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /utxo_info: #RPC
     post:
@@ -700,7 +699,7 @@ paths:
       operationId: tx_utxos
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /address_info: #RPC
     post:
@@ -992,7 +991,7 @@ paths:
       operationId: account_rewards
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_reward_history: #RPC
     post:
       tags:
@@ -1133,7 +1132,7 @@ paths:
       operationId: account_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_stake_history: #RPC
     post:
       tags:
@@ -1308,8 +1307,8 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Addresses
       description: Get the list of all addresses holding a given asset <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: asset_addresses
   /asset_nft_address: #RPC
@@ -1355,9 +1354,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Policy Asset Address List
-      description: Get the list of addresses with quantity for each asset on the given policy <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+      description:
+        Get the list of addresses with quantity for each asset on the given policy <br><br>
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: policy_asset_addresses
   /policy_asset_info: #RPC
@@ -1587,7 +1587,7 @@ paths:
       operationId: drep_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_voting_power_history: #RPC
     get:
       tags:
@@ -1636,7 +1636,7 @@ paths:
       operationId: drep_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_delegators: #RPC
     get:
       tags:
@@ -1790,7 +1790,7 @@ paths:
   /vote_list: #RPC
     get:
       tags:
-        - Governance      
+        - Governance
       responses:
         "200":
           description: Success!!
@@ -2124,8 +2124,8 @@ paths:
       operationId: pool_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
-  
+          label: "Deprecated"
+
   /pool_groups: #RPC
     get:
       tags:
@@ -2343,7 +2343,7 @@ paths:
         We do support transparent forwarding for various methods from Ogmios, you can read about those <a href="#tag--Ogmios">here</a>.
         </div>
       operationId: ogmios
-        
+
 components:
   parameters:
     _after_block_height:
@@ -2561,9 +2561,9 @@ components:
                   $ref: "#/components/schemas/blocks/items/properties/hash"
             example:
               _block_hashes:
-                - af2f6f7dd4e4ea6765103a1e38e023da3edd2b3c7fea2aa367222564dbe01cfd
-                - bddbbc6df0ad09567a513349bafd56d8ec5c8fcd9ee9db12173624b896350d57
-                - 732bf9bbc3780e6cd7ad57a3889dd5904f6e8a27d54eabf43eb0dbc485323f04
+                -  af2f6f7dd4e4ea6765103a1e38e023da3edd2b3c7fea2aa367222564dbe01cfd
+                -  bddbbc6df0ad09567a513349bafd56d8ec5c8fcd9ee9db12173624b896350d57
+                -  732bf9bbc3780e6cd7ad57a3889dd5904f6e8a27d54eabf43eb0dbc485323f04
       description: Array of block hashes
     block_tx_info:
       content:
@@ -2607,9 +2607,9 @@ components:
                 description: Controls whether to include bytecode for associated reference/plutus scripts
             example:
               _block_hashes:
-                - af2f6f7dd4e4ea6765103a1e38e023da3edd2b3c7fea2aa367222564dbe01cfd
-                - bddbbc6df0ad09567a513349bafd56d8ec5c8fcd9ee9db12173624b896350d57
-                - 732bf9bbc3780e6cd7ad57a3889dd5904f6e8a27d54eabf43eb0dbc485323f04
+                -  af2f6f7dd4e4ea6765103a1e38e023da3edd2b3c7fea2aa367222564dbe01cfd
+                -  bddbbc6df0ad09567a513349bafd56d8ec5c8fcd9ee9db12173624b896350d57
+                -  732bf9bbc3780e6cd7ad57a3889dd5904f6e8a27d54eabf43eb0dbc485323f04
               _inputs: false
               _metadata: false
               _assets: false
@@ -2633,8 +2633,8 @@ components:
                 description: Array of Cardano payment address(es) in bech32 format
             example:
               _addresses:
-                - addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
-                - addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
+                -  addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
+                -  addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
       description: Array of Cardano payment address(es)
     payment_addresses_with_extended:
       content:
@@ -2655,8 +2655,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _addresses:
-                - addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
-                - addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
+                -  addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
+                -  addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
               _extended: true
       description: Array of Cardano payment address(es) with extended flag to toggle additional fields
     address_txs:
@@ -2678,8 +2678,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _addresses:
-                - addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
-                - addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
+                -  addr_test1qzmtfv43a8ncx6ve92ja6yy25npn9raz9pu5a2tfxsqv9gy9ktf0pu6yu4zjh9r37fzx3h4tsxqdjhu3t4d5ffdsfz9s6ska3z
+                -  addr_test1vq67g5u8ls4vm4wdvs0r8xvsuej66nvaqedyrj2tcz6tuycz275pu
               _after_block_height: 120000
       description: Array of Cardano payment address(es)
     stake_addresses_with_epoch_no:
@@ -2701,8 +2701,8 @@ components:
                 description: Only fetch information for a specific epoch
             example:
               _stake_addresses:
-                - stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
-                - stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
+                -  stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
+                -  stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
               _epoch_no: 1500
       description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
     stake_addresses_with_first_only_and_empty:
@@ -2728,8 +2728,8 @@ components:
                 description: Include zero quantity entries
             example:
               _stake_addresses:
-                - stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
-                - stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
+                -  stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
+                -  stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
               _first_only: false
               _empty: false
       description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
@@ -2752,8 +2752,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _stake_addresses:
-                - stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
-                - stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
+                -  stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
+                -  stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
               _extended: true
       description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
     stake_addresses:
@@ -2771,8 +2771,8 @@ components:
                 description: Array of Cardano stake address(es) in bech32 format
             example:
               _stake_addresses:
-                - stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
-                - stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
+                -  stake_test17zt9x005zkd2usz2vhvktyzqsuwz25gmgnaqdka5hcj9m2qfg2py2
+                -  stake_test1uzzm95hs7dzw23ftj3cly3rgm64crqxet7g46k6y5kcy3zcs3mpjd
       description: Array of Cardano stake credential(s) in bech32 format
     credential_txs:
       content:
@@ -2793,8 +2793,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _payment_credentials:
-                - b6b4b2b1e9e78369992aa5dd108aa4c3328fa228794ea9693400c2a0
-                - 35e45387fc2acdd5cd641e339990e665ad4d9d065a41c94bc0b4be13
+                -  b6b4b2b1e9e78369992aa5dd108aa4c3328fa228794ea9693400c2a0
+                -  35e45387fc2acdd5cd641e339990e665ad4d9d065a41c94bc0b4be13
               _after_block_height: 120000
       description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
     credential_utxos:
@@ -2813,11 +2813,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _payment_credentials:
-                - b6b4b2b1e9e78369992aa5dd108aa4c3328fa228794ea9693400c2a0
-                - 35e45387fc2acdd5cd641e339990e665ad4d9d065a41c94bc0b4be13
+                -  b6b4b2b1e9e78369992aa5dd108aa4c3328fa228794ea9693400c2a0
+                -  35e45387fc2acdd5cd641e339990e665ad4d9d065a41c94bc0b4be13
               _extended: true
       description: Array of Cardano payment credential(s) in hex format
     tx_ids:
@@ -2835,8 +2835,8 @@ components:
                 description: Array of Cardano Transaction hashes
             example:
               _tx_hashes:
-                - bf04578d452dd3acb7c70fbac32dc972cb69f932f804171cfb4268f5af0228e7
-                - 63b716064012f858450731cb5f960c100c6cb639ec1ec999b898c604451f116a
+                -  bf04578d452dd3acb7c70fbac32dc972cb69f932f804171cfb4268f5af0228e7
+                -  63b716064012f858450731cb5f960c100c6cb639ec1ec999b898c604451f116a
       description: Array of Cardano Transaction hashes
     tx_info:
       content:
@@ -2885,8 +2885,8 @@ components:
                 description: Controls whether to include governance certificates, votes and proposals in the result
             example:
               _tx_hashes:
-                - bf04578d452dd3acb7c70fbac32dc972cb69f932f804171cfb4268f5af0228e7
-                - 63b716064012f858450731cb5f960c100c6cb639ec1ec999b898c604451f116a
+                -  bf04578d452dd3acb7c70fbac32dc972cb69f932f804171cfb4268f5af0228e7
+                -  63b716064012f858450731cb5f960c100c6cb639ec1ec999b898c604451f116a
               _inputs: false
               _metadata: false
               _assets: false
@@ -2918,9 +2918,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool19st4a2vvu78tjtyywjte2eml3kx6ynersgd2nyw0y4jvyhlfu0u
-                - pool1uul8pytp2p0xq4ckjn3l294km0m7fuef46teehvh3x5tk46sfx3
-                - pool1us9ww725p0vygae5zaydme3apt7wg9se2yemhl8mgwkes3tlrqp
+                -  pool19st4a2vvu78tjtyywjte2eml3kx6ynersgd2nyw0y4jvyhlfu0u
+                -  pool1uul8pytp2p0xq4ckjn3l294km0m7fuef46teehvh3x5tk46sfx3
+                -  pool1us9ww725p0vygae5zaydme3apt7wg9se2yemhl8mgwkes3tlrqp
       description: Array of Cardano pool IDs (bech32 format)
     pool_ids_optional:
       content:
@@ -2935,9 +2935,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool19st4a2vvu78tjtyywjte2eml3kx6ynersgd2nyw0y4jvyhlfu0u
-                - pool1uul8pytp2p0xq4ckjn3l294km0m7fuef46teehvh3x5tk46sfx3
-                - pool1us9ww725p0vygae5zaydme3apt7wg9se2yemhl8mgwkes3tlrqp
+                -  pool19st4a2vvu78tjtyywjte2eml3kx6ynersgd2nyw0y4jvyhlfu0u
+                -  pool1uul8pytp2p0xq4ckjn3l294km0m7fuef46teehvh3x5tk46sfx3
+                -  pool1us9ww725p0vygae5zaydme3apt7wg9se2yemhl8mgwkes3tlrqp
       description: Array of Cardano pool IDs (bech32 format) [Optional]
     script_hashes:
       content:
@@ -2952,8 +2952,8 @@ components:
                 description: Array of Cardano script hashes
             example:
               _script_hashes:
-                  - a08a267e92456ba48e157dd7e77bdd35aba0fc50fe625a10a6a7fc5e
-                  - 1f3a4aa08cfa0e47fff200578f0d4847b6890b7093a765773feb35de
+                -  a08a267e92456ba48e157dd7e77bdd35aba0fc50fe625a10a6a7fc5e
+                -  1f3a4aa08cfa0e47fff200578f0d4847b6890b7093a765773feb35de
       description: Array of Cardano script hashes
     datum_hashes:
       content:
@@ -2968,8 +2968,8 @@ components:
                 description: Array of Cardano datum hashes
             example:
               _datum_hashes:
-                  - 964af1ff2a66ce472d34ac39b47f356b6d971d62c794a89ec12825d5de30f3aa
-                  - 17bdb9c96b77c7718d546be50193a80bc9d72081b7375e5e16891db196af14fc
+                -  964af1ff2a66ce472d34ac39b47f356b6d971d62c794a89ec12825d5de30f3aa
+                -  17bdb9c96b77c7718d546be50193a80bc9d72081b7375e5e16891db196af14fc
       description: Array of Cardano datum hashes
     asset_list:
       content:
@@ -2988,8 +2988,8 @@ components:
                     type: string
             example:
               _asset_list:
-                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
-                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
+                -  ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
+                -  ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
       description: Array of array of policyID and asset names (hex)
     asset_list_with_extended:
       content:
@@ -3012,8 +3012,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _asset_list:
-                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
-                - ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
+                -  ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
+                -  ['313534a537bc476c86ff7c57ec511bd7f24a9d15654091b24e9c606e','41484c636f696e']
               _extended: true
       description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
     drep_id_bulk:
@@ -3031,8 +3031,8 @@ components:
                   type: string
             example:
               _drep_ids:
-                - drep1s9qaseg7qyum807fcv0hdky9gv0c89tn98t4urjn5ewz57dml0r
-                - drep13p45vxysc2s6vp6ez2ng7lynlsheh64zxexpcennn68cuc05yps
+                -  drep1s9qaseg7qyum807fcv0hdky9gv0c89tn98t4urjn5ewz57dml0r
+                -  drep13p45vxysc2s6vp6ez2ng7lynlsheh64zxexpcennn68cuc05yps
     utxo_refs_with_extended:
       content:
         application/json:
@@ -3049,11 +3049,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _utxo_refs:
-                - f82e568d42604fd71424d193c86ec00c97aead2b8f018e81c3139d9e3770c735#0
-                - 88ae22495123c7ee37a0bbe865243757185a302ed5359d1eae9347030628290a#0
+                -  f82e568d42604fd71424d193c86ec00c97aead2b8f018e81c3139d9e3770c735#0
+                -  88ae22495123c7ee37a0bbe865243757185a302ed5359d1eae9347030628290a#0
               _extended: false
       description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
     ogmios:
@@ -3072,7 +3072,22 @@ components:
               method:
                 type: string
                 description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
-                enum: ["queryNetwork/blockHeight","queryNetwork/genesisConfiguration","queryNetwork/startTime","queryNetwork/tip","queryLedgerState/epoch","queryLedgerState/eraStart","queryLedgerState/eraSummaries","queryLedgerState/liveStakeDistribution","queryLedgerState/protocolParameters","queryLedgerState/proposedProtocolParameters","queryLedgerState/stakePools","submitTransaction","evaluateTransaction"]
+                enum:
+                  [
+                    "queryNetwork/blockHeight",
+                    "queryNetwork/genesisConfiguration",
+                    "queryNetwork/startTime",
+                    "queryNetwork/tip",
+                    "queryLedgerState/epoch",
+                    "queryLedgerState/eraStart",
+                    "queryLedgerState/eraSummaries",
+                    "queryLedgerState/liveStakeDistribution",
+                    "queryLedgerState/protocolParameters",
+                    "queryLedgerState/proposedProtocolParameters",
+                    "queryLedgerState/stakePools",
+                    "submitTransaction",
+                    "evaluateTransaction",
+                  ]
                 example: "queryNetwork/tip"
               params:
                 type: object
@@ -3084,7 +3099,12 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
             genesisConfiguration:
               description: Query the genesis configuration of a given era.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/genesisConfiguration", "params": { "era": "shelley" } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryNetwork/genesisConfiguration",
+                  "params": { "era": "shelley" },
+                }
             startTimeTime:
               description: Query the network start time.
               value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
@@ -3099,25 +3119,61 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
             eraSummaries:
               description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
+              value:
+                { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
             liveStakeDistribution:
               description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/liveStakeDistribution" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/liveStakeDistribution",
+                }
             protocolParameters:
               description: Query the current protocol parameters.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/protocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/protocolParameters",
+                }
             proposedProtocolParameters:
               description: Query the last update proposal w.r.t. protocol parameters, if any.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/proposedProtocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/proposedProtocolParameters",
+                }
             StakePools:
               description: Query the list of all stake pool identifiers currently registered and active.
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
             submitTransaction:
               description: Submit a signed and serialized transaction to the network.
-              value: { "jsonrpc": "2.0", "method": "submitTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" } } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "submitTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                    },
+                }
             evaluateTransaction:
               description: Evaluate execution units of scripts in a well-formed transaction.
-              value: { "jsonrpc": "2.0", "method": "evaluateTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" }, "additionalUtxo": [ { ... } ] } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "evaluateTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                      "additionalUtxo": [{ ... }],
+                    },
+                }
       description: JSON-RPC 2.0 standard request body
   securitySchemes:
     bearerAuth:
@@ -3244,6 +3300,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array
@@ -3260,7 +3328,7 @@ components:
           data:
             type: string
             description: JSON encoded data with details about the parameter update
-            example: {"decentralisation": 0.9}
+            example: { "decentralisation": 0.9 }
     cli_protocol_params:
       description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
       type: object
@@ -3277,10 +3345,7 @@ components:
           "monetaryExpansion": 3.0e-3,
           "poolPledgeInfluence": 0.3,
           "poolRetireMaxEpoch": 18,
-          "protocolVersion": {
-            "major": 8,
-            "minor": 0
-          },
+          "protocolVersion": { "major": 8, "minor": 0 },
           "...": "...",
           "stakeAddressDeposit": 2000000,
           "stakePoolDeposit": 500000000,
@@ -3288,7 +3353,7 @@ components:
           "treasuryCut": 0.2,
           "txFeeFixed": 155381,
           "txFeePerByte": 44,
-          "utxoCostPerByte": 4310
+          "utxoCostPerByte": 4310,
         }
     reserve_withdrawals:
       description: Array of withdrawals from reserves/treasury against stake accounts
@@ -3317,6 +3382,7 @@ components:
             description: Epoch where the earned amount can be spent
             allOf:
               - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+
     pool_list:
       description: Array of pool IDs and tickers
       type: array
@@ -3345,7 +3411,7 @@ components:
           ticker:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ticker
             example: AHL
           pool_group:
@@ -3375,7 +3441,7 @@ components:
           active_stake_pct:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Active stake for the pool, expressed as a percentage of total active stake on network
             example: 13.512182543475783
           saturation_pct:
@@ -3385,7 +3451,7 @@ components:
           block_cnt:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of blocks pool created in that epoch
             example: 14
           delegator_cnt:
@@ -3411,7 +3477,7 @@ components:
           member_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
             example: "123456780123"
           epoch_ros:
@@ -3455,49 +3521,49 @@ components:
           vrf_key_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool VRF key hash
             example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
           margin:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Margin (decimal format)
             example: 0.1
           fixed_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool fixed cost per epoch
             example: "500000000"
           pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool pledge in number
             example: "64000000000000"
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool's registration deposit in number
             example: "500000000"
           reward_addr:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool reward address
             example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
           reward_addr_delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           owners:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               type: string
               description: Pool (co)owner address
@@ -3510,49 +3576,49 @@ components:
                 dns:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS name of the relay (nullable)
                   example: relays-new.cardano-mainnet.iohk.io
                 srv:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS service name of the relay (nullable)
                   example: biostakingpool3.hopto.org
                 ipv4:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv4 address of the relay (nullable)
                   example: "54.220.20.40"
                 ipv6:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv6 address of the relay (nullable)
                   example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
                 port:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Port number of the relay (nullable)
                   example: 6000
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata URL
             example: https://pools.iohk.io/IOGP.json
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             properties:
               name:
                 type: string
@@ -3578,49 +3644,49 @@ components:
           retiring_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Announced retiring epoch (nullable)
             example: null
           op_cert:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           op_cert_counter:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate counter value
             example: 8
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Amount of delegated stake to this pool at the time of epoch snapshot
             example: "64328627680963"
           sigma:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool relative active stake share
             example: 0.0034839235
           block_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Total pool blocks on chain
             example: 4509
           live_pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Summary of account balance for all pool owner's
             example: "64328594406327"
           live_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool live stake
             example: "64328627680963"
           live_delegators:
@@ -3630,13 +3696,13 @@ components:
           live_saturation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool live saturation (decimal format)
             example: 94.52
           voting_power:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Current voting power (lovelaces) of this stake pool
             example: "123456789"
     pool_snapshot:
@@ -3707,7 +3773,7 @@ components:
       description: Array of pool delegators (historical)
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         type: object
         properties:
@@ -3754,7 +3820,7 @@ components:
           active_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Epoch number in which the update becomes active
             example: 324
           vrf_key_hash:
@@ -3847,7 +3913,7 @@ components:
           pool_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A group that the pool was identified to be associated with
             example: IOG
           ticker:
@@ -3855,15 +3921,16 @@ components:
           adastat_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per adastat.net
             example: iohk.io
           balanceanalytics_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per balanceanalytics.io
             example: IOG
+
     epoch_info:
       description: Array of detailed summary for each epoch
       type: array
@@ -3909,19 +3976,19 @@ components:
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
             example: "23395112387185880"
           total_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total rewards earned in epoch (null for pre-Shelley epochs)
             example: "252902897534230"
           avg_blk_reward:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Average block reward for epoch (null for pre-Shelley epochs)
             example: "660233450"
     epoch_params:
@@ -3936,119 +4003,119 @@ components:
           min_fee_a:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'a' parameter to calculate the minimum transaction fee
             example: 44
           min_fee_b:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'b' parameter to calculate the minimum transaction fee
             example: 155381
           max_block_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block size (in bytes)
             example: 65536
           max_tx_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum transaction size (in bytes)
             example: 16384
           max_bh_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block header size (in bytes)
             example: 1100
           key_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake address
             example: "2000000"
           pool_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake pool
             example: "500000000"
           max_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
             example: 18
           optimal_pool_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The optimal number of stake pools
             example: 500
           influence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The pledge influence on pool rewards
             example: 0.3
           monetary_expand_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The monetary expansion rate
             example: 0.003
           treasury_growth_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The treasury growth rate
             example: 0.2
           decentralisation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
             example: 0.1
           extra_entropy:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
             example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
           protocol_major:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol major version
             example: 5
           protocol_minor:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol minor version
             example: 0
           min_utxo_value:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum value of a UTxO entry
             example: "34482"
           min_pool_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum pool cost
             example: "340000000"
           nonce:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The nonce value for this epoch
             example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
           block_hash:
@@ -4058,201 +4125,201 @@ components:
           cost_models:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The per language cost model in JSON
             example: null
           price_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The per word cost of script memory usage
             example: 0.0577
           price_step:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The cost of script execution step usage
             example: 7.21e-05
           max_tx_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single transaction
             example: 10000000
           max_tx_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single transaction
             example: 10000000000
           max_block_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single block
             example: 50000000
           max_block_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single block
             example: 40000000000
           max_val_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum Val size
             example: 5000
           collateral_percent:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
             example: 150
           max_collateral_inputs:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of collateral inputs allowed in a transaction
             example: 3
           coins_per_utxo_size:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The cost per UTxO size
             example: "34482"
           pvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for motion of no-confidence.
             example: 0.6
           pvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (normal state).
             example: 0.65
           pvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           pvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for hard-fork initiation.
             example: 0.51
           dvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for motion of no-confidence.
             example: 0.67
           dvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (normal state).
             example: 0.67
           dvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           dvt_update_to_constitution:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for update to the Constitution.
             example: 0.75
           dvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for hard-fork initiation.
             example: 0.6
           dvt_p_p_network_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, network group.
             example: 0.67
           dvt_p_p_economic_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, economic group.
             example: 0.67
           dvt_p_p_technical_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, technical group.
             example: 0.67
           dvt_p_p_gov_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, governance group.
             example: 0.75
           dvt_treasury_withdrawal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for treasury withdrawal.
             example: 0.67
           committee_min_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimal constitutional committee size.
             example: 5
           committee_max_term_length:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Constitutional committee term limits.
             example: 146
           gov_action_lifetime:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Governance action expiration.
             example: 14
           gov_action_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Governance action deposit.
             example: 100000000000
           drep_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep deposit amount.
             example: 500000000
           drep_activity:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep activity period.
             example: 20
           pvtpp_security_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for protocol parameter changes, security group.
             example: 0.6
           min_fee_ref_script_cost_per_byte:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimum Fee for Reference Script cost pre byte
             example: 15
     epoch_block_protocols:
@@ -4272,6 +4339,7 @@ components:
             type: number
             description: Amount of blocks with specified major and protocol combination
             example: 2183
+
     blocks:
       description: Array of block information
       type: array
@@ -4317,7 +4385,7 @@ components:
           pool:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ID in bech32 format (null for pre-Shelley blocks)
             example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
           op_cert_counter:
@@ -4371,13 +4439,13 @@ components:
           total_output:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total output of the block (in number)
             example: "92384672389"
           total_fees:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total fees of the block (in number)
             example: "2346834"
           num_confirmations:
@@ -4473,8 +4541,8 @@ components:
           inputs:
             description: An array of UTxO inputs spent in the transaction
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           outputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
           withdrawals:
@@ -4489,6 +4557,7 @@ components:
             $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
           plutus_contracts:
             $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
+
     address_info:
       description: Array of information for address(es)
       type: array
@@ -4503,8 +4572,8 @@ components:
             example: "10723473983"
           stake_address:
             anyOf:
-            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            - type: 'null'
+              - $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              - type: "null"
           script_address:
             type: boolean
             description: Signifies whether the address is a script address
@@ -4606,7 +4675,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script hash in case the stake address is locked by a script
             example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
     account_info:
@@ -4625,13 +4694,13 @@ components:
           delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           delegated_pool:
             anyOf:
-            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-            - type: 'null'
+              - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+              - type: "null"
           total_balance:
             type: string
             description: Total balance of the account including UTxO, rewards and MIRs (in number)
@@ -4668,109 +4737,6 @@ components:
             type: string
             description: Total proposal refund for this account
             example: "0"
-    utxo_infos:
-      description: Array of complete UTxO information
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          inline_datum:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-          reference_script:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-          asset_list:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: An array of assets on the UTxO
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of assets on the UTxO
-                  example: "1"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    tx_outs_epoch:
-      description: List of transaction outputs with basic details for requested epoch
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
     account_rewards:
       description: Array of reward history information
       type: array
@@ -4799,7 +4765,7 @@ components:
                 pool_id:
                   anyOf:
                     - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-                    - type: 'null'
+                    - type: "null"
     account_reward_history:
       description: Array of reward history information
       type: array
@@ -4823,7 +4789,7 @@ components:
           pool_id_bech32:
             anyOf:
               - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-              - type: 'null'
+              - type: "null"
     account_updates:
       description: Array of account updates information
       type: array
@@ -4840,7 +4806,14 @@ components:
                 action_type:
                   type: string
                   description: Type of certificate submitted
-                  enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+                  enum:
+                    [
+                      "registration",
+                      "delegation_pool",
+                      "delegation_drep",
+                      "withdrawal",
+                      "deregistration",
+                    ]
                   example: "registration"
                 tx_hash:
                   $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4863,7 +4836,14 @@ components:
           action_type:
             type: string
             description: Type of certificate submitted
-            enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+            enum:
+              [
+                "registration",
+                "delegation_pool",
+                "delegation_drep",
+                "withdrawal",
+                "deregistration",
+              ]
             example: "registration"
           tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4952,6 +4932,7 @@ components:
             type: string
             description: Active stake amount (in numbers)
             example: 682334162
+
     tx_info:
       description: Array of detailed information about transaction(s)
       type: array
@@ -5001,25 +4982,25 @@ components:
           invalid_before:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot before which transaction cannot be validated (if supplied, else null)
             example: "42331172"
           invalid_after:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot after which transaction cannot be validated
             example: "42332172"
           collateral_inputs:
             description: An array of collateral inputs needed for smart contracts in case of contract failure
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           collateral_output:
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               properties:
                 payment_addr:
@@ -5045,7 +5026,7 @@ components:
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
             anyOf:
               - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-              - type: 'null'
+              - type: "null"
           inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             #description: An array of UTxO inputs spent in the transaction
@@ -5077,13 +5058,13 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
-                  description: Hash of datum (if any) connected to UTxO 
+                    - type: "null"
+                  description: Hash of datum (if any) connected to UTxO
                   example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
                 inline_datum:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allows datums to be attached to UTxO (CIP-32)
                   properties:
                     bytes:
@@ -5097,7 +5078,7 @@ components:
                 reference_script:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
                   properties:
                     hash:
@@ -5119,7 +5100,7 @@ components:
                     value:
                       anyOf:
                         - type: object
-                        - type: 'null'
+                        - type: "null"
                       description: Value (json)
                       example: null
                 asset_list:
@@ -5127,7 +5108,7 @@ components:
           withdrawals:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of withdrawals with-in a transaction
             items:
               type: object
@@ -5143,7 +5124,7 @@ components:
           assets_minted:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of minted assets with-in a transaction
             items:
               properties:
@@ -5164,14 +5145,14 @@ components:
           certificates:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Certificates present with-in a transaction (if any)
             items:
               properties:
                 index:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Certificate index
                   example: 0
                 type:
@@ -5181,7 +5162,7 @@ components:
                 info:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: A JSON array containing information from the certificate
                   example:
                     {
@@ -5191,7 +5172,7 @@ components:
           native_scripts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Native scripts present in a transaction (if any)
             items:
               properties:
@@ -5222,20 +5203,20 @@ components:
           plutus_contracts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Plutus contracts present in transaction (if any)
             items:
               properties:
                 address:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
                 spends_input:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   properties:
                     tx_hash:
                       $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -5286,7 +5267,7 @@ components:
           voting_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance votes in a transaction (if any)
             items:
               properties:
@@ -5305,7 +5286,7 @@ components:
           proposal_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance proposals in a transaction (if any)
             items:
               properties:
@@ -5390,7 +5371,7 @@ components:
       description: Array of metadata information present in each of the transactions queried
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         properties:
           tx_hash:
@@ -5398,7 +5379,7 @@ components:
           metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: A JSON array containing details about metadata within transaction
             example:
               {
@@ -5421,7 +5402,7 @@ components:
           num_confirmations:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of block confirmations
             example: 17
     tx_metalabels:
@@ -5433,6 +5414,130 @@ components:
             type: string
             description: A distinct known metalabel
             example: "721"
+    utxo_infos:
+      description: Array of complete UTxO information
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          inline_datum:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+          reference_script:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+          asset_list:
+            anyOf:
+              - type: array
+              - type: "null"
+            description: An array of assets on the UTxO
+            items:
+              properties:
+                policy_id:
+                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+                asset_name:
+                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+                fingerprint:
+                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+                quantity:
+                  type: string
+                  description: Quantity of assets on the UTxO
+                  example: "1"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_outs_epoch:
+      description: List of transaction outputs with basic details for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_treasury_donations_epoch:
+      description: List of treasury donation transactions for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          tx_hash:
+            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+          block_hash:
+            $ref: "#/components/schemas/blocks/items/properties/hash"
+          tx_block_index:
+            $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          treasury_donation:
+            $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+
     asset_list:
       description: Array of policy IDs and asset names
       type: array
@@ -5530,7 +5635,7 @@ components:
           asset_name:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Asset Name (hex)
             example: 444f4e545350414d
           asset_name_ascii:
@@ -5568,33 +5673,33 @@ components:
           token_registry_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Asset metadata registered on the Cardano Token Registry
             properties:
               name:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Rackmob
               description:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Metaverse Blockchain Cryptocurrency.
               ticker:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: MOB
               url:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: https://www.rackmob.com/
               logo:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: A PNG image file as a byte string
                 example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
               decimals:
@@ -5603,9 +5708,27 @@ components:
           cip68_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: CIP 68 metadata if present for asset
-            example: {"222": {"fields": [{"map": [{"k": {"bytes": "6e616d65"}, "v": {"bytes": "74657374"}}]}], "constructor": 0}}
+            example:
+              {
+                "222":
+                  {
+                    "fields":
+                      [
+                        {
+                          "map":
+                            [
+                              {
+                                "k": { "bytes": "6e616d65" },
+                                "v": { "bytes": "74657374" },
+                              },
+                            ],
+                        },
+                      ],
+                    "constructor": 0,
+                  },
+              }
     asset_history:
       description: Array of asset mint/burn history
       type: array
@@ -5620,7 +5743,7 @@ components:
           minting_txs:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of all mint/burn transactions for an asset
             items:
               type: object
@@ -5640,6 +5763,7 @@ components:
                   description: Array of Transaction Metadata for given transaction
                   items:
                     $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+
     policy_asset_addresses:
       description: Array of asset names and payment addresses for the given policy (including balances)
       type: array
@@ -5716,6 +5840,7 @@ components:
             $ref: "#/components/schemas/asset_info/items/properties/total_supply"
           decimals:
             $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+
     drep_info:
       description: Get detailed information about requested delegated representatives (DReps)
       type: array
@@ -5740,7 +5865,7 @@ components:
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep's registration deposit  in number
             example: "500000000"
           active:
@@ -5750,7 +5875,7 @@ components:
           expires_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: After which epoch DRep is considered inactive.
             example: 410
           amount:
@@ -5760,13 +5885,13 @@ components:
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A URL to a JSON payload of metadata
             example: "https://hornan7.github.io/Vote_Context.jsonld"
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A hash of the contents of the metadata URL
             example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
     drep_epoch_summary:
@@ -5832,36 +5957,121 @@ components:
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The payload as JSON
             example:
-              {"body": {"title": "...", "...": "...", "references": [{"uri": "...", "@type": "Other", "label": "Hardfork to PV10"}]}, "authors": [{"name": "...", "witness": {"publicKey": "...", "signature": "...", "witnessAlgorithm": "ed25519"}}], "@context": {"body": {"@id": "CIP108:body", "@context": {"title": "CIP108:title", "abstract": "CIP108:abstract", "rationale": "CIP108:rationale", "motivation": "CIP108:motivation", "references": {"@id": "CIP108:references", "@context": {"uri": "CIP100:reference-uri", "Other": "CIP100:OtherReference", "label": "CIP100:reference-label", "referenceHash": {"@id": "CIP108:referenceHash", "@context": {"hashDigest": "CIP108:hashDigest", "hashAlgorithm": "CIP100:hashAlgorithm"}}, "GovernanceMetadata": "CIP100:GovernanceMetadataReference"}, "@container": "@set"}}}, "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#", "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#", "authors": {"@id": "CIP100:authors", "@context": {"name": "http://xmlns.com/foaf/0.1/name", "witness": {"@id": "CIP100:witness", "@context": {"publicKey": "CIP100:publicKey", "signature": "CIP100:signature", "witnessAlgorithm": "CIP100:witnessAlgorithm"}}}, "@container": "@set"}, "@language": "en-us", "hashAlgorithm": "CIP100:hashAlgorithm"}, "hashAlgorithm": "blake2b-256"}
+              {
+                "body":
+                  {
+                    "title": "...",
+                    "...": "...",
+                    "references":
+                      [
+                        {
+                          "uri": "...",
+                          "@type": "Other",
+                          "label": "Hardfork to PV10",
+                        },
+                      ],
+                  },
+                "authors":
+                  [
+                    {
+                      "name": "...",
+                      "witness":
+                        {
+                          "publicKey": "...",
+                          "signature": "...",
+                          "witnessAlgorithm": "ed25519",
+                        },
+                    },
+                  ],
+                "@context":
+                  {
+                    "body":
+                      {
+                        "@id": "CIP108:body",
+                        "@context":
+                          {
+                            "title": "CIP108:title",
+                            "abstract": "CIP108:abstract",
+                            "rationale": "CIP108:rationale",
+                            "motivation": "CIP108:motivation",
+                            "references":
+                              {
+                                "@id": "CIP108:references",
+                                "@context":
+                                  {
+                                    "uri": "CIP100:reference-uri",
+                                    "Other": "CIP100:OtherReference",
+                                    "label": "CIP100:reference-label",
+                                    "referenceHash":
+                                      {
+                                        "@id": "CIP108:referenceHash",
+                                        "@context":
+                                          {
+                                            "hashDigest": "CIP108:hashDigest",
+                                            "hashAlgorithm": "CIP100:hashAlgorithm",
+                                          },
+                                      },
+                                    "GovernanceMetadata": "CIP100:GovernanceMetadataReference",
+                                  },
+                                "@container": "@set",
+                              },
+                          },
+                      },
+                    "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
+                    "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#",
+                    "authors":
+                      {
+                        "@id": "CIP100:authors",
+                        "@context":
+                          {
+                            "name": "http://xmlns.com/foaf/0.1/name",
+                            "witness":
+                              {
+                                "@id": "CIP100:witness",
+                                "@context":
+                                  {
+                                    "publicKey": "CIP100:publicKey",
+                                    "signature": "CIP100:signature",
+                                    "witnessAlgorithm": "CIP100:witnessAlgorithm",
+                                  },
+                              },
+                          },
+                        "@container": "@set",
+                      },
+                    "@language": "en-us",
+                    "hashAlgorithm": "CIP100:hashAlgorithm",
+                  },
+                "hashAlgorithm": "blake2b-256",
+              }
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The raw bytes of the payload
             example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
           warning:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A warning that occured while validating the metadata
           language:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The language described in the context of the metadata as per CIP-100
             example: en-us
           comment:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Comment attached to the metadata
           is_valid:
             anyOf:
               - type: boolean
-              - type: 'null'
+              - type: "null"
             description: Indicate whether data is invalid (currently returns null for all as per dbsync)
             example: null
     drep_updates:
@@ -5886,7 +6096,7 @@ components:
           action:
             type: string
             description: Effective action for this DRep Update certificate
-            enum: ["updated","registered","deregistered"]
+            enum: ["updated", "registered", "deregistered"]
             example: registered
           deposit:
             $ref: "#/components/schemas/drep_info/items/properties/deposit"
@@ -5907,8 +6117,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the DRep
             example: "14231445553"
     drep_votes:
@@ -5928,7 +6138,7 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/block_time"
           vote:
             type: string
-            enum: ["Yes","No","Abstain"]
+            enum: ["Yes", "No", "Abstain"]
             description: Actual Vote casted
             example: "Yes"
           meta_url:
@@ -5946,8 +6156,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the pool for the epoch
             example: "11231445553"
     pool_votes:
@@ -5970,7 +6180,7 @@ components:
           proposal_id:
             type: string
             description: Proposal Action ID in accordance with CIP-129 format
-            example: 'gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh'
+            example: "gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh"
           proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           proposal_index:
@@ -5979,7 +6189,16 @@ components:
             example: 0
           proposal_type:
             type: string
-            enum: ["ParameterChange", "HardForkInitiation", "TreasuryWithdrawals", "NoConfidence", "NewCommittee", "NewConstitution", "InfoAction"]
+            enum:
+              [
+                "ParameterChange",
+                "HardForkInitiation",
+                "TreasuryWithdrawals",
+                "NoConfidence",
+                "NewCommittee",
+                "NewConstitution",
+                "InfoAction",
+              ]
             description: Proposal Action Type
             example: ParameterChange
           proposal_description:
@@ -5999,31 +6218,31 @@ components:
           ratified_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been ratified at the specfied epoch.
             example: 670
           enacted_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been enacted at the specfied epoch.
             example: 675
           dropped_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
             example: 680
           expired_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been expired at the specfied epoch.
             example: 680
           expiration:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Shows the epoch at which this governance action is expected to expire.
           meta_url:
             $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
@@ -6040,7 +6259,7 @@ components:
           withdrawal:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: If not null, the amount withdrawn from treasury into stake address by this this proposal
             properties:
               stake_address:
@@ -6052,8 +6271,8 @@ components:
             description: If not null, the proposed new parameter set
             anyOf:
               - type: object
-              - type: 'null'
-            example: {"key_deposit": 1000000}
+              - type: "null"
+            example: { "key_deposit": 1000000 }
     voter_proposal_list:
       description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
       type: array
@@ -6281,7 +6500,7 @@ components:
               status:
                 type: string
                 description: Member authentication status
-                enum: [ "authorized", "not_authorized", "resigned" ]
+                enum: ["authorized", "not_authorized", "resigned"]
                 example: authorized
               cc_cold_hex:
                 type: string
@@ -6294,19 +6513,20 @@ components:
               cc_hot_hex:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: Committee member key hash from last valid hot key authorization certificate in hex format
                 example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
               cc_hot_has_script:
                 anyOf:
                   - type: boolean
-                  - type: 'null'
+                  - type: "null"
                 description: Flag which shows if this credential is a script hash
                 example: false
               expiration_epoch:
                 type: number
                 description: Epoch number in which the committee member vote rights expire
                 example: 324
+
     script_info:
       type: array
       items:
@@ -6315,7 +6535,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Hash of a script
             example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
           creation_tx_hash:
@@ -6325,18 +6545,18 @@ components:
           type:
             type: string
             description: Type of the script
-            enum: ["plutusV1","plutusV2","timelock","multisig"]
+            enum: ["plutusV1", "plutusV2", "timelock", "multisig"]
             example: plutusV1
           value:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Data in JSON format
             example: null
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script bytes (cborSeq)
             example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
           size:
@@ -6377,14 +6597,14 @@ components:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Memory to run a script
                   example: 520448
                 unit_steps:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Cpu steps to run a script
                   example: 211535239
                 fee:
@@ -6399,7 +6619,7 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: The Hash of the Plutus Data
                   example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
                 datum_value:
@@ -6418,6 +6638,7 @@ components:
             $ref: "#/components/schemas/script_info/items/properties/value"
           bytes:
             $ref: "#/components/schemas/script_info/items/properties/bytes"
+
     ogmiostip:
       description: Current tip of the chain, identified by a slot and a block header hash.
       type: object
@@ -6436,7 +6657,7 @@ components:
             - type: number
             - type: array
             - type: object
-            - type: 'null'
+            - type: "null"
           description: Result of the query
           properties:
             slot:
@@ -6447,7 +6668,11 @@ components:
               type: string
               description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
               example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
-          example: {"slot": 59886800, "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"}
+          example:
+            {
+              "slot": 59886800,
+              "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1",
+            }
   headers: {}
   responses:
     NotFound:

--- a/specs/results/koiosapi-mainnet.yaml
+++ b/specs/results/koiosapi-mainnet.yaml
@@ -157,7 +157,6 @@ servers:
   - url: https://sancho.koios.rest/api/v1
     description: Sanchonet Network
 paths:
-
   /tip: #RPC
     get:
       tags:
@@ -490,7 +489,7 @@ paths:
       operationId: block_tx_info
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /utxo_info: #RPC
     post:
@@ -700,7 +699,7 @@ paths:
       operationId: tx_utxos
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /address_info: #RPC
     post:
@@ -992,7 +991,7 @@ paths:
       operationId: account_rewards
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_reward_history: #RPC
     post:
       tags:
@@ -1133,7 +1132,7 @@ paths:
       operationId: account_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_stake_history: #RPC
     post:
       tags:
@@ -1308,8 +1307,8 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Addresses
       description: Get the list of all addresses holding a given asset <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: asset_addresses
   /asset_nft_address: #RPC
@@ -1355,9 +1354,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Policy Asset Address List
-      description: Get the list of addresses with quantity for each asset on the given policy <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+      description:
+        Get the list of addresses with quantity for each asset on the given policy <br><br>
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: policy_asset_addresses
   /policy_asset_info: #RPC
@@ -1587,7 +1587,7 @@ paths:
       operationId: drep_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_voting_power_history: #RPC
     get:
       tags:
@@ -1636,7 +1636,7 @@ paths:
       operationId: drep_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_delegators: #RPC
     get:
       tags:
@@ -1790,7 +1790,7 @@ paths:
   /vote_list: #RPC
     get:
       tags:
-        - Governance      
+        - Governance
       responses:
         "200":
           description: Success!!
@@ -2124,8 +2124,8 @@ paths:
       operationId: pool_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
-  
+          label: "Deprecated"
+
   /pool_groups: #RPC
     get:
       tags:
@@ -2343,7 +2343,7 @@ paths:
         We do support transparent forwarding for various methods from Ogmios, you can read about those <a href="#tag--Ogmios">here</a>.
         </div>
       operationId: ogmios
-        
+
 components:
   parameters:
     _after_block_height:
@@ -2561,9 +2561,9 @@ components:
                   $ref: "#/components/schemas/blocks/items/properties/hash"
             example:
               _block_hashes:
-                - fb9087c9f1408a7bbd7b022fd294ab565fec8dd3a8ef091567482722a1fa4e30
-                - 60188a8dcb6db0d80628815be2cf626c4d17cb3e826cebfca84adaff93ad492a
-                - c6646214a1f377aa461a0163c213fc6b86a559a2d6ebd647d54c4eb00aaab015
+                -  fb9087c9f1408a7bbd7b022fd294ab565fec8dd3a8ef091567482722a1fa4e30
+                -  60188a8dcb6db0d80628815be2cf626c4d17cb3e826cebfca84adaff93ad492a
+                -  c6646214a1f377aa461a0163c213fc6b86a559a2d6ebd647d54c4eb00aaab015
       description: Array of block hashes
     block_tx_info:
       content:
@@ -2607,9 +2607,9 @@ components:
                 description: Controls whether to include bytecode for associated reference/plutus scripts
             example:
               _block_hashes:
-                - fb9087c9f1408a7bbd7b022fd294ab565fec8dd3a8ef091567482722a1fa4e30
-                - 60188a8dcb6db0d80628815be2cf626c4d17cb3e826cebfca84adaff93ad492a
-                - c6646214a1f377aa461a0163c213fc6b86a559a2d6ebd647d54c4eb00aaab015
+                -  fb9087c9f1408a7bbd7b022fd294ab565fec8dd3a8ef091567482722a1fa4e30
+                -  60188a8dcb6db0d80628815be2cf626c4d17cb3e826cebfca84adaff93ad492a
+                -  c6646214a1f377aa461a0163c213fc6b86a559a2d6ebd647d54c4eb00aaab015
               _inputs: false
               _metadata: false
               _assets: false
@@ -2633,8 +2633,8 @@ components:
                 description: Array of Cardano payment address(es) in bech32 format
             example:
               _addresses:
-                - addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
-                - addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
+                -  addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
+                -  addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
       description: Array of Cardano payment address(es)
     payment_addresses_with_extended:
       content:
@@ -2655,8 +2655,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _addresses:
-                - addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
-                - addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
+                -  addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
+                -  addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
               _extended: true
       description: Array of Cardano payment address(es) with extended flag to toggle additional fields
     address_txs:
@@ -2678,8 +2678,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _addresses:
-                - addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
-                - addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
+                -  addr1qy2jt0qpqz2z2z9zx5w4xemekkce7yderz53kjue53lpqv90lkfa9sgrfjuz6uvt4uqtrqhl2kj0a9lnr9ndzutx32gqleeckv
+                -  addr1q9xvgr4ehvu5k5tmaly7ugpnvekpqvnxj8xy50pa7kyetlnhel389pa4rnq6fmkzwsaynmw0mnldhlmchn2sfd589fgsz9dd0y
               _after_block_height: 6238675
       description: Array of Cardano payment address(es)
     stake_addresses_with_epoch_no:
@@ -2701,8 +2701,8 @@ components:
                 description: Only fetch information for a specific epoch
             example:
               _stake_addresses:
-                - stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
-                - stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
+                -  stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
+                -  stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
               _epoch_no: 409
       description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
     stake_addresses_with_first_only_and_empty:
@@ -2728,8 +2728,8 @@ components:
                 description: Include zero quantity entries
             example:
               _stake_addresses:
-                - stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
-                - stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
+                -  stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
+                -  stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
               _first_only: false
               _empty: false
       description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
@@ -2752,8 +2752,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _stake_addresses:
-                - stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
-                - stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
+                -  stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
+                -  stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
               _extended: true
       description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
     stake_addresses:
@@ -2771,8 +2771,8 @@ components:
                 description: Array of Cardano stake address(es) in bech32 format
             example:
               _stake_addresses:
-                - stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
-                - stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
+                -  stake1uyrx65wjqjgeeksd8hptmcgl5jfyrqkfq0xe8xlp367kphsckq250
+                -  stake1uxpdrerp9wrxunfh6ukyv5267j70fzxgw0fr3z8zeac5vyqhf9jhy
       description: Array of Cardano stake credential(s) in bech32 format
     credential_txs:
       content:
@@ -2793,8 +2793,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _payment_credentials:
-                - 025b0a8f85cb8a46e1dda3fae5d22f07e2d56abb4019a2129c5d6c52
-                - 13f6870c5e4f3b242463e4dc1f2f56b02a032d3797d933816f15e555
+                -  025b0a8f85cb8a46e1dda3fae5d22f07e2d56abb4019a2129c5d6c52
+                -  13f6870c5e4f3b242463e4dc1f2f56b02a032d3797d933816f15e555
               _after_block_height: 6238675
       description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
     credential_utxos:
@@ -2813,11 +2813,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _payment_credentials:
-                - 025b0a8f85cb8a46e1dda3fae5d22f07e2d56abb4019a2129c5d6c52
-                - 13f6870c5e4f3b242463e4dc1f2f56b02a032d3797d933816f15e555
+                -  025b0a8f85cb8a46e1dda3fae5d22f07e2d56abb4019a2129c5d6c52
+                -  13f6870c5e4f3b242463e4dc1f2f56b02a032d3797d933816f15e555
               _extended: true
       description: Array of Cardano payment credential(s) in hex format
     tx_ids:
@@ -2835,8 +2835,8 @@ components:
                 description: Array of Cardano Transaction hashes
             example:
               _tx_hashes:
-                - f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-                - 0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94
+                -  f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+                -  0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94
       description: Array of Cardano Transaction hashes
     tx_info:
       content:
@@ -2885,8 +2885,8 @@ components:
                 description: Controls whether to include governance certificates, votes and proposals in the result
             example:
               _tx_hashes:
-                - f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-                - 0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94
+                -  f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+                -  0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94
               _inputs: false
               _metadata: false
               _assets: false
@@ -2918,9 +2918,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool100wj94uzf54vup2hdzk0afng4dhjaqggt7j434mtgm8v2gfvfgp
-                - pool102s2nqtea2hf5q0s4amj0evysmfnhrn4apyyhd4azcmsclzm96m
-                - pool102vsulhfx8ua2j9fwl2u7gv57fhhutc3tp6juzaefgrn7ae35wm
+                -  pool100wj94uzf54vup2hdzk0afng4dhjaqggt7j434mtgm8v2gfvfgp
+                -  pool102s2nqtea2hf5q0s4amj0evysmfnhrn4apyyhd4azcmsclzm96m
+                -  pool102vsulhfx8ua2j9fwl2u7gv57fhhutc3tp6juzaefgrn7ae35wm
       description: Array of Cardano pool IDs (bech32 format)
     pool_ids_optional:
       content:
@@ -2935,9 +2935,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool100wj94uzf54vup2hdzk0afng4dhjaqggt7j434mtgm8v2gfvfgp
-                - pool102s2nqtea2hf5q0s4amj0evysmfnhrn4apyyhd4azcmsclzm96m
-                - pool102vsulhfx8ua2j9fwl2u7gv57fhhutc3tp6juzaefgrn7ae35wm
+                -  pool100wj94uzf54vup2hdzk0afng4dhjaqggt7j434mtgm8v2gfvfgp
+                -  pool102s2nqtea2hf5q0s4amj0evysmfnhrn4apyyhd4azcmsclzm96m
+                -  pool102vsulhfx8ua2j9fwl2u7gv57fhhutc3tp6juzaefgrn7ae35wm
       description: Array of Cardano pool IDs (bech32 format) [Optional]
     script_hashes:
       content:
@@ -2952,8 +2952,8 @@ components:
                 description: Array of Cardano script hashes
             example:
               _script_hashes:
-                  - bd2119ee2bfb8c8d7c427e8af3c35d537534281e09e23013bca5b138
-                  - c0c671fba483641a71bb92d3a8b7c52c90bf1c01e2b83116ad7d4536
+                -  bd2119ee2bfb8c8d7c427e8af3c35d537534281e09e23013bca5b138
+                -  c0c671fba483641a71bb92d3a8b7c52c90bf1c01e2b83116ad7d4536
       description: Array of Cardano script hashes
     datum_hashes:
       content:
@@ -2968,8 +2968,8 @@ components:
                 description: Array of Cardano datum hashes
             example:
               _datum_hashes:
-                  - 818ee3db3bbbd04f9f2ce21778cac3ac605802a4fcb00c8b3a58ee2dafc17d46
-                  - 45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
+                -  818ee3db3bbbd04f9f2ce21778cac3ac605802a4fcb00c8b3a58ee2dafc17d46
+                -  45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0
       description: Array of Cardano datum hashes
     asset_list:
       content:
@@ -2988,8 +2988,8 @@ components:
                     type: string
             example:
               _asset_list:
-                - ['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']
-                - ['f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a','6b6f696f732e72657374']
+                -  ['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']
+                -  ['f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a','6b6f696f732e72657374']
       description: Array of array of policyID and asset names (hex)
     asset_list_with_extended:
       content:
@@ -3012,8 +3012,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _asset_list:
-                - ['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']
-                - ['f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a','6b6f696f732e72657374']
+                -  ['750900e4999ebe0d58f19b634768ba25e525aaf12403bfe8fe130501','424f4f4b']
+                -  ['f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a','6b6f696f732e72657374']
               _extended: true
       description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
     drep_id_bulk:
@@ -3031,8 +3031,8 @@ components:
                   type: string
             example:
               _drep_ids:
-                - drep17l6sywnwqu9aedd6aumev42w39ln5zfl9nw7j4ak6u8swyrwvz3
-                - drep1s9q5uyddsvza4uk2n9wswy90n8wx9d2jmrq4zgcvlyv055007av
+                -  drep17l6sywnwqu9aedd6aumev42w39ln5zfl9nw7j4ak6u8swyrwvz3
+                -  drep1s9q5uyddsvza4uk2n9wswy90n8wx9d2jmrq4zgcvlyv055007av
     utxo_refs_with_extended:
       content:
         application/json:
@@ -3049,11 +3049,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _utxo_refs:
-                - f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e#0
-                - 0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94#0
+                -  f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e#0
+                -  0b8ba3bed976fa4913f19adc9f6dd9063138db5b4dd29cecde369456b5155e94#0
               _extended: false
       description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
     ogmios:
@@ -3072,7 +3072,22 @@ components:
               method:
                 type: string
                 description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
-                enum: ["queryNetwork/blockHeight","queryNetwork/genesisConfiguration","queryNetwork/startTime","queryNetwork/tip","queryLedgerState/epoch","queryLedgerState/eraStart","queryLedgerState/eraSummaries","queryLedgerState/liveStakeDistribution","queryLedgerState/protocolParameters","queryLedgerState/proposedProtocolParameters","queryLedgerState/stakePools","submitTransaction","evaluateTransaction"]
+                enum:
+                  [
+                    "queryNetwork/blockHeight",
+                    "queryNetwork/genesisConfiguration",
+                    "queryNetwork/startTime",
+                    "queryNetwork/tip",
+                    "queryLedgerState/epoch",
+                    "queryLedgerState/eraStart",
+                    "queryLedgerState/eraSummaries",
+                    "queryLedgerState/liveStakeDistribution",
+                    "queryLedgerState/protocolParameters",
+                    "queryLedgerState/proposedProtocolParameters",
+                    "queryLedgerState/stakePools",
+                    "submitTransaction",
+                    "evaluateTransaction",
+                  ]
                 example: "queryNetwork/tip"
               params:
                 type: object
@@ -3084,7 +3099,12 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
             genesisConfiguration:
               description: Query the genesis configuration of a given era.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/genesisConfiguration", "params": { "era": "shelley" } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryNetwork/genesisConfiguration",
+                  "params": { "era": "shelley" },
+                }
             startTimeTime:
               description: Query the network start time.
               value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
@@ -3099,25 +3119,61 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
             eraSummaries:
               description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
+              value:
+                { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
             liveStakeDistribution:
               description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/liveStakeDistribution" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/liveStakeDistribution",
+                }
             protocolParameters:
               description: Query the current protocol parameters.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/protocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/protocolParameters",
+                }
             proposedProtocolParameters:
               description: Query the last update proposal w.r.t. protocol parameters, if any.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/proposedProtocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/proposedProtocolParameters",
+                }
             StakePools:
               description: Query the list of all stake pool identifiers currently registered and active.
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
             submitTransaction:
               description: Submit a signed and serialized transaction to the network.
-              value: { "jsonrpc": "2.0", "method": "submitTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" } } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "submitTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                    },
+                }
             evaluateTransaction:
               description: Evaluate execution units of scripts in a well-formed transaction.
-              value: { "jsonrpc": "2.0", "method": "evaluateTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" }, "additionalUtxo": [ { ... } ] } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "evaluateTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                      "additionalUtxo": [{ ... }],
+                    },
+                }
       description: JSON-RPC 2.0 standard request body
   securitySchemes:
     bearerAuth:
@@ -3244,6 +3300,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array
@@ -3260,7 +3328,7 @@ components:
           data:
             type: string
             description: JSON encoded data with details about the parameter update
-            example: {"decentralisation": 0.9}
+            example: { "decentralisation": 0.9 }
     cli_protocol_params:
       description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
       type: object
@@ -3277,10 +3345,7 @@ components:
           "monetaryExpansion": 3.0e-3,
           "poolPledgeInfluence": 0.3,
           "poolRetireMaxEpoch": 18,
-          "protocolVersion": {
-            "major": 8,
-            "minor": 0
-          },
+          "protocolVersion": { "major": 8, "minor": 0 },
           "...": "...",
           "stakeAddressDeposit": 2000000,
           "stakePoolDeposit": 500000000,
@@ -3288,7 +3353,7 @@ components:
           "treasuryCut": 0.2,
           "txFeeFixed": 155381,
           "txFeePerByte": 44,
-          "utxoCostPerByte": 4310
+          "utxoCostPerByte": 4310,
         }
     reserve_withdrawals:
       description: Array of withdrawals from reserves/treasury against stake accounts
@@ -3317,6 +3382,7 @@ components:
             description: Epoch where the earned amount can be spent
             allOf:
               - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+
     pool_list:
       description: Array of pool IDs and tickers
       type: array
@@ -3345,7 +3411,7 @@ components:
           ticker:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ticker
             example: AHL
           pool_group:
@@ -3375,7 +3441,7 @@ components:
           active_stake_pct:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Active stake for the pool, expressed as a percentage of total active stake on network
             example: 13.512182543475783
           saturation_pct:
@@ -3385,7 +3451,7 @@ components:
           block_cnt:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of blocks pool created in that epoch
             example: 14
           delegator_cnt:
@@ -3411,7 +3477,7 @@ components:
           member_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
             example: "123456780123"
           epoch_ros:
@@ -3455,49 +3521,49 @@ components:
           vrf_key_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool VRF key hash
             example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
           margin:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Margin (decimal format)
             example: 0.1
           fixed_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool fixed cost per epoch
             example: "500000000"
           pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool pledge in number
             example: "64000000000000"
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool's registration deposit in number
             example: "500000000"
           reward_addr:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool reward address
             example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
           reward_addr_delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           owners:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               type: string
               description: Pool (co)owner address
@@ -3510,49 +3576,49 @@ components:
                 dns:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS name of the relay (nullable)
                   example: relays-new.cardano-mainnet.iohk.io
                 srv:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS service name of the relay (nullable)
                   example: biostakingpool3.hopto.org
                 ipv4:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv4 address of the relay (nullable)
                   example: "54.220.20.40"
                 ipv6:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv6 address of the relay (nullable)
                   example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
                 port:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Port number of the relay (nullable)
                   example: 6000
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata URL
             example: https://pools.iohk.io/IOGP.json
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             properties:
               name:
                 type: string
@@ -3578,49 +3644,49 @@ components:
           retiring_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Announced retiring epoch (nullable)
             example: null
           op_cert:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           op_cert_counter:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate counter value
             example: 8
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Amount of delegated stake to this pool at the time of epoch snapshot
             example: "64328627680963"
           sigma:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool relative active stake share
             example: 0.0034839235
           block_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Total pool blocks on chain
             example: 4509
           live_pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Summary of account balance for all pool owner's
             example: "64328594406327"
           live_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool live stake
             example: "64328627680963"
           live_delegators:
@@ -3630,13 +3696,13 @@ components:
           live_saturation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool live saturation (decimal format)
             example: 94.52
           voting_power:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Current voting power (lovelaces) of this stake pool
             example: "123456789"
     pool_snapshot:
@@ -3707,7 +3773,7 @@ components:
       description: Array of pool delegators (historical)
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         type: object
         properties:
@@ -3754,7 +3820,7 @@ components:
           active_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Epoch number in which the update becomes active
             example: 324
           vrf_key_hash:
@@ -3847,7 +3913,7 @@ components:
           pool_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A group that the pool was identified to be associated with
             example: IOG
           ticker:
@@ -3855,15 +3921,16 @@ components:
           adastat_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per adastat.net
             example: iohk.io
           balanceanalytics_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per balanceanalytics.io
             example: IOG
+
     epoch_info:
       description: Array of detailed summary for each epoch
       type: array
@@ -3909,19 +3976,19 @@ components:
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
             example: "23395112387185880"
           total_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total rewards earned in epoch (null for pre-Shelley epochs)
             example: "252902897534230"
           avg_blk_reward:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Average block reward for epoch (null for pre-Shelley epochs)
             example: "660233450"
     epoch_params:
@@ -3936,119 +4003,119 @@ components:
           min_fee_a:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'a' parameter to calculate the minimum transaction fee
             example: 44
           min_fee_b:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'b' parameter to calculate the minimum transaction fee
             example: 155381
           max_block_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block size (in bytes)
             example: 65536
           max_tx_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum transaction size (in bytes)
             example: 16384
           max_bh_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block header size (in bytes)
             example: 1100
           key_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake address
             example: "2000000"
           pool_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake pool
             example: "500000000"
           max_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
             example: 18
           optimal_pool_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The optimal number of stake pools
             example: 500
           influence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The pledge influence on pool rewards
             example: 0.3
           monetary_expand_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The monetary expansion rate
             example: 0.003
           treasury_growth_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The treasury growth rate
             example: 0.2
           decentralisation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
             example: 0.1
           extra_entropy:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
             example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
           protocol_major:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol major version
             example: 5
           protocol_minor:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol minor version
             example: 0
           min_utxo_value:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum value of a UTxO entry
             example: "34482"
           min_pool_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum pool cost
             example: "340000000"
           nonce:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The nonce value for this epoch
             example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
           block_hash:
@@ -4058,201 +4125,201 @@ components:
           cost_models:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The per language cost model in JSON
             example: null
           price_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The per word cost of script memory usage
             example: 0.0577
           price_step:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The cost of script execution step usage
             example: 7.21e-05
           max_tx_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single transaction
             example: 10000000
           max_tx_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single transaction
             example: 10000000000
           max_block_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single block
             example: 50000000
           max_block_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single block
             example: 40000000000
           max_val_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum Val size
             example: 5000
           collateral_percent:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
             example: 150
           max_collateral_inputs:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of collateral inputs allowed in a transaction
             example: 3
           coins_per_utxo_size:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The cost per UTxO size
             example: "34482"
           pvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for motion of no-confidence.
             example: 0.6
           pvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (normal state).
             example: 0.65
           pvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           pvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for hard-fork initiation.
             example: 0.51
           dvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for motion of no-confidence.
             example: 0.67
           dvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (normal state).
             example: 0.67
           dvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           dvt_update_to_constitution:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for update to the Constitution.
             example: 0.75
           dvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for hard-fork initiation.
             example: 0.6
           dvt_p_p_network_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, network group.
             example: 0.67
           dvt_p_p_economic_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, economic group.
             example: 0.67
           dvt_p_p_technical_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, technical group.
             example: 0.67
           dvt_p_p_gov_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, governance group.
             example: 0.75
           dvt_treasury_withdrawal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for treasury withdrawal.
             example: 0.67
           committee_min_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimal constitutional committee size.
             example: 5
           committee_max_term_length:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Constitutional committee term limits.
             example: 146
           gov_action_lifetime:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Governance action expiration.
             example: 14
           gov_action_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Governance action deposit.
             example: 100000000000
           drep_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep deposit amount.
             example: 500000000
           drep_activity:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep activity period.
             example: 20
           pvtpp_security_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for protocol parameter changes, security group.
             example: 0.6
           min_fee_ref_script_cost_per_byte:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimum Fee for Reference Script cost pre byte
             example: 15
     epoch_block_protocols:
@@ -4272,6 +4339,7 @@ components:
             type: number
             description: Amount of blocks with specified major and protocol combination
             example: 2183
+
     blocks:
       description: Array of block information
       type: array
@@ -4317,7 +4385,7 @@ components:
           pool:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ID in bech32 format (null for pre-Shelley blocks)
             example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
           op_cert_counter:
@@ -4371,13 +4439,13 @@ components:
           total_output:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total output of the block (in number)
             example: "92384672389"
           total_fees:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total fees of the block (in number)
             example: "2346834"
           num_confirmations:
@@ -4473,8 +4541,8 @@ components:
           inputs:
             description: An array of UTxO inputs spent in the transaction
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           outputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
           withdrawals:
@@ -4489,6 +4557,7 @@ components:
             $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
           plutus_contracts:
             $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
+
     address_info:
       description: Array of information for address(es)
       type: array
@@ -4503,8 +4572,8 @@ components:
             example: "10723473983"
           stake_address:
             anyOf:
-            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            - type: 'null'
+              - $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              - type: "null"
           script_address:
             type: boolean
             description: Signifies whether the address is a script address
@@ -4606,7 +4675,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script hash in case the stake address is locked by a script
             example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
     account_info:
@@ -4625,13 +4694,13 @@ components:
           delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           delegated_pool:
             anyOf:
-            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-            - type: 'null'
+              - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+              - type: "null"
           total_balance:
             type: string
             description: Total balance of the account including UTxO, rewards and MIRs (in number)
@@ -4668,109 +4737,6 @@ components:
             type: string
             description: Total proposal refund for this account
             example: "0"
-    utxo_infos:
-      description: Array of complete UTxO information
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          inline_datum:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-          reference_script:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-          asset_list:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: An array of assets on the UTxO
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of assets on the UTxO
-                  example: "1"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    tx_outs_epoch:
-      description: List of transaction outputs with basic details for requested epoch
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
     account_rewards:
       description: Array of reward history information
       type: array
@@ -4799,7 +4765,7 @@ components:
                 pool_id:
                   anyOf:
                     - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-                    - type: 'null'
+                    - type: "null"
     account_reward_history:
       description: Array of reward history information
       type: array
@@ -4823,7 +4789,7 @@ components:
           pool_id_bech32:
             anyOf:
               - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-              - type: 'null'
+              - type: "null"
     account_updates:
       description: Array of account updates information
       type: array
@@ -4840,7 +4806,14 @@ components:
                 action_type:
                   type: string
                   description: Type of certificate submitted
-                  enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+                  enum:
+                    [
+                      "registration",
+                      "delegation_pool",
+                      "delegation_drep",
+                      "withdrawal",
+                      "deregistration",
+                    ]
                   example: "registration"
                 tx_hash:
                   $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4863,7 +4836,14 @@ components:
           action_type:
             type: string
             description: Type of certificate submitted
-            enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+            enum:
+              [
+                "registration",
+                "delegation_pool",
+                "delegation_drep",
+                "withdrawal",
+                "deregistration",
+              ]
             example: "registration"
           tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4952,6 +4932,7 @@ components:
             type: string
             description: Active stake amount (in numbers)
             example: 682334162
+
     tx_info:
       description: Array of detailed information about transaction(s)
       type: array
@@ -5001,25 +4982,25 @@ components:
           invalid_before:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot before which transaction cannot be validated (if supplied, else null)
             example: "42331172"
           invalid_after:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot after which transaction cannot be validated
             example: "42332172"
           collateral_inputs:
             description: An array of collateral inputs needed for smart contracts in case of contract failure
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           collateral_output:
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               properties:
                 payment_addr:
@@ -5045,7 +5026,7 @@ components:
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
             anyOf:
               - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-              - type: 'null'
+              - type: "null"
           inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             #description: An array of UTxO inputs spent in the transaction
@@ -5077,13 +5058,13 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
-                  description: Hash of datum (if any) connected to UTxO 
+                    - type: "null"
+                  description: Hash of datum (if any) connected to UTxO
                   example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
                 inline_datum:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allows datums to be attached to UTxO (CIP-32)
                   properties:
                     bytes:
@@ -5097,7 +5078,7 @@ components:
                 reference_script:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
                   properties:
                     hash:
@@ -5119,7 +5100,7 @@ components:
                     value:
                       anyOf:
                         - type: object
-                        - type: 'null'
+                        - type: "null"
                       description: Value (json)
                       example: null
                 asset_list:
@@ -5127,7 +5108,7 @@ components:
           withdrawals:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of withdrawals with-in a transaction
             items:
               type: object
@@ -5143,7 +5124,7 @@ components:
           assets_minted:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of minted assets with-in a transaction
             items:
               properties:
@@ -5164,14 +5145,14 @@ components:
           certificates:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Certificates present with-in a transaction (if any)
             items:
               properties:
                 index:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Certificate index
                   example: 0
                 type:
@@ -5181,7 +5162,7 @@ components:
                 info:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: A JSON array containing information from the certificate
                   example:
                     {
@@ -5191,7 +5172,7 @@ components:
           native_scripts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Native scripts present in a transaction (if any)
             items:
               properties:
@@ -5222,20 +5203,20 @@ components:
           plutus_contracts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Plutus contracts present in transaction (if any)
             items:
               properties:
                 address:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
                 spends_input:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   properties:
                     tx_hash:
                       $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -5286,7 +5267,7 @@ components:
           voting_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance votes in a transaction (if any)
             items:
               properties:
@@ -5305,7 +5286,7 @@ components:
           proposal_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance proposals in a transaction (if any)
             items:
               properties:
@@ -5390,7 +5371,7 @@ components:
       description: Array of metadata information present in each of the transactions queried
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         properties:
           tx_hash:
@@ -5398,7 +5379,7 @@ components:
           metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: A JSON array containing details about metadata within transaction
             example:
               {
@@ -5421,7 +5402,7 @@ components:
           num_confirmations:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of block confirmations
             example: 17
     tx_metalabels:
@@ -5433,6 +5414,130 @@ components:
             type: string
             description: A distinct known metalabel
             example: "721"
+    utxo_infos:
+      description: Array of complete UTxO information
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          inline_datum:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+          reference_script:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+          asset_list:
+            anyOf:
+              - type: array
+              - type: "null"
+            description: An array of assets on the UTxO
+            items:
+              properties:
+                policy_id:
+                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+                asset_name:
+                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+                fingerprint:
+                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+                quantity:
+                  type: string
+                  description: Quantity of assets on the UTxO
+                  example: "1"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_outs_epoch:
+      description: List of transaction outputs with basic details for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_treasury_donations_epoch:
+      description: List of treasury donation transactions for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          tx_hash:
+            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+          block_hash:
+            $ref: "#/components/schemas/blocks/items/properties/hash"
+          tx_block_index:
+            $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          treasury_donation:
+            $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+
     asset_list:
       description: Array of policy IDs and asset names
       type: array
@@ -5530,7 +5635,7 @@ components:
           asset_name:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Asset Name (hex)
             example: 444f4e545350414d
           asset_name_ascii:
@@ -5568,33 +5673,33 @@ components:
           token_registry_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Asset metadata registered on the Cardano Token Registry
             properties:
               name:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Rackmob
               description:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Metaverse Blockchain Cryptocurrency.
               ticker:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: MOB
               url:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: https://www.rackmob.com/
               logo:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: A PNG image file as a byte string
                 example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
               decimals:
@@ -5603,9 +5708,27 @@ components:
           cip68_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: CIP 68 metadata if present for asset
-            example: {"222": {"fields": [{"map": [{"k": {"bytes": "6e616d65"}, "v": {"bytes": "74657374"}}]}], "constructor": 0}}
+            example:
+              {
+                "222":
+                  {
+                    "fields":
+                      [
+                        {
+                          "map":
+                            [
+                              {
+                                "k": { "bytes": "6e616d65" },
+                                "v": { "bytes": "74657374" },
+                              },
+                            ],
+                        },
+                      ],
+                    "constructor": 0,
+                  },
+              }
     asset_history:
       description: Array of asset mint/burn history
       type: array
@@ -5620,7 +5743,7 @@ components:
           minting_txs:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of all mint/burn transactions for an asset
             items:
               type: object
@@ -5640,6 +5763,7 @@ components:
                   description: Array of Transaction Metadata for given transaction
                   items:
                     $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+
     policy_asset_addresses:
       description: Array of asset names and payment addresses for the given policy (including balances)
       type: array
@@ -5716,6 +5840,7 @@ components:
             $ref: "#/components/schemas/asset_info/items/properties/total_supply"
           decimals:
             $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+
     drep_info:
       description: Get detailed information about requested delegated representatives (DReps)
       type: array
@@ -5740,7 +5865,7 @@ components:
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep's registration deposit  in number
             example: "500000000"
           active:
@@ -5750,7 +5875,7 @@ components:
           expires_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: After which epoch DRep is considered inactive.
             example: 410
           amount:
@@ -5760,13 +5885,13 @@ components:
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A URL to a JSON payload of metadata
             example: "https://hornan7.github.io/Vote_Context.jsonld"
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A hash of the contents of the metadata URL
             example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
     drep_epoch_summary:
@@ -5832,36 +5957,121 @@ components:
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The payload as JSON
             example:
-              {"body": {"title": "...", "...": "...", "references": [{"uri": "...", "@type": "Other", "label": "Hardfork to PV10"}]}, "authors": [{"name": "...", "witness": {"publicKey": "...", "signature": "...", "witnessAlgorithm": "ed25519"}}], "@context": {"body": {"@id": "CIP108:body", "@context": {"title": "CIP108:title", "abstract": "CIP108:abstract", "rationale": "CIP108:rationale", "motivation": "CIP108:motivation", "references": {"@id": "CIP108:references", "@context": {"uri": "CIP100:reference-uri", "Other": "CIP100:OtherReference", "label": "CIP100:reference-label", "referenceHash": {"@id": "CIP108:referenceHash", "@context": {"hashDigest": "CIP108:hashDigest", "hashAlgorithm": "CIP100:hashAlgorithm"}}, "GovernanceMetadata": "CIP100:GovernanceMetadataReference"}, "@container": "@set"}}}, "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#", "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#", "authors": {"@id": "CIP100:authors", "@context": {"name": "http://xmlns.com/foaf/0.1/name", "witness": {"@id": "CIP100:witness", "@context": {"publicKey": "CIP100:publicKey", "signature": "CIP100:signature", "witnessAlgorithm": "CIP100:witnessAlgorithm"}}}, "@container": "@set"}, "@language": "en-us", "hashAlgorithm": "CIP100:hashAlgorithm"}, "hashAlgorithm": "blake2b-256"}
+              {
+                "body":
+                  {
+                    "title": "...",
+                    "...": "...",
+                    "references":
+                      [
+                        {
+                          "uri": "...",
+                          "@type": "Other",
+                          "label": "Hardfork to PV10",
+                        },
+                      ],
+                  },
+                "authors":
+                  [
+                    {
+                      "name": "...",
+                      "witness":
+                        {
+                          "publicKey": "...",
+                          "signature": "...",
+                          "witnessAlgorithm": "ed25519",
+                        },
+                    },
+                  ],
+                "@context":
+                  {
+                    "body":
+                      {
+                        "@id": "CIP108:body",
+                        "@context":
+                          {
+                            "title": "CIP108:title",
+                            "abstract": "CIP108:abstract",
+                            "rationale": "CIP108:rationale",
+                            "motivation": "CIP108:motivation",
+                            "references":
+                              {
+                                "@id": "CIP108:references",
+                                "@context":
+                                  {
+                                    "uri": "CIP100:reference-uri",
+                                    "Other": "CIP100:OtherReference",
+                                    "label": "CIP100:reference-label",
+                                    "referenceHash":
+                                      {
+                                        "@id": "CIP108:referenceHash",
+                                        "@context":
+                                          {
+                                            "hashDigest": "CIP108:hashDigest",
+                                            "hashAlgorithm": "CIP100:hashAlgorithm",
+                                          },
+                                      },
+                                    "GovernanceMetadata": "CIP100:GovernanceMetadataReference",
+                                  },
+                                "@container": "@set",
+                              },
+                          },
+                      },
+                    "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
+                    "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#",
+                    "authors":
+                      {
+                        "@id": "CIP100:authors",
+                        "@context":
+                          {
+                            "name": "http://xmlns.com/foaf/0.1/name",
+                            "witness":
+                              {
+                                "@id": "CIP100:witness",
+                                "@context":
+                                  {
+                                    "publicKey": "CIP100:publicKey",
+                                    "signature": "CIP100:signature",
+                                    "witnessAlgorithm": "CIP100:witnessAlgorithm",
+                                  },
+                              },
+                          },
+                        "@container": "@set",
+                      },
+                    "@language": "en-us",
+                    "hashAlgorithm": "CIP100:hashAlgorithm",
+                  },
+                "hashAlgorithm": "blake2b-256",
+              }
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The raw bytes of the payload
             example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
           warning:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A warning that occured while validating the metadata
           language:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The language described in the context of the metadata as per CIP-100
             example: en-us
           comment:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Comment attached to the metadata
           is_valid:
             anyOf:
               - type: boolean
-              - type: 'null'
+              - type: "null"
             description: Indicate whether data is invalid (currently returns null for all as per dbsync)
             example: null
     drep_updates:
@@ -5886,7 +6096,7 @@ components:
           action:
             type: string
             description: Effective action for this DRep Update certificate
-            enum: ["updated","registered","deregistered"]
+            enum: ["updated", "registered", "deregistered"]
             example: registered
           deposit:
             $ref: "#/components/schemas/drep_info/items/properties/deposit"
@@ -5907,8 +6117,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the DRep
             example: "14231445553"
     drep_votes:
@@ -5928,7 +6138,7 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/block_time"
           vote:
             type: string
-            enum: ["Yes","No","Abstain"]
+            enum: ["Yes", "No", "Abstain"]
             description: Actual Vote casted
             example: "Yes"
           meta_url:
@@ -5946,8 +6156,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the pool for the epoch
             example: "11231445553"
     pool_votes:
@@ -5970,7 +6180,7 @@ components:
           proposal_id:
             type: string
             description: Proposal Action ID in accordance with CIP-129 format
-            example: 'gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh'
+            example: "gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh"
           proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           proposal_index:
@@ -5979,7 +6189,16 @@ components:
             example: 0
           proposal_type:
             type: string
-            enum: ["ParameterChange", "HardForkInitiation", "TreasuryWithdrawals", "NoConfidence", "NewCommittee", "NewConstitution", "InfoAction"]
+            enum:
+              [
+                "ParameterChange",
+                "HardForkInitiation",
+                "TreasuryWithdrawals",
+                "NoConfidence",
+                "NewCommittee",
+                "NewConstitution",
+                "InfoAction",
+              ]
             description: Proposal Action Type
             example: ParameterChange
           proposal_description:
@@ -5999,31 +6218,31 @@ components:
           ratified_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been ratified at the specfied epoch.
             example: 670
           enacted_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been enacted at the specfied epoch.
             example: 675
           dropped_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
             example: 680
           expired_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been expired at the specfied epoch.
             example: 680
           expiration:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Shows the epoch at which this governance action is expected to expire.
           meta_url:
             $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
@@ -6040,7 +6259,7 @@ components:
           withdrawal:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: If not null, the amount withdrawn from treasury into stake address by this this proposal
             properties:
               stake_address:
@@ -6052,8 +6271,8 @@ components:
             description: If not null, the proposed new parameter set
             anyOf:
               - type: object
-              - type: 'null'
-            example: {"key_deposit": 1000000}
+              - type: "null"
+            example: { "key_deposit": 1000000 }
     voter_proposal_list:
       description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
       type: array
@@ -6281,7 +6500,7 @@ components:
               status:
                 type: string
                 description: Member authentication status
-                enum: [ "authorized", "not_authorized", "resigned" ]
+                enum: ["authorized", "not_authorized", "resigned"]
                 example: authorized
               cc_cold_hex:
                 type: string
@@ -6294,19 +6513,20 @@ components:
               cc_hot_hex:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: Committee member key hash from last valid hot key authorization certificate in hex format
                 example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
               cc_hot_has_script:
                 anyOf:
                   - type: boolean
-                  - type: 'null'
+                  - type: "null"
                 description: Flag which shows if this credential is a script hash
                 example: false
               expiration_epoch:
                 type: number
                 description: Epoch number in which the committee member vote rights expire
                 example: 324
+
     script_info:
       type: array
       items:
@@ -6315,7 +6535,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Hash of a script
             example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
           creation_tx_hash:
@@ -6325,18 +6545,18 @@ components:
           type:
             type: string
             description: Type of the script
-            enum: ["plutusV1","plutusV2","timelock","multisig"]
+            enum: ["plutusV1", "plutusV2", "timelock", "multisig"]
             example: plutusV1
           value:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Data in JSON format
             example: null
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script bytes (cborSeq)
             example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
           size:
@@ -6377,14 +6597,14 @@ components:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Memory to run a script
                   example: 520448
                 unit_steps:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Cpu steps to run a script
                   example: 211535239
                 fee:
@@ -6399,7 +6619,7 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: The Hash of the Plutus Data
                   example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
                 datum_value:
@@ -6418,6 +6638,7 @@ components:
             $ref: "#/components/schemas/script_info/items/properties/value"
           bytes:
             $ref: "#/components/schemas/script_info/items/properties/bytes"
+
     ogmiostip:
       description: Current tip of the chain, identified by a slot and a block header hash.
       type: object
@@ -6436,7 +6657,7 @@ components:
             - type: number
             - type: array
             - type: object
-            - type: 'null'
+            - type: "null"
           description: Result of the query
           properties:
             slot:
@@ -6447,7 +6668,11 @@ components:
               type: string
               description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
               example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
-          example: {"slot": 59886800, "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"}
+          example:
+            {
+              "slot": 59886800,
+              "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1",
+            }
   headers: {}
   responses:
     NotFound:

--- a/specs/results/koiosapi-preprod.yaml
+++ b/specs/results/koiosapi-preprod.yaml
@@ -157,7 +157,6 @@ servers:
   - url: https://sancho.koios.rest/api/v1
     description: Sanchonet Network
 paths:
-
   /tip: #RPC
     get:
       tags:
@@ -490,7 +489,7 @@ paths:
       operationId: block_tx_info
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /utxo_info: #RPC
     post:
@@ -700,7 +699,7 @@ paths:
       operationId: tx_utxos
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /address_info: #RPC
     post:
@@ -992,7 +991,7 @@ paths:
       operationId: account_rewards
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_reward_history: #RPC
     post:
       tags:
@@ -1133,7 +1132,7 @@ paths:
       operationId: account_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_stake_history: #RPC
     post:
       tags:
@@ -1308,8 +1307,8 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Addresses
       description: Get the list of all addresses holding a given asset <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: asset_addresses
   /asset_nft_address: #RPC
@@ -1355,9 +1354,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Policy Asset Address List
-      description: Get the list of addresses with quantity for each asset on the given policy <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+      description:
+        Get the list of addresses with quantity for each asset on the given policy <br><br>
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: policy_asset_addresses
   /policy_asset_info: #RPC
@@ -1587,7 +1587,7 @@ paths:
       operationId: drep_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_voting_power_history: #RPC
     get:
       tags:
@@ -1636,7 +1636,7 @@ paths:
       operationId: drep_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_delegators: #RPC
     get:
       tags:
@@ -1790,7 +1790,7 @@ paths:
   /vote_list: #RPC
     get:
       tags:
-        - Governance      
+        - Governance
       responses:
         "200":
           description: Success!!
@@ -2124,8 +2124,8 @@ paths:
       operationId: pool_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
-  
+          label: "Deprecated"
+
   /pool_groups: #RPC
     get:
       tags:
@@ -2343,7 +2343,7 @@ paths:
         We do support transparent forwarding for various methods from Ogmios, you can read about those <a href="#tag--Ogmios">here</a>.
         </div>
       operationId: ogmios
-        
+
 components:
   parameters:
     _after_block_height:
@@ -2561,9 +2561,9 @@ components:
                   $ref: "#/components/schemas/blocks/items/properties/hash"
             example:
               _block_hashes:
-                - 2abeb8d1c1227139763be30ddb7a2fd79abd7d44195fca87a7c836a510b2802d
-                - 4e790b758c495953bb33c4aad4a4b4c1b98f7c2ec135ebd3db21f32059481718
-                - 389da613316d2aec61edc34d51f1b3d004891ab38c9419771e5e0a3b12de3ef6
+                -  2abeb8d1c1227139763be30ddb7a2fd79abd7d44195fca87a7c836a510b2802d
+                -  4e790b758c495953bb33c4aad4a4b4c1b98f7c2ec135ebd3db21f32059481718
+                -  389da613316d2aec61edc34d51f1b3d004891ab38c9419771e5e0a3b12de3ef6
       description: Array of block hashes
     block_tx_info:
       content:
@@ -2607,9 +2607,9 @@ components:
                 description: Controls whether to include bytecode for associated reference/plutus scripts
             example:
               _block_hashes:
-                - 2abeb8d1c1227139763be30ddb7a2fd79abd7d44195fca87a7c836a510b2802d
-                - 4e790b758c495953bb33c4aad4a4b4c1b98f7c2ec135ebd3db21f32059481718
-                - 389da613316d2aec61edc34d51f1b3d004891ab38c9419771e5e0a3b12de3ef6
+                -  2abeb8d1c1227139763be30ddb7a2fd79abd7d44195fca87a7c836a510b2802d
+                -  4e790b758c495953bb33c4aad4a4b4c1b98f7c2ec135ebd3db21f32059481718
+                -  389da613316d2aec61edc34d51f1b3d004891ab38c9419771e5e0a3b12de3ef6
               _inputs: false
               _metadata: false
               _assets: false
@@ -2633,8 +2633,8 @@ components:
                 description: Array of Cardano payment address(es) in bech32 format
             example:
               _addresses:
-                - addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
       description: Array of Cardano payment address(es)
     payment_addresses_with_extended:
       content:
@@ -2655,8 +2655,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _addresses:
-                - addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
               _extended: true
       description: Array of Cardano payment address(es) with extended flag to toggle additional fields
     address_txs:
@@ -2678,8 +2678,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _addresses:
-                - addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
               _after_block_height: 9417
       description: Array of Cardano payment address(es)
     stake_addresses_with_epoch_no:
@@ -2701,8 +2701,8 @@ components:
                 description: Only fetch information for a specific epoch
             example:
               _stake_addresses:
-                - stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
-                - stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
+                -  stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
+                -  stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
               _epoch_no: 30
       description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
     stake_addresses_with_first_only_and_empty:
@@ -2728,8 +2728,8 @@ components:
                 description: Include zero quantity entries
             example:
               _stake_addresses:
-                - stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
-                - stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
+                -  stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
+                -  stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
               _first_only: false
               _empty: false
       description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
@@ -2752,8 +2752,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _stake_addresses:
-                - stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
-                - stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
+                -  stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
+                -  stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
               _extended: true
       description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
     stake_addresses:
@@ -2771,8 +2771,8 @@ components:
                 description: Array of Cardano stake address(es) in bech32 format
             example:
               _stake_addresses:
-                - stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
-                - stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
+                -  stake_test1urq4rcynzj4uxqc74c852zky7wa6epgmn9r6k3j3gv7502q8jks0l
+                -  stake_test1ur4t5nhceyn2amfuj7z74uxmmj8jf9fmgd2egqw8c98ve3cp2g4wx
       description: Array of Cardano stake credential(s) in bech32 format
     credential_txs:
       content:
@@ -2793,8 +2793,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _payment_credentials:
-                - b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d4436
-                - 82e016828989cd9d809b50d6976d9efa9bc5b2c1a78d4b3bfa1bb83b
+                -  b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d4436
+                -  82e016828989cd9d809b50d6976d9efa9bc5b2c1a78d4b3bfa1bb83b
               _after_block_height: 9417
       description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
     credential_utxos:
@@ -2813,11 +2813,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _payment_credentials:
-                - b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d4436
-                - 82e016828989cd9d809b50d6976d9efa9bc5b2c1a78d4b3bfa1bb83b
+                -  b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d4436
+                -  82e016828989cd9d809b50d6976d9efa9bc5b2c1a78d4b3bfa1bb83b
               _extended: true
       description: Array of Cardano payment credential(s) in hex format
     tx_ids:
@@ -2835,8 +2835,8 @@ components:
                 description: Array of Cardano Transaction hashes
             example:
               _tx_hashes:
-                - d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530
-                - 145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576
+                -  d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530
+                -  145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576
       description: Array of Cardano Transaction hashes
     tx_info:
       content:
@@ -2885,8 +2885,8 @@ components:
                 description: Controls whether to include governance certificates, votes and proposals in the result
             example:
               _tx_hashes:
-                - d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530
-                - 145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576
+                -  d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530
+                -  145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576
               _inputs: false
               _metadata: false
               _assets: false
@@ -2918,9 +2918,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool1ext7qrwjzaxcdfhdnkq5mth59ukuu2atcg6tgqpmevpt7ratkta
-                - pool1vw6fr9agt58djrp3w0t0lsn6t329t6eusqxz5ugd9w7ecyedsdv
-                - pool1ws42l6rawqjv58crs5l32v0eem3qnngpnjfd7epwd4lmjccc5cg
+                -  pool1ext7qrwjzaxcdfhdnkq5mth59ukuu2atcg6tgqpmevpt7ratkta
+                -  pool1vw6fr9agt58djrp3w0t0lsn6t329t6eusqxz5ugd9w7ecyedsdv
+                -  pool1ws42l6rawqjv58crs5l32v0eem3qnngpnjfd7epwd4lmjccc5cg
       description: Array of Cardano pool IDs (bech32 format)
     pool_ids_optional:
       content:
@@ -2935,9 +2935,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool1ext7qrwjzaxcdfhdnkq5mth59ukuu2atcg6tgqpmevpt7ratkta
-                - pool1vw6fr9agt58djrp3w0t0lsn6t329t6eusqxz5ugd9w7ecyedsdv
-                - pool1ws42l6rawqjv58crs5l32v0eem3qnngpnjfd7epwd4lmjccc5cg
+                -  pool1ext7qrwjzaxcdfhdnkq5mth59ukuu2atcg6tgqpmevpt7ratkta
+                -  pool1vw6fr9agt58djrp3w0t0lsn6t329t6eusqxz5ugd9w7ecyedsdv
+                -  pool1ws42l6rawqjv58crs5l32v0eem3qnngpnjfd7epwd4lmjccc5cg
       description: Array of Cardano pool IDs (bech32 format) [Optional]
     script_hashes:
       content:
@@ -2952,8 +2952,8 @@ components:
                 description: Array of Cardano script hashes
             example:
               _script_hashes:
-                  - a8e9f8f34fd631b1d5b9f41a90f4abc0d3935cea7baba0bb34c96f59
-                  - b4fd6dfe4a643aeec5d75dbb1f27198fc2aabf30bf92ed5470253792
+                -  a8e9f8f34fd631b1d5b9f41a90f4abc0d3935cea7baba0bb34c96f59
+                -  b4fd6dfe4a643aeec5d75dbb1f27198fc2aabf30bf92ed5470253792
       description: Array of Cardano script hashes
     datum_hashes:
       content:
@@ -2968,8 +2968,8 @@ components:
                 description: Array of Cardano datum hashes
             example:
               _datum_hashes:
-                  - 5571e2c3549f15934a38382d1318707a86751fb70827f4cbd29b104480f1be9b
-                  - 5f7212f546d7e7308ce99b925f05538db19981f4ea3084559c0b28a363245826
+                -  5571e2c3549f15934a38382d1318707a86751fb70827f4cbd29b104480f1be9b
+                -  5f7212f546d7e7308ce99b925f05538db19981f4ea3084559c0b28a363245826
       description: Array of Cardano datum hashes
     asset_list:
       content:
@@ -2988,8 +2988,8 @@ components:
                     type: string
             example:
               _asset_list:
-                - ['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']
-                - ['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']
+                -  ['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']
+                -  ['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']
       description: Array of array of policyID and asset names (hex)
     asset_list_with_extended:
       content:
@@ -3012,8 +3012,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _asset_list:
-                - ['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']
-                - ['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']
+                -  ['c6e65ba7878b2f8ea0ad39287d3e2fd256dc5c4160fc19bdf4c4d87e','7447454e53']
+                -  ['777e6b4903dab74963ae581d39875c5dac16c09bb1f511c0af1ddda8','6141414441']
               _extended: true
       description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
     drep_id_bulk:
@@ -3031,8 +3031,8 @@ components:
                   type: string
             example:
               _drep_ids:
-                - drep1ydmraa6kv8cvmry059v608tehl50nfmg0z764lmsqkvwurs40sw2z
-                - drep1y25j98kvqf7t3tj4pvxwrjr2728dsrfekptgg3kxqrr56qqcny8sn
+                -  drep1ydmraa6kv8cvmry059v608tehl50nfmg0z764lmsqkvwurs40sw2z
+                -  drep1y25j98kvqf7t3tj4pvxwrjr2728dsrfekptgg3kxqrr56qqcny8sn
     utxo_refs_with_extended:
       content:
         application/json:
@@ -3049,11 +3049,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _utxo_refs:
-                - d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530#0
-                - 145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576#0
+                -  d10133964da9e443b303917fd0b7644ae3d01c133deff85b4f59416c2d00f530#0
+                -  145688d3619e7524510ea64c0ec6363b77a9b8da179ef9bb0273a0940d57d576#0
               _extended: false
       description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
     ogmios:
@@ -3072,7 +3072,22 @@ components:
               method:
                 type: string
                 description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
-                enum: ["queryNetwork/blockHeight","queryNetwork/genesisConfiguration","queryNetwork/startTime","queryNetwork/tip","queryLedgerState/epoch","queryLedgerState/eraStart","queryLedgerState/eraSummaries","queryLedgerState/liveStakeDistribution","queryLedgerState/protocolParameters","queryLedgerState/proposedProtocolParameters","queryLedgerState/stakePools","submitTransaction","evaluateTransaction"]
+                enum:
+                  [
+                    "queryNetwork/blockHeight",
+                    "queryNetwork/genesisConfiguration",
+                    "queryNetwork/startTime",
+                    "queryNetwork/tip",
+                    "queryLedgerState/epoch",
+                    "queryLedgerState/eraStart",
+                    "queryLedgerState/eraSummaries",
+                    "queryLedgerState/liveStakeDistribution",
+                    "queryLedgerState/protocolParameters",
+                    "queryLedgerState/proposedProtocolParameters",
+                    "queryLedgerState/stakePools",
+                    "submitTransaction",
+                    "evaluateTransaction",
+                  ]
                 example: "queryNetwork/tip"
               params:
                 type: object
@@ -3084,7 +3099,12 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
             genesisConfiguration:
               description: Query the genesis configuration of a given era.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/genesisConfiguration", "params": { "era": "shelley" } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryNetwork/genesisConfiguration",
+                  "params": { "era": "shelley" },
+                }
             startTimeTime:
               description: Query the network start time.
               value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
@@ -3099,25 +3119,61 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
             eraSummaries:
               description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
+              value:
+                { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
             liveStakeDistribution:
               description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/liveStakeDistribution" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/liveStakeDistribution",
+                }
             protocolParameters:
               description: Query the current protocol parameters.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/protocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/protocolParameters",
+                }
             proposedProtocolParameters:
               description: Query the last update proposal w.r.t. protocol parameters, if any.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/proposedProtocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/proposedProtocolParameters",
+                }
             StakePools:
               description: Query the list of all stake pool identifiers currently registered and active.
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
             submitTransaction:
               description: Submit a signed and serialized transaction to the network.
-              value: { "jsonrpc": "2.0", "method": "submitTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" } } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "submitTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                    },
+                }
             evaluateTransaction:
               description: Evaluate execution units of scripts in a well-formed transaction.
-              value: { "jsonrpc": "2.0", "method": "evaluateTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" }, "additionalUtxo": [ { ... } ] } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "evaluateTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                      "additionalUtxo": [{ ... }],
+                    },
+                }
       description: JSON-RPC 2.0 standard request body
   securitySchemes:
     bearerAuth:
@@ -3244,6 +3300,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array
@@ -3260,7 +3328,7 @@ components:
           data:
             type: string
             description: JSON encoded data with details about the parameter update
-            example: {"decentralisation": 0.9}
+            example: { "decentralisation": 0.9 }
     cli_protocol_params:
       description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
       type: object
@@ -3277,10 +3345,7 @@ components:
           "monetaryExpansion": 3.0e-3,
           "poolPledgeInfluence": 0.3,
           "poolRetireMaxEpoch": 18,
-          "protocolVersion": {
-            "major": 8,
-            "minor": 0
-          },
+          "protocolVersion": { "major": 8, "minor": 0 },
           "...": "...",
           "stakeAddressDeposit": 2000000,
           "stakePoolDeposit": 500000000,
@@ -3288,7 +3353,7 @@ components:
           "treasuryCut": 0.2,
           "txFeeFixed": 155381,
           "txFeePerByte": 44,
-          "utxoCostPerByte": 4310
+          "utxoCostPerByte": 4310,
         }
     reserve_withdrawals:
       description: Array of withdrawals from reserves/treasury against stake accounts
@@ -3317,6 +3382,7 @@ components:
             description: Epoch where the earned amount can be spent
             allOf:
               - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+
     pool_list:
       description: Array of pool IDs and tickers
       type: array
@@ -3345,7 +3411,7 @@ components:
           ticker:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ticker
             example: AHL
           pool_group:
@@ -3375,7 +3441,7 @@ components:
           active_stake_pct:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Active stake for the pool, expressed as a percentage of total active stake on network
             example: 13.512182543475783
           saturation_pct:
@@ -3385,7 +3451,7 @@ components:
           block_cnt:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of blocks pool created in that epoch
             example: 14
           delegator_cnt:
@@ -3411,7 +3477,7 @@ components:
           member_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
             example: "123456780123"
           epoch_ros:
@@ -3455,49 +3521,49 @@ components:
           vrf_key_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool VRF key hash
             example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
           margin:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Margin (decimal format)
             example: 0.1
           fixed_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool fixed cost per epoch
             example: "500000000"
           pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool pledge in number
             example: "64000000000000"
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool's registration deposit in number
             example: "500000000"
           reward_addr:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool reward address
             example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
           reward_addr_delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           owners:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               type: string
               description: Pool (co)owner address
@@ -3510,49 +3576,49 @@ components:
                 dns:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS name of the relay (nullable)
                   example: relays-new.cardano-mainnet.iohk.io
                 srv:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS service name of the relay (nullable)
                   example: biostakingpool3.hopto.org
                 ipv4:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv4 address of the relay (nullable)
                   example: "54.220.20.40"
                 ipv6:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv6 address of the relay (nullable)
                   example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
                 port:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Port number of the relay (nullable)
                   example: 6000
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata URL
             example: https://pools.iohk.io/IOGP.json
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             properties:
               name:
                 type: string
@@ -3578,49 +3644,49 @@ components:
           retiring_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Announced retiring epoch (nullable)
             example: null
           op_cert:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           op_cert_counter:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate counter value
             example: 8
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Amount of delegated stake to this pool at the time of epoch snapshot
             example: "64328627680963"
           sigma:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool relative active stake share
             example: 0.0034839235
           block_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Total pool blocks on chain
             example: 4509
           live_pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Summary of account balance for all pool owner's
             example: "64328594406327"
           live_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool live stake
             example: "64328627680963"
           live_delegators:
@@ -3630,13 +3696,13 @@ components:
           live_saturation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool live saturation (decimal format)
             example: 94.52
           voting_power:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Current voting power (lovelaces) of this stake pool
             example: "123456789"
     pool_snapshot:
@@ -3707,7 +3773,7 @@ components:
       description: Array of pool delegators (historical)
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         type: object
         properties:
@@ -3754,7 +3820,7 @@ components:
           active_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Epoch number in which the update becomes active
             example: 324
           vrf_key_hash:
@@ -3847,7 +3913,7 @@ components:
           pool_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A group that the pool was identified to be associated with
             example: IOG
           ticker:
@@ -3855,15 +3921,16 @@ components:
           adastat_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per adastat.net
             example: iohk.io
           balanceanalytics_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per balanceanalytics.io
             example: IOG
+
     epoch_info:
       description: Array of detailed summary for each epoch
       type: array
@@ -3909,19 +3976,19 @@ components:
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
             example: "23395112387185880"
           total_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total rewards earned in epoch (null for pre-Shelley epochs)
             example: "252902897534230"
           avg_blk_reward:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Average block reward for epoch (null for pre-Shelley epochs)
             example: "660233450"
     epoch_params:
@@ -3936,119 +4003,119 @@ components:
           min_fee_a:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'a' parameter to calculate the minimum transaction fee
             example: 44
           min_fee_b:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'b' parameter to calculate the minimum transaction fee
             example: 155381
           max_block_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block size (in bytes)
             example: 65536
           max_tx_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum transaction size (in bytes)
             example: 16384
           max_bh_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block header size (in bytes)
             example: 1100
           key_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake address
             example: "2000000"
           pool_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake pool
             example: "500000000"
           max_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
             example: 18
           optimal_pool_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The optimal number of stake pools
             example: 500
           influence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The pledge influence on pool rewards
             example: 0.3
           monetary_expand_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The monetary expansion rate
             example: 0.003
           treasury_growth_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The treasury growth rate
             example: 0.2
           decentralisation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
             example: 0.1
           extra_entropy:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
             example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
           protocol_major:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol major version
             example: 5
           protocol_minor:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol minor version
             example: 0
           min_utxo_value:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum value of a UTxO entry
             example: "34482"
           min_pool_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum pool cost
             example: "340000000"
           nonce:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The nonce value for this epoch
             example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
           block_hash:
@@ -4058,201 +4125,201 @@ components:
           cost_models:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The per language cost model in JSON
             example: null
           price_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The per word cost of script memory usage
             example: 0.0577
           price_step:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The cost of script execution step usage
             example: 7.21e-05
           max_tx_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single transaction
             example: 10000000
           max_tx_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single transaction
             example: 10000000000
           max_block_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single block
             example: 50000000
           max_block_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single block
             example: 40000000000
           max_val_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum Val size
             example: 5000
           collateral_percent:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
             example: 150
           max_collateral_inputs:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of collateral inputs allowed in a transaction
             example: 3
           coins_per_utxo_size:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The cost per UTxO size
             example: "34482"
           pvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for motion of no-confidence.
             example: 0.6
           pvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (normal state).
             example: 0.65
           pvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           pvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for hard-fork initiation.
             example: 0.51
           dvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for motion of no-confidence.
             example: 0.67
           dvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (normal state).
             example: 0.67
           dvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           dvt_update_to_constitution:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for update to the Constitution.
             example: 0.75
           dvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for hard-fork initiation.
             example: 0.6
           dvt_p_p_network_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, network group.
             example: 0.67
           dvt_p_p_economic_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, economic group.
             example: 0.67
           dvt_p_p_technical_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, technical group.
             example: 0.67
           dvt_p_p_gov_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, governance group.
             example: 0.75
           dvt_treasury_withdrawal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for treasury withdrawal.
             example: 0.67
           committee_min_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimal constitutional committee size.
             example: 5
           committee_max_term_length:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Constitutional committee term limits.
             example: 146
           gov_action_lifetime:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Governance action expiration.
             example: 14
           gov_action_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Governance action deposit.
             example: 100000000000
           drep_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep deposit amount.
             example: 500000000
           drep_activity:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep activity period.
             example: 20
           pvtpp_security_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for protocol parameter changes, security group.
             example: 0.6
           min_fee_ref_script_cost_per_byte:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimum Fee for Reference Script cost pre byte
             example: 15
     epoch_block_protocols:
@@ -4272,6 +4339,7 @@ components:
             type: number
             description: Amount of blocks with specified major and protocol combination
             example: 2183
+
     blocks:
       description: Array of block information
       type: array
@@ -4317,7 +4385,7 @@ components:
           pool:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ID in bech32 format (null for pre-Shelley blocks)
             example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
           op_cert_counter:
@@ -4371,13 +4439,13 @@ components:
           total_output:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total output of the block (in number)
             example: "92384672389"
           total_fees:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total fees of the block (in number)
             example: "2346834"
           num_confirmations:
@@ -4473,8 +4541,8 @@ components:
           inputs:
             description: An array of UTxO inputs spent in the transaction
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           outputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
           withdrawals:
@@ -4489,6 +4557,7 @@ components:
             $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
           plutus_contracts:
             $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
+
     address_info:
       description: Array of information for address(es)
       type: array
@@ -4503,8 +4572,8 @@ components:
             example: "10723473983"
           stake_address:
             anyOf:
-            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            - type: 'null'
+              - $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              - type: "null"
           script_address:
             type: boolean
             description: Signifies whether the address is a script address
@@ -4606,7 +4675,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script hash in case the stake address is locked by a script
             example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
     account_info:
@@ -4625,13 +4694,13 @@ components:
           delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           delegated_pool:
             anyOf:
-            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-            - type: 'null'
+              - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+              - type: "null"
           total_balance:
             type: string
             description: Total balance of the account including UTxO, rewards and MIRs (in number)
@@ -4668,109 +4737,6 @@ components:
             type: string
             description: Total proposal refund for this account
             example: "0"
-    utxo_infos:
-      description: Array of complete UTxO information
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          inline_datum:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-          reference_script:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-          asset_list:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: An array of assets on the UTxO
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of assets on the UTxO
-                  example: "1"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    tx_outs_epoch:
-      description: List of transaction outputs with basic details for requested epoch
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
     account_rewards:
       description: Array of reward history information
       type: array
@@ -4799,7 +4765,7 @@ components:
                 pool_id:
                   anyOf:
                     - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-                    - type: 'null'
+                    - type: "null"
     account_reward_history:
       description: Array of reward history information
       type: array
@@ -4823,7 +4789,7 @@ components:
           pool_id_bech32:
             anyOf:
               - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-              - type: 'null'
+              - type: "null"
     account_updates:
       description: Array of account updates information
       type: array
@@ -4840,7 +4806,14 @@ components:
                 action_type:
                   type: string
                   description: Type of certificate submitted
-                  enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+                  enum:
+                    [
+                      "registration",
+                      "delegation_pool",
+                      "delegation_drep",
+                      "withdrawal",
+                      "deregistration",
+                    ]
                   example: "registration"
                 tx_hash:
                   $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4863,7 +4836,14 @@ components:
           action_type:
             type: string
             description: Type of certificate submitted
-            enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+            enum:
+              [
+                "registration",
+                "delegation_pool",
+                "delegation_drep",
+                "withdrawal",
+                "deregistration",
+              ]
             example: "registration"
           tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4952,6 +4932,7 @@ components:
             type: string
             description: Active stake amount (in numbers)
             example: 682334162
+
     tx_info:
       description: Array of detailed information about transaction(s)
       type: array
@@ -5001,25 +4982,25 @@ components:
           invalid_before:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot before which transaction cannot be validated (if supplied, else null)
             example: "42331172"
           invalid_after:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot after which transaction cannot be validated
             example: "42332172"
           collateral_inputs:
             description: An array of collateral inputs needed for smart contracts in case of contract failure
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           collateral_output:
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               properties:
                 payment_addr:
@@ -5045,7 +5026,7 @@ components:
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
             anyOf:
               - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-              - type: 'null'
+              - type: "null"
           inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             #description: An array of UTxO inputs spent in the transaction
@@ -5077,13 +5058,13 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
-                  description: Hash of datum (if any) connected to UTxO 
+                    - type: "null"
+                  description: Hash of datum (if any) connected to UTxO
                   example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
                 inline_datum:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allows datums to be attached to UTxO (CIP-32)
                   properties:
                     bytes:
@@ -5097,7 +5078,7 @@ components:
                 reference_script:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
                   properties:
                     hash:
@@ -5119,7 +5100,7 @@ components:
                     value:
                       anyOf:
                         - type: object
-                        - type: 'null'
+                        - type: "null"
                       description: Value (json)
                       example: null
                 asset_list:
@@ -5127,7 +5108,7 @@ components:
           withdrawals:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of withdrawals with-in a transaction
             items:
               type: object
@@ -5143,7 +5124,7 @@ components:
           assets_minted:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of minted assets with-in a transaction
             items:
               properties:
@@ -5164,14 +5145,14 @@ components:
           certificates:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Certificates present with-in a transaction (if any)
             items:
               properties:
                 index:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Certificate index
                   example: 0
                 type:
@@ -5181,7 +5162,7 @@ components:
                 info:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: A JSON array containing information from the certificate
                   example:
                     {
@@ -5191,7 +5172,7 @@ components:
           native_scripts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Native scripts present in a transaction (if any)
             items:
               properties:
@@ -5222,20 +5203,20 @@ components:
           plutus_contracts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Plutus contracts present in transaction (if any)
             items:
               properties:
                 address:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
                 spends_input:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   properties:
                     tx_hash:
                       $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -5286,7 +5267,7 @@ components:
           voting_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance votes in a transaction (if any)
             items:
               properties:
@@ -5305,7 +5286,7 @@ components:
           proposal_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance proposals in a transaction (if any)
             items:
               properties:
@@ -5390,7 +5371,7 @@ components:
       description: Array of metadata information present in each of the transactions queried
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         properties:
           tx_hash:
@@ -5398,7 +5379,7 @@ components:
           metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: A JSON array containing details about metadata within transaction
             example:
               {
@@ -5421,7 +5402,7 @@ components:
           num_confirmations:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of block confirmations
             example: 17
     tx_metalabels:
@@ -5433,6 +5414,130 @@ components:
             type: string
             description: A distinct known metalabel
             example: "721"
+    utxo_infos:
+      description: Array of complete UTxO information
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          inline_datum:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+          reference_script:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+          asset_list:
+            anyOf:
+              - type: array
+              - type: "null"
+            description: An array of assets on the UTxO
+            items:
+              properties:
+                policy_id:
+                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+                asset_name:
+                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+                fingerprint:
+                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+                quantity:
+                  type: string
+                  description: Quantity of assets on the UTxO
+                  example: "1"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_outs_epoch:
+      description: List of transaction outputs with basic details for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_treasury_donations_epoch:
+      description: List of treasury donation transactions for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          tx_hash:
+            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+          block_hash:
+            $ref: "#/components/schemas/blocks/items/properties/hash"
+          tx_block_index:
+            $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          treasury_donation:
+            $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+
     asset_list:
       description: Array of policy IDs and asset names
       type: array
@@ -5530,7 +5635,7 @@ components:
           asset_name:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Asset Name (hex)
             example: 444f4e545350414d
           asset_name_ascii:
@@ -5568,33 +5673,33 @@ components:
           token_registry_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Asset metadata registered on the Cardano Token Registry
             properties:
               name:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Rackmob
               description:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Metaverse Blockchain Cryptocurrency.
               ticker:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: MOB
               url:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: https://www.rackmob.com/
               logo:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: A PNG image file as a byte string
                 example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
               decimals:
@@ -5603,9 +5708,27 @@ components:
           cip68_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: CIP 68 metadata if present for asset
-            example: {"222": {"fields": [{"map": [{"k": {"bytes": "6e616d65"}, "v": {"bytes": "74657374"}}]}], "constructor": 0}}
+            example:
+              {
+                "222":
+                  {
+                    "fields":
+                      [
+                        {
+                          "map":
+                            [
+                              {
+                                "k": { "bytes": "6e616d65" },
+                                "v": { "bytes": "74657374" },
+                              },
+                            ],
+                        },
+                      ],
+                    "constructor": 0,
+                  },
+              }
     asset_history:
       description: Array of asset mint/burn history
       type: array
@@ -5620,7 +5743,7 @@ components:
           minting_txs:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of all mint/burn transactions for an asset
             items:
               type: object
@@ -5640,6 +5763,7 @@ components:
                   description: Array of Transaction Metadata for given transaction
                   items:
                     $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+
     policy_asset_addresses:
       description: Array of asset names and payment addresses for the given policy (including balances)
       type: array
@@ -5716,6 +5840,7 @@ components:
             $ref: "#/components/schemas/asset_info/items/properties/total_supply"
           decimals:
             $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+
     drep_info:
       description: Get detailed information about requested delegated representatives (DReps)
       type: array
@@ -5740,7 +5865,7 @@ components:
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep's registration deposit  in number
             example: "500000000"
           active:
@@ -5750,7 +5875,7 @@ components:
           expires_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: After which epoch DRep is considered inactive.
             example: 410
           amount:
@@ -5760,13 +5885,13 @@ components:
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A URL to a JSON payload of metadata
             example: "https://hornan7.github.io/Vote_Context.jsonld"
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A hash of the contents of the metadata URL
             example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
     drep_epoch_summary:
@@ -5832,36 +5957,121 @@ components:
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The payload as JSON
             example:
-              {"body": {"title": "...", "...": "...", "references": [{"uri": "...", "@type": "Other", "label": "Hardfork to PV10"}]}, "authors": [{"name": "...", "witness": {"publicKey": "...", "signature": "...", "witnessAlgorithm": "ed25519"}}], "@context": {"body": {"@id": "CIP108:body", "@context": {"title": "CIP108:title", "abstract": "CIP108:abstract", "rationale": "CIP108:rationale", "motivation": "CIP108:motivation", "references": {"@id": "CIP108:references", "@context": {"uri": "CIP100:reference-uri", "Other": "CIP100:OtherReference", "label": "CIP100:reference-label", "referenceHash": {"@id": "CIP108:referenceHash", "@context": {"hashDigest": "CIP108:hashDigest", "hashAlgorithm": "CIP100:hashAlgorithm"}}, "GovernanceMetadata": "CIP100:GovernanceMetadataReference"}, "@container": "@set"}}}, "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#", "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#", "authors": {"@id": "CIP100:authors", "@context": {"name": "http://xmlns.com/foaf/0.1/name", "witness": {"@id": "CIP100:witness", "@context": {"publicKey": "CIP100:publicKey", "signature": "CIP100:signature", "witnessAlgorithm": "CIP100:witnessAlgorithm"}}}, "@container": "@set"}, "@language": "en-us", "hashAlgorithm": "CIP100:hashAlgorithm"}, "hashAlgorithm": "blake2b-256"}
+              {
+                "body":
+                  {
+                    "title": "...",
+                    "...": "...",
+                    "references":
+                      [
+                        {
+                          "uri": "...",
+                          "@type": "Other",
+                          "label": "Hardfork to PV10",
+                        },
+                      ],
+                  },
+                "authors":
+                  [
+                    {
+                      "name": "...",
+                      "witness":
+                        {
+                          "publicKey": "...",
+                          "signature": "...",
+                          "witnessAlgorithm": "ed25519",
+                        },
+                    },
+                  ],
+                "@context":
+                  {
+                    "body":
+                      {
+                        "@id": "CIP108:body",
+                        "@context":
+                          {
+                            "title": "CIP108:title",
+                            "abstract": "CIP108:abstract",
+                            "rationale": "CIP108:rationale",
+                            "motivation": "CIP108:motivation",
+                            "references":
+                              {
+                                "@id": "CIP108:references",
+                                "@context":
+                                  {
+                                    "uri": "CIP100:reference-uri",
+                                    "Other": "CIP100:OtherReference",
+                                    "label": "CIP100:reference-label",
+                                    "referenceHash":
+                                      {
+                                        "@id": "CIP108:referenceHash",
+                                        "@context":
+                                          {
+                                            "hashDigest": "CIP108:hashDigest",
+                                            "hashAlgorithm": "CIP100:hashAlgorithm",
+                                          },
+                                      },
+                                    "GovernanceMetadata": "CIP100:GovernanceMetadataReference",
+                                  },
+                                "@container": "@set",
+                              },
+                          },
+                      },
+                    "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
+                    "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#",
+                    "authors":
+                      {
+                        "@id": "CIP100:authors",
+                        "@context":
+                          {
+                            "name": "http://xmlns.com/foaf/0.1/name",
+                            "witness":
+                              {
+                                "@id": "CIP100:witness",
+                                "@context":
+                                  {
+                                    "publicKey": "CIP100:publicKey",
+                                    "signature": "CIP100:signature",
+                                    "witnessAlgorithm": "CIP100:witnessAlgorithm",
+                                  },
+                              },
+                          },
+                        "@container": "@set",
+                      },
+                    "@language": "en-us",
+                    "hashAlgorithm": "CIP100:hashAlgorithm",
+                  },
+                "hashAlgorithm": "blake2b-256",
+              }
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The raw bytes of the payload
             example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
           warning:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A warning that occured while validating the metadata
           language:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The language described in the context of the metadata as per CIP-100
             example: en-us
           comment:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Comment attached to the metadata
           is_valid:
             anyOf:
               - type: boolean
-              - type: 'null'
+              - type: "null"
             description: Indicate whether data is invalid (currently returns null for all as per dbsync)
             example: null
     drep_updates:
@@ -5886,7 +6096,7 @@ components:
           action:
             type: string
             description: Effective action for this DRep Update certificate
-            enum: ["updated","registered","deregistered"]
+            enum: ["updated", "registered", "deregistered"]
             example: registered
           deposit:
             $ref: "#/components/schemas/drep_info/items/properties/deposit"
@@ -5907,8 +6117,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the DRep
             example: "14231445553"
     drep_votes:
@@ -5928,7 +6138,7 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/block_time"
           vote:
             type: string
-            enum: ["Yes","No","Abstain"]
+            enum: ["Yes", "No", "Abstain"]
             description: Actual Vote casted
             example: "Yes"
           meta_url:
@@ -5946,8 +6156,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the pool for the epoch
             example: "11231445553"
     pool_votes:
@@ -5970,7 +6180,7 @@ components:
           proposal_id:
             type: string
             description: Proposal Action ID in accordance with CIP-129 format
-            example: 'gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh'
+            example: "gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh"
           proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           proposal_index:
@@ -5979,7 +6189,16 @@ components:
             example: 0
           proposal_type:
             type: string
-            enum: ["ParameterChange", "HardForkInitiation", "TreasuryWithdrawals", "NoConfidence", "NewCommittee", "NewConstitution", "InfoAction"]
+            enum:
+              [
+                "ParameterChange",
+                "HardForkInitiation",
+                "TreasuryWithdrawals",
+                "NoConfidence",
+                "NewCommittee",
+                "NewConstitution",
+                "InfoAction",
+              ]
             description: Proposal Action Type
             example: ParameterChange
           proposal_description:
@@ -5999,31 +6218,31 @@ components:
           ratified_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been ratified at the specfied epoch.
             example: 670
           enacted_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been enacted at the specfied epoch.
             example: 675
           dropped_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
             example: 680
           expired_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been expired at the specfied epoch.
             example: 680
           expiration:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Shows the epoch at which this governance action is expected to expire.
           meta_url:
             $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
@@ -6040,7 +6259,7 @@ components:
           withdrawal:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: If not null, the amount withdrawn from treasury into stake address by this this proposal
             properties:
               stake_address:
@@ -6052,8 +6271,8 @@ components:
             description: If not null, the proposed new parameter set
             anyOf:
               - type: object
-              - type: 'null'
-            example: {"key_deposit": 1000000}
+              - type: "null"
+            example: { "key_deposit": 1000000 }
     voter_proposal_list:
       description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
       type: array
@@ -6281,7 +6500,7 @@ components:
               status:
                 type: string
                 description: Member authentication status
-                enum: [ "authorized", "not_authorized", "resigned" ]
+                enum: ["authorized", "not_authorized", "resigned"]
                 example: authorized
               cc_cold_hex:
                 type: string
@@ -6294,19 +6513,20 @@ components:
               cc_hot_hex:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: Committee member key hash from last valid hot key authorization certificate in hex format
                 example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
               cc_hot_has_script:
                 anyOf:
                   - type: boolean
-                  - type: 'null'
+                  - type: "null"
                 description: Flag which shows if this credential is a script hash
                 example: false
               expiration_epoch:
                 type: number
                 description: Epoch number in which the committee member vote rights expire
                 example: 324
+
     script_info:
       type: array
       items:
@@ -6315,7 +6535,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Hash of a script
             example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
           creation_tx_hash:
@@ -6325,18 +6545,18 @@ components:
           type:
             type: string
             description: Type of the script
-            enum: ["plutusV1","plutusV2","timelock","multisig"]
+            enum: ["plutusV1", "plutusV2", "timelock", "multisig"]
             example: plutusV1
           value:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Data in JSON format
             example: null
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script bytes (cborSeq)
             example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
           size:
@@ -6377,14 +6597,14 @@ components:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Memory to run a script
                   example: 520448
                 unit_steps:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Cpu steps to run a script
                   example: 211535239
                 fee:
@@ -6399,7 +6619,7 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: The Hash of the Plutus Data
                   example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
                 datum_value:
@@ -6418,6 +6638,7 @@ components:
             $ref: "#/components/schemas/script_info/items/properties/value"
           bytes:
             $ref: "#/components/schemas/script_info/items/properties/bytes"
+
     ogmiostip:
       description: Current tip of the chain, identified by a slot and a block header hash.
       type: object
@@ -6436,7 +6657,7 @@ components:
             - type: number
             - type: array
             - type: object
-            - type: 'null'
+            - type: "null"
           description: Result of the query
           properties:
             slot:
@@ -6447,7 +6668,11 @@ components:
               type: string
               description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
               example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
-          example: {"slot": 59886800, "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"}
+          example:
+            {
+              "slot": 59886800,
+              "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1",
+            }
   headers: {}
   responses:
     NotFound:

--- a/specs/results/koiosapi-preview.yaml
+++ b/specs/results/koiosapi-preview.yaml
@@ -157,7 +157,6 @@ servers:
   - url: https://sancho.koios.rest/api/v1
     description: Sanchonet Network
 paths:
-
   /tip: #RPC
     get:
       tags:
@@ -490,7 +489,7 @@ paths:
       operationId: block_tx_info
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /utxo_info: #RPC
     post:
@@ -700,7 +699,7 @@ paths:
       operationId: tx_utxos
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /address_info: #RPC
     post:
@@ -992,7 +991,7 @@ paths:
       operationId: account_rewards
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_reward_history: #RPC
     post:
       tags:
@@ -1133,7 +1132,7 @@ paths:
       operationId: account_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_stake_history: #RPC
     post:
       tags:
@@ -1308,8 +1307,8 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Addresses
       description: Get the list of all addresses holding a given asset <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: asset_addresses
   /asset_nft_address: #RPC
@@ -1355,9 +1354,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Policy Asset Address List
-      description: Get the list of addresses with quantity for each asset on the given policy <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+      description:
+        Get the list of addresses with quantity for each asset on the given policy <br><br>
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: policy_asset_addresses
   /policy_asset_info: #RPC
@@ -1587,7 +1587,7 @@ paths:
       operationId: drep_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_voting_power_history: #RPC
     get:
       tags:
@@ -1636,7 +1636,7 @@ paths:
       operationId: drep_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_delegators: #RPC
     get:
       tags:
@@ -1790,7 +1790,7 @@ paths:
   /vote_list: #RPC
     get:
       tags:
-        - Governance      
+        - Governance
       responses:
         "200":
           description: Success!!
@@ -2124,8 +2124,8 @@ paths:
       operationId: pool_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
-  
+          label: "Deprecated"
+
   /pool_groups: #RPC
     get:
       tags:
@@ -2343,7 +2343,7 @@ paths:
         We do support transparent forwarding for various methods from Ogmios, you can read about those <a href="#tag--Ogmios">here</a>.
         </div>
       operationId: ogmios
-        
+
 components:
   parameters:
     _after_block_height:
@@ -2561,9 +2561,9 @@ components:
                   $ref: "#/components/schemas/blocks/items/properties/hash"
             example:
               _block_hashes:
-                - a4504e2495ed03b48be36676f430c54dca0769d29f72ebf18d493abf42d2167b
-                - 8e7a6206d2b21ae4f26e7e09353fadae17f838a63d095c2be51acbd16e9b7716
-                - 1baaf7812ed48e663adb9eeaa68fe25034e5e30b4f8e56cc8600cac5e9d42ce7
+                -  a4504e2495ed03b48be36676f430c54dca0769d29f72ebf18d493abf42d2167b
+                -  8e7a6206d2b21ae4f26e7e09353fadae17f838a63d095c2be51acbd16e9b7716
+                -  1baaf7812ed48e663adb9eeaa68fe25034e5e30b4f8e56cc8600cac5e9d42ce7
       description: Array of block hashes
     block_tx_info:
       content:
@@ -2607,9 +2607,9 @@ components:
                 description: Controls whether to include bytecode for associated reference/plutus scripts
             example:
               _block_hashes:
-                - a4504e2495ed03b48be36676f430c54dca0769d29f72ebf18d493abf42d2167b
-                - 8e7a6206d2b21ae4f26e7e09353fadae17f838a63d095c2be51acbd16e9b7716
-                - 1baaf7812ed48e663adb9eeaa68fe25034e5e30b4f8e56cc8600cac5e9d42ce7
+                -  a4504e2495ed03b48be36676f430c54dca0769d29f72ebf18d493abf42d2167b
+                -  8e7a6206d2b21ae4f26e7e09353fadae17f838a63d095c2be51acbd16e9b7716
+                -  1baaf7812ed48e663adb9eeaa68fe25034e5e30b4f8e56cc8600cac5e9d42ce7
               _inputs: false
               _metadata: false
               _assets: false
@@ -2633,8 +2633,8 @@ components:
                 description: Array of Cardano payment address(es) in bech32 format
             example:
               _addresses:
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
-                - addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
       description: Array of Cardano payment address(es)
     payment_addresses_with_extended:
       content:
@@ -2655,8 +2655,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _addresses:
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
-                - addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
               _extended: true
       description: Array of Cardano payment address(es) with extended flag to toggle additional fields
     address_txs:
@@ -2678,8 +2678,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _addresses:
-                - addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
-                - addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
+                -  addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc
+                -  addr_test1vqneq3v0dqh3x3muv6ee3lt8e5729xymnxuavx6tndcjc2cv24ef9
               _after_block_height: 40356
       description: Array of Cardano payment address(es)
     stake_addresses_with_epoch_no:
@@ -2701,8 +2701,8 @@ components:
                 description: Only fetch information for a specific epoch
             example:
               _stake_addresses:
-                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
-                - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
+                -  stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
+                -  stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
               _epoch_no: 11
       description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
     stake_addresses_with_first_only_and_empty:
@@ -2728,8 +2728,8 @@ components:
                 description: Include zero quantity entries
             example:
               _stake_addresses:
-                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
-                - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
+                -  stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
+                -  stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
               _first_only: false
               _empty: false
       description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
@@ -2752,8 +2752,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _stake_addresses:
-                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
-                - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
+                -  stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
+                -  stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
               _extended: true
       description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
     stake_addresses:
@@ -2771,8 +2771,8 @@ components:
                 description: Array of Cardano stake address(es) in bech32 format
             example:
               _stake_addresses:
-                - stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
-                - stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
+                -  stake_test1urqntq4wexjylnrdnp97qq79qkxxvrsa9lcnwr7ckjd6w0cr04y4p
+                -  stake_test1up6wqzrw2h9vvjy5zfkjn0dwtymy5r29zyhf8fyhm6fat9c2am5hl
       description: Array of Cardano stake credential(s) in bech32 format
     credential_txs:
       content:
@@ -2793,8 +2793,8 @@ components:
                 description: Only fetch information after specific block height
             example:
               _payment_credentials:
-                - 33c378cee41b2e15ac848f7f6f1d2f78155ab12d93b713de898d855f
-                - 52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
+                -  33c378cee41b2e15ac848f7f6f1d2f78155ab12d93b713de898d855f
+                -  52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
               _after_block_height: 40356
       description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
     credential_utxos:
@@ -2813,11 +2813,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _payment_credentials:
-                - 33c378cee41b2e15ac848f7f6f1d2f78155ab12d93b713de898d855f
-                - 52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
+                -  33c378cee41b2e15ac848f7f6f1d2f78155ab12d93b713de898d855f
+                -  52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
               _extended: true
       description: Array of Cardano payment credential(s) in hex format
     tx_ids:
@@ -2835,8 +2835,8 @@ components:
                 description: Array of Cardano Transaction hashes
             example:
               _tx_hashes:
-                - f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c
-                - 206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00
+                -  f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c
+                -  206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00
       description: Array of Cardano Transaction hashes
     tx_info:
       content:
@@ -2885,8 +2885,8 @@ components:
                 description: Controls whether to include governance certificates, votes and proposals in the result
             example:
               _tx_hashes:
-                - f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c
-                - 206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00
+                -  f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c
+                -  206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00
               _inputs: false
               _metadata: false
               _assets: false
@@ -2918,9 +2918,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool1p90428kec03mjdya3k4gv5d20w7lmed7ca0snknef5j977l3y8l
-                - pool1wwh3k3ldzujdvgxllfwlnnkxyheafkacqlufnvpr77n5q72f9hw
-                - pool1p835jxsj8py5n34lrgk6fvpgpxxvh585qm8dzvp7ups37vdet5a
+                -  pool1p90428kec03mjdya3k4gv5d20w7lmed7ca0snknef5j977l3y8l
+                -  pool1wwh3k3ldzujdvgxllfwlnnkxyheafkacqlufnvpr77n5q72f9hw
+                -  pool1p835jxsj8py5n34lrgk6fvpgpxxvh585qm8dzvp7ups37vdet5a
       description: Array of Cardano pool IDs (bech32 format)
     pool_ids_optional:
       content:
@@ -2935,9 +2935,9 @@ components:
                 description: Array of Cardano pool IDs (bech32 format)
             example:
               _pool_bech32_ids:
-                - pool1p90428kec03mjdya3k4gv5d20w7lmed7ca0snknef5j977l3y8l
-                - pool1wwh3k3ldzujdvgxllfwlnnkxyheafkacqlufnvpr77n5q72f9hw
-                - pool1p835jxsj8py5n34lrgk6fvpgpxxvh585qm8dzvp7ups37vdet5a
+                -  pool1p90428kec03mjdya3k4gv5d20w7lmed7ca0snknef5j977l3y8l
+                -  pool1wwh3k3ldzujdvgxllfwlnnkxyheafkacqlufnvpr77n5q72f9hw
+                -  pool1p835jxsj8py5n34lrgk6fvpgpxxvh585qm8dzvp7ups37vdet5a
       description: Array of Cardano pool IDs (bech32 format) [Optional]
     script_hashes:
       content:
@@ -2952,8 +2952,8 @@ components:
                 description: Array of Cardano script hashes
             example:
               _script_hashes:
-                  - c6d963e8892916ab8753d3c342037cd122123c4dd783a07af21f8dac
-                  - c0c671fba483641a71bb92d3a8b7c52c90bf1c01e2b83116ad7d4536
+                -  c6d963e8892916ab8753d3c342037cd122123c4dd783a07af21f8dac
+                -  c0c671fba483641a71bb92d3a8b7c52c90bf1c01e2b83116ad7d4536
       description: Array of Cardano script hashes
     datum_hashes:
       content:
@@ -2968,8 +2968,8 @@ components:
                 description: Array of Cardano datum hashes
             example:
               _datum_hashes:
-                  - 6181b3dc623cd8812caf027a3507e9b3095388a7cf3db65983e1fddd3a84c88c
-                  - f8ae55ff89e1f5366f23e16bcaf2073252337b96031a02d79e41d653b5f0a978
+                -  6181b3dc623cd8812caf027a3507e9b3095388a7cf3db65983e1fddd3a84c88c
+                -  f8ae55ff89e1f5366f23e16bcaf2073252337b96031a02d79e41d653b5f0a978
       description: Array of Cardano datum hashes
     asset_list:
       content:
@@ -2988,8 +2988,8 @@ components:
                     type: string
             example:
               _asset_list:
-                - ['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']
-                - ['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']
+                -  ['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']
+                -  ['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']
       description: Array of array of policyID and asset names (hex)
     asset_list_with_extended:
       content:
@@ -3012,8 +3012,8 @@ components:
                 description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _asset_list:
-                - ['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']
-                - ['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']
+                -  ['065270479316f1d92e00f7f9f095ebeaac9d009c878dc35ce36d3404','433374']
+                -  ['189e2c53985411addb8df0f3e09f70e343da69f06746c408aba672a8','15fc257714a51769e192761d674db2ee2e80137428e522f9b914debb5f785301']
               _extended: true
       description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
     drep_id_bulk:
@@ -3031,8 +3031,8 @@ components:
                   type: string
             example:
               _drep_ids:
-                - drep1yt76he02dprm2af6x26vg76mhs2vajlg43cr9jh9dq3f2qs68ts3s
-                - drep1g5vl99xcpv8uce5hhh50xe3fh68tl9f8hcprleekw0c6jhhr45f
+                -  drep1yt76he02dprm2af6x26vg76mhs2vajlg43cr9jh9dq3f2qs68ts3s
+                -  drep1g5vl99xcpv8uce5hhh50xe3fh68tl9f8hcprleekw0c6jhhr45f
     utxo_refs_with_extended:
       content:
         application/json:
@@ -3049,11 +3049,11 @@ components:
               _extended:
                 format: boolean
                 type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
+                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
             example:
               _utxo_refs:
-                - 206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00#0
-                - f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c#0
+                -  206f6da5b0b0de45605a95f5ce7e172be9674550f7dde3838c45cbf24bab8b00#0
+                -  f1592b29b79ae85d753913dd25644c60925a4a0683979faa33832fead4b4bd9c#0
               _extended: false
       description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
     ogmios:
@@ -3072,7 +3072,22 @@ components:
               method:
                 type: string
                 description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
-                enum: ["queryNetwork/blockHeight","queryNetwork/genesisConfiguration","queryNetwork/startTime","queryNetwork/tip","queryLedgerState/epoch","queryLedgerState/eraStart","queryLedgerState/eraSummaries","queryLedgerState/liveStakeDistribution","queryLedgerState/protocolParameters","queryLedgerState/proposedProtocolParameters","queryLedgerState/stakePools","submitTransaction","evaluateTransaction"]
+                enum:
+                  [
+                    "queryNetwork/blockHeight",
+                    "queryNetwork/genesisConfiguration",
+                    "queryNetwork/startTime",
+                    "queryNetwork/tip",
+                    "queryLedgerState/epoch",
+                    "queryLedgerState/eraStart",
+                    "queryLedgerState/eraSummaries",
+                    "queryLedgerState/liveStakeDistribution",
+                    "queryLedgerState/protocolParameters",
+                    "queryLedgerState/proposedProtocolParameters",
+                    "queryLedgerState/stakePools",
+                    "submitTransaction",
+                    "evaluateTransaction",
+                  ]
                 example: "queryNetwork/tip"
               params:
                 type: object
@@ -3084,7 +3099,12 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
             genesisConfiguration:
               description: Query the genesis configuration of a given era.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/genesisConfiguration", "params": { "era": "shelley" } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryNetwork/genesisConfiguration",
+                  "params": { "era": "shelley" },
+                }
             startTimeTime:
               description: Query the network start time.
               value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
@@ -3099,25 +3119,61 @@ components:
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
             eraSummaries:
               description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
+              value:
+                { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
             liveStakeDistribution:
               description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/liveStakeDistribution" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/liveStakeDistribution",
+                }
             protocolParameters:
               description: Query the current protocol parameters.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/protocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/protocolParameters",
+                }
             proposedProtocolParameters:
               description: Query the last update proposal w.r.t. protocol parameters, if any.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/proposedProtocolParameters" }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "queryLedgerState/proposedProtocolParameters",
+                }
             StakePools:
               description: Query the list of all stake pool identifiers currently registered and active.
               value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
             submitTransaction:
               description: Submit a signed and serialized transaction to the network.
-              value: { "jsonrpc": "2.0", "method": "submitTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" } } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "submitTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                    },
+                }
             evaluateTransaction:
               description: Evaluate execution units of scripts in a well-formed transaction.
-              value: { "jsonrpc": "2.0", "method": "evaluateTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" }, "additionalUtxo": [ { ... } ] } }
+              value:
+                {
+                  "jsonrpc": "2.0",
+                  "method": "evaluateTransaction",
+                  "params":
+                    {
+                      "transaction":
+                        {
+                          "cbor": "<CBOR-serialized signed transaction (base16)>",
+                        },
+                      "additionalUtxo": [{ ... }],
+                    },
+                }
       description: JSON-RPC 2.0 standard request body
   securitySchemes:
     bearerAuth:
@@ -3244,6 +3300,18 @@ components:
             type: string
             description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
             example: 0
+          treasury_donation:
+            type: string
+            description: The amount (in Lovelace) donated to the treasury.
+            example: 0
+          treasury_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from the treasury.
+            example: 0
+          reserves_withdrawal:
+            type: string
+            description: The amount (in Lovelace) withdrawn from reserves.
+            example: 0
     param_updates:
       description: Array of unique param update proposals submitted on chain
       type: array
@@ -3260,7 +3328,7 @@ components:
           data:
             type: string
             description: JSON encoded data with details about the parameter update
-            example: {"decentralisation": 0.9}
+            example: { "decentralisation": 0.9 }
     cli_protocol_params:
       description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
       type: object
@@ -3277,10 +3345,7 @@ components:
           "monetaryExpansion": 3.0e-3,
           "poolPledgeInfluence": 0.3,
           "poolRetireMaxEpoch": 18,
-          "protocolVersion": {
-            "major": 8,
-            "minor": 0
-          },
+          "protocolVersion": { "major": 8, "minor": 0 },
           "...": "...",
           "stakeAddressDeposit": 2000000,
           "stakePoolDeposit": 500000000,
@@ -3288,7 +3353,7 @@ components:
           "treasuryCut": 0.2,
           "txFeeFixed": 155381,
           "txFeePerByte": 44,
-          "utxoCostPerByte": 4310
+          "utxoCostPerByte": 4310,
         }
     reserve_withdrawals:
       description: Array of withdrawals from reserves/treasury against stake accounts
@@ -3317,6 +3382,7 @@ components:
             description: Epoch where the earned amount can be spent
             allOf:
               - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+
     pool_list:
       description: Array of pool IDs and tickers
       type: array
@@ -3345,7 +3411,7 @@ components:
           ticker:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ticker
             example: AHL
           pool_group:
@@ -3375,7 +3441,7 @@ components:
           active_stake_pct:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Active stake for the pool, expressed as a percentage of total active stake on network
             example: 13.512182543475783
           saturation_pct:
@@ -3385,7 +3451,7 @@ components:
           block_cnt:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of blocks pool created in that epoch
             example: 14
           delegator_cnt:
@@ -3411,7 +3477,7 @@ components:
           member_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
             example: "123456780123"
           epoch_ros:
@@ -3455,49 +3521,49 @@ components:
           vrf_key_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool VRF key hash
             example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
           margin:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Margin (decimal format)
             example: 0.1
           fixed_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool fixed cost per epoch
             example: "500000000"
           pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool pledge in number
             example: "64000000000000"
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool's registration deposit in number
             example: "500000000"
           reward_addr:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool reward address
             example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
           reward_addr_delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           owners:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               type: string
               description: Pool (co)owner address
@@ -3510,49 +3576,49 @@ components:
                 dns:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS name of the relay (nullable)
                   example: relays-new.cardano-mainnet.iohk.io
                 srv:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: DNS service name of the relay (nullable)
                   example: biostakingpool3.hopto.org
                 ipv4:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv4 address of the relay (nullable)
                   example: "54.220.20.40"
                 ipv6:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: IPv6 address of the relay (nullable)
                   example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
                 port:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Port number of the relay (nullable)
                   example: 6000
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata URL
             example: https://pools.iohk.io/IOGP.json
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool metadata hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             properties:
               name:
                 type: string
@@ -3578,49 +3644,49 @@ components:
           retiring_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Announced retiring epoch (nullable)
             example: null
           op_cert:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate hash
             example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
           op_cert_counter:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool latest operational certificate counter value
             example: 8
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Amount of delegated stake to this pool at the time of epoch snapshot
             example: "64328627680963"
           sigma:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool relative active stake share
             example: 0.0034839235
           block_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Total pool blocks on chain
             example: 4509
           live_pledge:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Summary of account balance for all pool owner's
             example: "64328594406327"
           live_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool live stake
             example: "64328627680963"
           live_delegators:
@@ -3630,13 +3696,13 @@ components:
           live_saturation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool live saturation (decimal format)
             example: 94.52
           voting_power:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Current voting power (lovelaces) of this stake pool
             example: "123456789"
     pool_snapshot:
@@ -3707,7 +3773,7 @@ components:
       description: Array of pool delegators (historical)
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         type: object
         properties:
@@ -3754,7 +3820,7 @@ components:
           active_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Epoch number in which the update becomes active
             example: 324
           vrf_key_hash:
@@ -3847,7 +3913,7 @@ components:
           pool_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A group that the pool was identified to be associated with
             example: IOG
           ticker:
@@ -3855,15 +3921,16 @@ components:
           adastat_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per adastat.net
             example: iohk.io
           balanceanalytics_group:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The pool's group identification as per balanceanalytics.io
             example: IOG
+
     epoch_info:
       description: Array of detailed summary for each epoch
       type: array
@@ -3909,19 +3976,19 @@ components:
           active_stake:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
             example: "23395112387185880"
           total_rewards:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total rewards earned in epoch (null for pre-Shelley epochs)
             example: "252902897534230"
           avg_blk_reward:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Average block reward for epoch (null for pre-Shelley epochs)
             example: "660233450"
     epoch_params:
@@ -3936,119 +4003,119 @@ components:
           min_fee_a:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'a' parameter to calculate the minimum transaction fee
             example: 44
           min_fee_b:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The 'b' parameter to calculate the minimum transaction fee
             example: 155381
           max_block_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block size (in bytes)
             example: 65536
           max_tx_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum transaction size (in bytes)
             example: 16384
           max_bh_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum block header size (in bytes)
             example: 1100
           key_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake address
             example: "2000000"
           pool_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The amount (in number) required for a deposit to register a stake pool
             example: "500000000"
           max_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
             example: 18
           optimal_pool_count:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The optimal number of stake pools
             example: 500
           influence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The pledge influence on pool rewards
             example: 0.3
           monetary_expand_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The monetary expansion rate
             example: 0.003
           treasury_growth_rate:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The treasury growth rate
             example: 0.2
           decentralisation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
             example: 0.1
           extra_entropy:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
             example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
           protocol_major:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol major version
             example: 5
           protocol_minor:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The protocol minor version
             example: 0
           min_utxo_value:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum value of a UTxO entry
             example: "34482"
           min_pool_cost:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The minimum pool cost
             example: "340000000"
           nonce:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The nonce value for this epoch
             example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
           block_hash:
@@ -4058,201 +4125,201 @@ components:
           cost_models:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The per language cost model in JSON
             example: null
           price_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The per word cost of script memory usage
             example: 0.0577
           price_step:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             format: double
             description: The cost of script execution step usage
             example: 7.21e-05
           max_tx_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single transaction
             example: 10000000
           max_tx_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single transaction
             example: 10000000000
           max_block_ex_mem:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution memory allowed to be used in a single block
             example: 50000000
           max_block_ex_steps:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of execution steps allowed to be used in a single block
             example: 40000000000
           max_val_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum Val size
             example: 5000
           collateral_percent:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
             example: 150
           max_collateral_inputs:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: The maximum number of collateral inputs allowed in a transaction
             example: 3
           coins_per_utxo_size:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The cost per UTxO size
             example: "34482"
           pvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for motion of no-confidence.
             example: 0.6
           pvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (normal state).
             example: 0.65
           pvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           pvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for hard-fork initiation.
             example: 0.51
           dvt_motion_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for motion of no-confidence.
             example: 0.67
           dvt_committee_normal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (normal state).
             example: 0.67
           dvt_committee_no_confidence:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for new committee/threshold (state of no-confidence).
             example: 0.65
           dvt_update_to_constitution:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for update to the Constitution.
             example: 0.75
           dvt_hard_fork_initiation:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for hard-fork initiation.
             example: 0.6
           dvt_p_p_network_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, network group.
             example: 0.67
           dvt_p_p_economic_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, economic group.
             example: 0.67
           dvt_p_p_technical_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, technical group.
             example: 0.67
           dvt_p_p_gov_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for protocol parameter changes, governance group.
             example: 0.75
           dvt_treasury_withdrawal:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep Vote threshold for treasury withdrawal.
             example: 0.67
           committee_min_size:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimal constitutional committee size.
             example: 5
           committee_max_term_length:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Constitutional committee term limits.
             example: 146
           gov_action_lifetime:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Governance action expiration.
             example: 14
           gov_action_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Governance action deposit.
             example: 100000000000
           drep_deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep deposit amount.
             example: 500000000
           drep_activity:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: DRep activity period.
             example: 20
           pvtpp_security_group:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Pool Voting threshold for protocol parameter changes, security group.
             example: 0.6
           min_fee_ref_script_cost_per_byte:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Minimum Fee for Reference Script cost pre byte
             example: 15
     epoch_block_protocols:
@@ -4272,6 +4339,7 @@ components:
             type: number
             description: Amount of blocks with specified major and protocol combination
             example: 2183
+
     blocks:
       description: Array of block information
       type: array
@@ -4317,7 +4385,7 @@ components:
           pool:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Pool ID in bech32 format (null for pre-Shelley blocks)
             example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
           op_cert_counter:
@@ -4371,13 +4439,13 @@ components:
           total_output:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total output of the block (in number)
             example: "92384672389"
           total_fees:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Total fees of the block (in number)
             example: "2346834"
           num_confirmations:
@@ -4473,8 +4541,8 @@ components:
           inputs:
             description: An array of UTxO inputs spent in the transaction
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           outputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
           withdrawals:
@@ -4489,6 +4557,7 @@ components:
             $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
           plutus_contracts:
             $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
+
     address_info:
       description: Array of information for address(es)
       type: array
@@ -4503,8 +4572,8 @@ components:
             example: "10723473983"
           stake_address:
             anyOf:
-            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            - type: 'null'
+              - $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              - type: "null"
           script_address:
             type: boolean
             description: Signifies whether the address is a script address
@@ -4606,7 +4675,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script hash in case the stake address is locked by a script
             example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
     account_info:
@@ -4625,13 +4694,13 @@ components:
           delegated_drep:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
             example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
           delegated_pool:
             anyOf:
-            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-            - type: 'null'
+              - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+              - type: "null"
           total_balance:
             type: string
             description: Total balance of the account including UTxO, rewards and MIRs (in number)
@@ -4668,109 +4737,6 @@ components:
             type: string
             description: Total proposal refund for this account
             example: "0"
-    utxo_infos:
-      description: Array of complete UTxO information
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          inline_datum:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-          reference_script:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-          asset_list:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: An array of assets on the UTxO
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of assets on the UTxO
-                  example: "1"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    tx_outs_epoch:
-      description: List of transaction outputs with basic details for requested epoch
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
     account_rewards:
       description: Array of reward history information
       type: array
@@ -4799,7 +4765,7 @@ components:
                 pool_id:
                   anyOf:
                     - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-                    - type: 'null'
+                    - type: "null"
     account_reward_history:
       description: Array of reward history information
       type: array
@@ -4823,7 +4789,7 @@ components:
           pool_id_bech32:
             anyOf:
               - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-              - type: 'null'
+              - type: "null"
     account_updates:
       description: Array of account updates information
       type: array
@@ -4840,7 +4806,14 @@ components:
                 action_type:
                   type: string
                   description: Type of certificate submitted
-                  enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+                  enum:
+                    [
+                      "registration",
+                      "delegation_pool",
+                      "delegation_drep",
+                      "withdrawal",
+                      "deregistration",
+                    ]
                   example: "registration"
                 tx_hash:
                   $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4863,7 +4836,14 @@ components:
           action_type:
             type: string
             description: Type of certificate submitted
-            enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
+            enum:
+              [
+                "registration",
+                "delegation_pool",
+                "delegation_drep",
+                "withdrawal",
+                "deregistration",
+              ]
             example: "registration"
           tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -4952,6 +4932,7 @@ components:
             type: string
             description: Active stake amount (in numbers)
             example: 682334162
+
     tx_info:
       description: Array of detailed information about transaction(s)
       type: array
@@ -5001,25 +4982,25 @@ components:
           invalid_before:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot before which transaction cannot be validated (if supplied, else null)
             example: "42331172"
           invalid_after:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Slot after which transaction cannot be validated
             example: "42332172"
           collateral_inputs:
             description: An array of collateral inputs needed for smart contracts in case of contract failure
             anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
+              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+              - type: "null"
           collateral_output:
             description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             items:
               properties:
                 payment_addr:
@@ -5045,7 +5026,7 @@ components:
             description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
             anyOf:
               - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-              - type: 'null'
+              - type: "null"
           inputs:
             $ref: "#/components/schemas/tx_info/items/properties/outputs"
             #description: An array of UTxO inputs spent in the transaction
@@ -5077,13 +5058,13 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
-                  description: Hash of datum (if any) connected to UTxO 
+                    - type: "null"
+                  description: Hash of datum (if any) connected to UTxO
                   example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
                 inline_datum:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allows datums to be attached to UTxO (CIP-32)
                   properties:
                     bytes:
@@ -5097,7 +5078,7 @@ components:
                 reference_script:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
                   properties:
                     hash:
@@ -5119,7 +5100,7 @@ components:
                     value:
                       anyOf:
                         - type: object
-                        - type: 'null'
+                        - type: "null"
                       description: Value (json)
                       example: null
                 asset_list:
@@ -5127,7 +5108,7 @@ components:
           withdrawals:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of withdrawals with-in a transaction
             items:
               type: object
@@ -5143,7 +5124,7 @@ components:
           assets_minted:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of minted assets with-in a transaction
             items:
               properties:
@@ -5164,14 +5145,14 @@ components:
           certificates:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Certificates present with-in a transaction (if any)
             items:
               properties:
                 index:
                   anyOf:
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: Certificate index
                   example: 0
                 type:
@@ -5181,7 +5162,7 @@ components:
                 info:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   description: A JSON array containing information from the certificate
                   example:
                     {
@@ -5191,7 +5172,7 @@ components:
           native_scripts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Native scripts present in a transaction (if any)
             items:
               properties:
@@ -5222,20 +5203,20 @@ components:
           plutus_contracts:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Plutus contracts present in transaction (if any)
             items:
               properties:
                 address:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: Plutus script address
                   example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
                 spends_input:
                   anyOf:
                     - type: object
-                    - type: 'null'
+                    - type: "null"
                   properties:
                     tx_hash:
                       $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
@@ -5286,7 +5267,7 @@ components:
           voting_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance votes in a transaction (if any)
             items:
               properties:
@@ -5305,7 +5286,7 @@ components:
           proposal_procedures:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Governance proposals in a transaction (if any)
             items:
               properties:
@@ -5390,7 +5371,7 @@ components:
       description: Array of metadata information present in each of the transactions queried
       anyOf:
         - type: array
-        - type: 'null'
+        - type: "null"
       items:
         properties:
           tx_hash:
@@ -5398,7 +5379,7 @@ components:
           metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: A JSON array containing details about metadata within transaction
             example:
               {
@@ -5421,7 +5402,7 @@ components:
           num_confirmations:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Number of block confirmations
             example: 17
     tx_metalabels:
@@ -5433,6 +5414,130 @@ components:
             type: string
             description: A distinct known metalabel
             example: "721"
+    utxo_infos:
+      description: Array of complete UTxO information
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          inline_datum:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+          reference_script:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+          asset_list:
+            anyOf:
+              - type: array
+              - type: "null"
+            description: An array of assets on the UTxO
+            items:
+              properties:
+                policy_id:
+                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+                asset_name:
+                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+                fingerprint:
+                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+                decimals:
+                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+                quantity:
+                  type: string
+                  description: Quantity of assets on the UTxO
+                  example: "1"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_outs_epoch:
+      description: List of transaction outputs with basic details for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          tx_hash:
+            type: string
+            description: Hash identifier of the transaction
+            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+          tx_index:
+            type: number
+            description: Index of UTxO in the transaction
+            example: 0
+          address:
+            type: string
+            description: A Cardano payment/base address (bech32 encoded)
+            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+          stake_address:
+            $ref: "#/components/schemas/address_info/items/properties/stake_address"
+          payment_cred:
+            anyOf:
+              - type: string
+              - type: "null"
+            description: Payment credential
+            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          value:
+            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+          datum_hash:
+            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+          is_spent:
+            type: boolean
+            description: True if the UTXO has been spent
+            example: true
+    tx_treasury_donations_epoch:
+      description: List of treasury donation transactions for requested epoch
+      type: array
+      items:
+        type: object
+        properties:
+          epoch_no:
+            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+          tx_hash:
+            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+          block_hash:
+            $ref: "#/components/schemas/blocks/items/properties/hash"
+          tx_block_index:
+            $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+          block_height:
+            $ref: "#/components/schemas/blocks/items/properties/block_height"
+          block_time:
+            $ref: "#/components/schemas/blocks/items/properties/block_time"
+          treasury_donation:
+            $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+
     asset_list:
       description: Array of policy IDs and asset names
       type: array
@@ -5530,7 +5635,7 @@ components:
           asset_name:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Asset Name (hex)
             example: 444f4e545350414d
           asset_name_ascii:
@@ -5568,33 +5673,33 @@ components:
           token_registry_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Asset metadata registered on the Cardano Token Registry
             properties:
               name:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Rackmob
               description:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: Metaverse Blockchain Cryptocurrency.
               ticker:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: MOB
               url:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 example: https://www.rackmob.com/
               logo:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: A PNG image file as a byte string
                 example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
               decimals:
@@ -5603,9 +5708,27 @@ components:
           cip68_metadata:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: CIP 68 metadata if present for asset
-            example: {"222": {"fields": [{"map": [{"k": {"bytes": "6e616d65"}, "v": {"bytes": "74657374"}}]}], "constructor": 0}}
+            example:
+              {
+                "222":
+                  {
+                    "fields":
+                      [
+                        {
+                          "map":
+                            [
+                              {
+                                "k": { "bytes": "6e616d65" },
+                                "v": { "bytes": "74657374" },
+                              },
+                            ],
+                        },
+                      ],
+                    "constructor": 0,
+                  },
+              }
     asset_history:
       description: Array of asset mint/burn history
       type: array
@@ -5620,7 +5743,7 @@ components:
           minting_txs:
             anyOf:
               - type: array
-              - type: 'null'
+              - type: "null"
             description: Array of all mint/burn transactions for an asset
             items:
               type: object
@@ -5640,6 +5763,7 @@ components:
                   description: Array of Transaction Metadata for given transaction
                   items:
                     $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+
     policy_asset_addresses:
       description: Array of asset names and payment addresses for the given policy (including balances)
       type: array
@@ -5716,6 +5840,7 @@ components:
             $ref: "#/components/schemas/asset_info/items/properties/total_supply"
           decimals:
             $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+
     drep_info:
       description: Get detailed information about requested delegated representatives (DReps)
       type: array
@@ -5740,7 +5865,7 @@ components:
           deposit:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: DRep's registration deposit  in number
             example: "500000000"
           active:
@@ -5750,7 +5875,7 @@ components:
           expires_epoch_no:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: After which epoch DRep is considered inactive.
             example: 410
           amount:
@@ -5760,13 +5885,13 @@ components:
           meta_url:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A URL to a JSON payload of metadata
             example: "https://hornan7.github.io/Vote_Context.jsonld"
           meta_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A hash of the contents of the metadata URL
             example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
     drep_epoch_summary:
@@ -5832,36 +5957,121 @@ components:
           meta_json:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: The payload as JSON
             example:
-              {"body": {"title": "...", "...": "...", "references": [{"uri": "...", "@type": "Other", "label": "Hardfork to PV10"}]}, "authors": [{"name": "...", "witness": {"publicKey": "...", "signature": "...", "witnessAlgorithm": "ed25519"}}], "@context": {"body": {"@id": "CIP108:body", "@context": {"title": "CIP108:title", "abstract": "CIP108:abstract", "rationale": "CIP108:rationale", "motivation": "CIP108:motivation", "references": {"@id": "CIP108:references", "@context": {"uri": "CIP100:reference-uri", "Other": "CIP100:OtherReference", "label": "CIP100:reference-label", "referenceHash": {"@id": "CIP108:referenceHash", "@context": {"hashDigest": "CIP108:hashDigest", "hashAlgorithm": "CIP100:hashAlgorithm"}}, "GovernanceMetadata": "CIP100:GovernanceMetadataReference"}, "@container": "@set"}}}, "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#", "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#", "authors": {"@id": "CIP100:authors", "@context": {"name": "http://xmlns.com/foaf/0.1/name", "witness": {"@id": "CIP100:witness", "@context": {"publicKey": "CIP100:publicKey", "signature": "CIP100:signature", "witnessAlgorithm": "CIP100:witnessAlgorithm"}}}, "@container": "@set"}, "@language": "en-us", "hashAlgorithm": "CIP100:hashAlgorithm"}, "hashAlgorithm": "blake2b-256"}
+              {
+                "body":
+                  {
+                    "title": "...",
+                    "...": "...",
+                    "references":
+                      [
+                        {
+                          "uri": "...",
+                          "@type": "Other",
+                          "label": "Hardfork to PV10",
+                        },
+                      ],
+                  },
+                "authors":
+                  [
+                    {
+                      "name": "...",
+                      "witness":
+                        {
+                          "publicKey": "...",
+                          "signature": "...",
+                          "witnessAlgorithm": "ed25519",
+                        },
+                    },
+                  ],
+                "@context":
+                  {
+                    "body":
+                      {
+                        "@id": "CIP108:body",
+                        "@context":
+                          {
+                            "title": "CIP108:title",
+                            "abstract": "CIP108:abstract",
+                            "rationale": "CIP108:rationale",
+                            "motivation": "CIP108:motivation",
+                            "references":
+                              {
+                                "@id": "CIP108:references",
+                                "@context":
+                                  {
+                                    "uri": "CIP100:reference-uri",
+                                    "Other": "CIP100:OtherReference",
+                                    "label": "CIP100:reference-label",
+                                    "referenceHash":
+                                      {
+                                        "@id": "CIP108:referenceHash",
+                                        "@context":
+                                          {
+                                            "hashDigest": "CIP108:hashDigest",
+                                            "hashAlgorithm": "CIP100:hashAlgorithm",
+                                          },
+                                      },
+                                    "GovernanceMetadata": "CIP100:GovernanceMetadataReference",
+                                  },
+                                "@container": "@set",
+                              },
+                          },
+                      },
+                    "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
+                    "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#",
+                    "authors":
+                      {
+                        "@id": "CIP100:authors",
+                        "@context":
+                          {
+                            "name": "http://xmlns.com/foaf/0.1/name",
+                            "witness":
+                              {
+                                "@id": "CIP100:witness",
+                                "@context":
+                                  {
+                                    "publicKey": "CIP100:publicKey",
+                                    "signature": "CIP100:signature",
+                                    "witnessAlgorithm": "CIP100:witnessAlgorithm",
+                                  },
+                              },
+                          },
+                        "@container": "@set",
+                      },
+                    "@language": "en-us",
+                    "hashAlgorithm": "CIP100:hashAlgorithm",
+                  },
+                "hashAlgorithm": "blake2b-256",
+              }
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The raw bytes of the payload
             example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
           warning:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: A warning that occured while validating the metadata
           language:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: The language described in the context of the metadata as per CIP-100
             example: en-us
           comment:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Comment attached to the metadata
           is_valid:
             anyOf:
               - type: boolean
-              - type: 'null'
+              - type: "null"
             description: Indicate whether data is invalid (currently returns null for all as per dbsync)
             example: null
     drep_updates:
@@ -5886,7 +6096,7 @@ components:
           action:
             type: string
             description: Effective action for this DRep Update certificate
-            enum: ["updated","registered","deregistered"]
+            enum: ["updated", "registered", "deregistered"]
             example: registered
           deposit:
             $ref: "#/components/schemas/drep_info/items/properties/deposit"
@@ -5907,8 +6117,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the DRep
             example: "14231445553"
     drep_votes:
@@ -5928,7 +6138,7 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/block_time"
           vote:
             type: string
-            enum: ["Yes","No","Abstain"]
+            enum: ["Yes", "No", "Abstain"]
             description: Actual Vote casted
             example: "Yes"
           meta_url:
@@ -5946,8 +6156,8 @@ components:
             $ref: "#/components/schemas/blocks/items/properties/epoch_no"
           amount:
             anyOf:
-            - type: string
-            - type: 'null'
+              - type: string
+              - type: "null"
             description: The voting power for the pool for the epoch
             example: "11231445553"
     pool_votes:
@@ -5970,7 +6180,7 @@ components:
           proposal_id:
             type: string
             description: Proposal Action ID in accordance with CIP-129 format
-            example: 'gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh'
+            example: "gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh"
           proposal_tx_hash:
             $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
           proposal_index:
@@ -5979,7 +6189,16 @@ components:
             example: 0
           proposal_type:
             type: string
-            enum: ["ParameterChange", "HardForkInitiation", "TreasuryWithdrawals", "NoConfidence", "NewCommittee", "NewConstitution", "InfoAction"]
+            enum:
+              [
+                "ParameterChange",
+                "HardForkInitiation",
+                "TreasuryWithdrawals",
+                "NoConfidence",
+                "NewCommittee",
+                "NewConstitution",
+                "InfoAction",
+              ]
             description: Proposal Action Type
             example: ParameterChange
           proposal_description:
@@ -5999,31 +6218,31 @@ components:
           ratified_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been ratified at the specfied epoch.
             example: 670
           enacted_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been enacted at the specfied epoch.
             example: 675
           dropped_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
             example: 680
           expired_epoch:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: If not null, then this proposal has been expired at the specfied epoch.
             example: 680
           expiration:
             anyOf:
               - type: number
-              - type: 'null'
+              - type: "null"
             description: Shows the epoch at which this governance action is expected to expire.
           meta_url:
             $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
@@ -6040,7 +6259,7 @@ components:
           withdrawal:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: If not null, the amount withdrawn from treasury into stake address by this this proposal
             properties:
               stake_address:
@@ -6052,8 +6271,8 @@ components:
             description: If not null, the proposed new parameter set
             anyOf:
               - type: object
-              - type: 'null'
-            example: {"key_deposit": 1000000}
+              - type: "null"
+            example: { "key_deposit": 1000000 }
     voter_proposal_list:
       description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
       type: array
@@ -6281,7 +6500,7 @@ components:
               status:
                 type: string
                 description: Member authentication status
-                enum: [ "authorized", "not_authorized", "resigned" ]
+                enum: ["authorized", "not_authorized", "resigned"]
                 example: authorized
               cc_cold_hex:
                 type: string
@@ -6294,19 +6513,20 @@ components:
               cc_hot_hex:
                 anyOf:
                   - type: string
-                  - type: 'null'
+                  - type: "null"
                 description: Committee member key hash from last valid hot key authorization certificate in hex format
                 example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
               cc_hot_has_script:
                 anyOf:
                   - type: boolean
-                  - type: 'null'
+                  - type: "null"
                 description: Flag which shows if this credential is a script hash
                 example: false
               expiration_epoch:
                 type: number
                 description: Epoch number in which the committee member vote rights expire
                 example: 324
+
     script_info:
       type: array
       items:
@@ -6315,7 +6535,7 @@ components:
           script_hash:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Hash of a script
             example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
           creation_tx_hash:
@@ -6325,18 +6545,18 @@ components:
           type:
             type: string
             description: Type of the script
-            enum: ["plutusV1","plutusV2","timelock","multisig"]
+            enum: ["plutusV1", "plutusV2", "timelock", "multisig"]
             example: plutusV1
           value:
             anyOf:
               - type: object
-              - type: 'null'
+              - type: "null"
             description: Data in JSON format
             example: null
           bytes:
             anyOf:
               - type: string
-              - type: 'null'
+              - type: "null"
             description: Script bytes (cborSeq)
             example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
           size:
@@ -6377,14 +6597,14 @@ components:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Memory to run a script
                   example: 520448
                 unit_steps:
                   anyOf:
                     - type: string
                     - type: number
-                    - type: 'null'
+                    - type: "null"
                   description: The budget in Cpu steps to run a script
                   example: 211535239
                 fee:
@@ -6399,7 +6619,7 @@ components:
                 datum_hash:
                   anyOf:
                     - type: string
-                    - type: 'null'
+                    - type: "null"
                   description: The Hash of the Plutus Data
                   example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
                 datum_value:
@@ -6418,6 +6638,7 @@ components:
             $ref: "#/components/schemas/script_info/items/properties/value"
           bytes:
             $ref: "#/components/schemas/script_info/items/properties/bytes"
+
     ogmiostip:
       description: Current tip of the chain, identified by a slot and a block header hash.
       type: object
@@ -6436,7 +6657,7 @@ components:
             - type: number
             - type: array
             - type: object
-            - type: 'null'
+            - type: "null"
           description: Result of the query
           properties:
             slot:
@@ -6447,7 +6668,11 @@ components:
               type: string
               description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
               example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
-          example: {"slot": 59886800, "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"}
+          example:
+            {
+              "slot": 59886800,
+              "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1",
+            }
   headers: {}
   responses:
     NotFound:

--- a/specs/templates/2-api-params.yaml
+++ b/specs/templates/2-api-params.yaml
@@ -1,201 +1,201 @@
 parameters:
-    _after_block_height:
-      deprecated: false
-      name: _after_block_height
-      description: Block height for specifying time delta
-      schema:
-        type: number
-        example: 50000
-      in: query
-      required: false
-      allowEmptyValue: true
-    _epoch_no:
-      deprecated: false
-      name: _epoch_no
-      description: Epoch Number to fetch details for
-      schema:
-        type: string
-      example: "##_epoch_no_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _stake_address:
-      deprecated: false
-      name: _stake_address
-      description: Cardano staking address (reward account) in bech32 format
-      schema:
-        type: string
-      example: "##_stake_address_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _tx_hash:
-      deprecated: false
-      name: _tx_hash
-      description: Transaction Hash in hexadecimal format (hex)
-      example: "##_tx_hash_param##"
-      schema:
-        type: string
-      in: query
-      required: true
-      allowEmptyValue: false
-    _asset_policy:
-      deprecated: false
-      name: _asset_policy
-      description: Asset Policy ID in hexadecimal format (hex)
-      schema:
-        type: string
-      example: "##_asset_policy_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _asset_name:
-      deprecated: false
-      name: _asset_name
-      description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
-      schema:
-        type: string
-      example: "##_asset_name_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _asset_policy_nft:
-      deprecated: false
-      name: _asset_policy
-      description: NFT Policy ID in hexadecimal format (hex)
-      schema:
-        type: string
-      example: "##_asset_policy_nft_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _asset_name_nft:
-      deprecated: false
-      name: _asset_name
-      description: NFT Name in hexadecimal format (hex)
-      schema:
-        type: string
-      example: "##_asset_name_nft_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _voter_id:
-      deprecated: false
-      name: _voter_id
-      description: Voter ID (Drep, SPO, Committee Member) in Bech32 format (CIP-5 | CIP-129)
-      schema:
-        type: string
-      example: "##_drep_id_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _drep_id:
-      deprecated: false
-      name: _drep_id
-      description: DRep ID in bech32 format
-      schema:
-        type: string
-      example: "##_drep_id_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _drep_id_optional:
-      deprecated: false
-      name: _drep_id
-      description: DRep ID in bech32 format
-      schema:
-        type: string
-      example: "##_drep_id_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _cc_hot_id:
-      deprecated: false
-      name: _cc_hot_id
-      description: Committee member hot key ID in Bech32 format (CIP-5 | CIP-129)
-      schema:
-        type: string
-      example: "##_cc_hot_id_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _extended:
-      deprecated: false
-      name: _extended
-      description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
-      schema:
-        type: boolean
-      example: false
-      in: query
-      required: false
-      allowEmptyValue: true
-    _history:
-      deprecated: false
-      name: _history
-      description: Include all historical transactions, setting to false includes only the non-empty ones
-      schema:
-        type: boolean
-      example: false
-      in: query
-      required: false
-      allowEmptyValue: false
-    _include_next_epoch:
-      deprecated: false
-      name: _include_next_epoch
-      description: Include information about nearing but not yet started epoch, to get access to active stake snapshot information if available
-      schema:
-        type: boolean
-      example: false
-      in: query
-      required: false
-      allowEmptyValue: true
-    _pool_bech32:
-      deprecated: false
-      name: _pool_bech32
-      description: Pool ID in bech32 format
-      schema:
-        type: string
-      example: "##_pool_bech32_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _pool_bech32_optional:
-      deprecated: false
-      name: _pool_bech32
-      description: Pool ID in bech32 format (optional)
-      schema:
-        type: string
-      example: "##_pool_bech32_optional_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _pool_epoch_no:
-      deprecated: false
-      name: _epoch_no
-      description: Epoch Number to fetch details for
-      schema:
-        type: string
-      example: "##_pool_epoch_no_param##"
-      in: query
-      required: false
-      allowEmptyValue: true
-    _script_hash:
-      deprecated: false
-      name: _script_hash
-      description: Script hash in hexadecimal format (hex)
-      schema:
-        type: string
-      example: "##_script_hash_param##"
-      in: query
-      required: true
-      allowEmptyValue: false
-    _proposal_id:
-      deprecated: false
-      name: _proposal_id
-      description: Government proposal ID in CIP-129 Bech32 format
-      example: "##_proposal_id_param##"
-      schema:
-        type: string
-      in: query
-      required: true
-      allowEmptyValue: false
+  _after_block_height:
+    deprecated: false
+    name: _after_block_height
+    description: Block height for specifying time delta
+    schema:
+      type: number
+      example: 50000
+    in: query
+    required: false
+    allowEmptyValue: true
+  _epoch_no:
+    deprecated: false
+    name: _epoch_no
+    description: Epoch Number to fetch details for
+    schema:
+      type: string
+    example: "##_epoch_no_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _stake_address:
+    deprecated: false
+    name: _stake_address
+    description: Cardano staking address (reward account) in bech32 format
+    schema:
+      type: string
+    example: "##_stake_address_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _tx_hash:
+    deprecated: false
+    name: _tx_hash
+    description: Transaction Hash in hexadecimal format (hex)
+    example: "##_tx_hash_param##"
+    schema:
+      type: string
+    in: query
+    required: true
+    allowEmptyValue: false
+  _asset_policy:
+    deprecated: false
+    name: _asset_policy
+    description: Asset Policy ID in hexadecimal format (hex)
+    schema:
+      type: string
+    example: "##_asset_policy_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _asset_name:
+    deprecated: false
+    name: _asset_name
+    description: Asset Name in hexadecimal format (hex), empty asset name returns royalties
+    schema:
+      type: string
+    example: "##_asset_name_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _asset_policy_nft:
+    deprecated: false
+    name: _asset_policy
+    description: NFT Policy ID in hexadecimal format (hex)
+    schema:
+      type: string
+    example: "##_asset_policy_nft_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _asset_name_nft:
+    deprecated: false
+    name: _asset_name
+    description: NFT Name in hexadecimal format (hex)
+    schema:
+      type: string
+    example: "##_asset_name_nft_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _voter_id:
+    deprecated: false
+    name: _voter_id
+    description: Voter ID (Drep, SPO, Committee Member) in Bech32 format (CIP-5 | CIP-129)
+    schema:
+      type: string
+    example: "##_drep_id_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _drep_id:
+    deprecated: false
+    name: _drep_id
+    description: DRep ID in bech32 format
+    schema:
+      type: string
+    example: "##_drep_id_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _drep_id_optional:
+    deprecated: false
+    name: _drep_id
+    description: DRep ID in bech32 format
+    schema:
+      type: string
+    example: "##_drep_id_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _cc_hot_id:
+    deprecated: false
+    name: _cc_hot_id
+    description: Committee member hot key ID in Bech32 format (CIP-5 | CIP-129)
+    schema:
+      type: string
+    example: "##_cc_hot_id_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _extended:
+    deprecated: false
+    name: _extended
+    description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+    schema:
+      type: boolean
+    example: false
+    in: query
+    required: false
+    allowEmptyValue: true
+  _history:
+    deprecated: false
+    name: _history
+    description: Include all historical transactions, setting to false includes only the non-empty ones
+    schema:
+      type: boolean
+    example: false
+    in: query
+    required: false
+    allowEmptyValue: false
+  _include_next_epoch:
+    deprecated: false
+    name: _include_next_epoch
+    description: Include information about nearing but not yet started epoch, to get access to active stake snapshot information if available
+    schema:
+      type: boolean
+    example: false
+    in: query
+    required: false
+    allowEmptyValue: true
+  _pool_bech32:
+    deprecated: false
+    name: _pool_bech32
+    description: Pool ID in bech32 format
+    schema:
+      type: string
+    example: "##_pool_bech32_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _pool_bech32_optional:
+    deprecated: false
+    name: _pool_bech32
+    description: Pool ID in bech32 format (optional)
+    schema:
+      type: string
+    example: "##_pool_bech32_optional_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _pool_epoch_no:
+    deprecated: false
+    name: _epoch_no
+    description: Epoch Number to fetch details for
+    schema:
+      type: string
+    example: "##_pool_epoch_no_param##"
+    in: query
+    required: false
+    allowEmptyValue: true
+  _script_hash:
+    deprecated: false
+    name: _script_hash
+    description: Script hash in hexadecimal format (hex)
+    schema:
+      type: string
+    example: "##_script_hash_param##"
+    in: query
+    required: true
+    allowEmptyValue: false
+  _proposal_id:
+    deprecated: false
+    name: _proposal_id
+    description: Government proposal ID in CIP-129 Bech32 format
+    example: "##_proposal_id_param##"
+    schema:
+      type: string
+    in: query
+    required: true
+    allowEmptyValue: false

--- a/specs/templates/3-api-requestBodies.yaml
+++ b/specs/templates/3-api-requestBodies.yaml
@@ -1,573 +1,629 @@
 requestBodies:
-    block_hashes:
-      content:
-        application/json:
-          schema:
-            required:
-              - _block_hashes
-            type: object
-            properties:
-              _block_hashes:
-                type: array
-                items:
-                  $ref: "#/components/schemas/blocks/items/properties/hash"
-            example:
-              _block_hashes:
-                - ##block_info1_rb##
-                - ##block_info2_rb##
-                - ##block_info3_rb##
-      description: Array of block hashes
-    block_tx_info:
-      content:
-        application/json:
-          schema:
-            required:
-              - _block_hashes
-            type: object
-            properties:
-              _block_hashes:
-                type: array
-                items:
-                  $ref: "#/components/schemas/blocks/items/properties/hash"
-              _inputs:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction inputs in the result
-              _metadata:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction metadata in the result
-              _assets:
-                format: boolean
-                type: boolean
-                description: Controls whether to include assets involved within transaction the result
-              _withdrawals:
-                format: boolean
-                type: boolean
-                description: Controls whether to include any stake account reward withdrawals in the result
-              _certs:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction certificates in the result
-              _scripts:
-                format: boolean
-                type: boolean
-                description: Controls whether to include any details regarding collateral/reference/datum/script objects in the result
-              _bytecode:
-                format: boolean
-                type: boolean
-                description: Controls whether to include bytecode for associated reference/plutus scripts
-            example:
-              _block_hashes:
-                - ##block_info1_rb##
-                - ##block_info2_rb##
-                - ##block_info3_rb##
-              _inputs: false
-              _metadata: false
-              _assets: false
-              _withdrawals: false
-              _certs: false
-              _scripts: false
-              _bytecode: false
-      description: Array of block hashes
-    payment_addresses:
-      content:
-        application/json:
-          schema:
-            required:
-              - _addresses
-            type: object
-            properties:
-              _addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano payment address(es) in bech32 format
-            example:
-              _addresses:
-                - ##payment_addresses1_rb##
-                - ##payment_addresses2_rb##
-      description: Array of Cardano payment address(es)
-    payment_addresses_with_extended:
-      content:
-        application/json:
-          schema:
-            required:
-              - _addresses
-            type: object
-            properties:
-              _addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano payment address(es) in bech32 format
-              _extended:
-                format: boolean
-                type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
-            example:
-              _addresses:
-                - ##payment_addresses1_rb##
-                - ##payment_addresses2_rb##
-              _extended: true
-      description: Array of Cardano payment address(es) with extended flag to toggle additional fields
-    address_txs:
-      content:
-        application/json:
-          schema:
-            required:
-              - _addresses
-            type: object
-            properties:
-              _addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano payment address(es) in bech32 format
-              _after_block_height:
-                format: integer
-                type: number
-                description: Only fetch information after specific block height
-            example:
-              _addresses:
-                - ##payment_addresses1_rb##
-                - ##payment_addresses2_rb##
-              _after_block_height: ##address_txs_after_block_height_rb##
-      description: Array of Cardano payment address(es)
-    stake_addresses_with_epoch_no:
-      content:
-        application/json:
-          schema:
-            required:
-              - _stake_addresses
-            type: object
-            properties:
-              _stake_addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano stake address(es) in bech32 format
-              _epoch_no:
-                format: integer
-                type: number
-                description: Only fetch information for a specific epoch
-            example:
-              _stake_addresses:
-                - ##stake_addresses1_rb##
-                - ##stake_addresses2_rb##
-              _epoch_no: ##epoch_no_rb##
-      description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
-    stake_addresses_with_first_only_and_empty:
-      content:
-        application/json:
-          schema:
-            required:
-              - _stake_addresses
-            type: object
-            properties:
-              _stake_addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano stake address(es) in bech32 format
-              _first_only:
-                format: boolean
-                type: boolean
-                description: Only return the first result
-              _empty:
-                format: boolean
-                type: boolean
-                description: Include zero quantity entries
-            example:
-              _stake_addresses:
-                - ##stake_addresses1_rb##
-                - ##stake_addresses2_rb##
-              _first_only: false
-              _empty: false
-      description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
-    stake_addresses_with_extended:
-      content:
-        application/json:
-          schema:
-            required:
-              - _stake_addresses
-            type: object
-            properties:
-              _stake_addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano stake address(es) in bech32 format
-              _extended:
-                format: boolean
-                type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
-            example:
-              _stake_addresses:
-                - ##stake_addresses1_rb##
-                - ##stake_addresses2_rb##
-              _extended: true
-      description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
-    stake_addresses:
-      content:
-        application/json:
-          schema:
-            required:
-              - _stake_addresses
-            type: object
-            properties:
-              _stake_addresses:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano stake address(es) in bech32 format
-            example:
-              _stake_addresses:
-                - ##stake_addresses1_rb##
-                - ##stake_addresses2_rb##
-      description: Array of Cardano stake credential(s) in bech32 format
-    credential_txs:
-      content:
-        application/json:
-          schema:
-            required:
-              - _payment_credentials
-            type: object
-            properties:
-              _payment_credentials:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano payment credential(s) in hex format
-              _after_block_height:
-                format: integer
-                type: number
-                description: Only fetch information after specific block height
-            example:
-              _payment_credentials:
-                - ##credential_txs_payment_credentials1_rb##
-                - ##credential_txs_payment_credentials2_rb##
-              _after_block_height: ##address_txs_after_block_height_rb##
-      description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
-    credential_utxos:
-      content:
-        application/json:
-          schema:
-            required:
-              - _payment_credentials
-            type: object
-            properties:
-              _payment_credentials:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano payment credential(s) in hex format
-              _extended:
-                format: boolean
-                type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
-            example:
-              _payment_credentials:
-                - ##credential_txs_payment_credentials1_rb##
-                - ##credential_txs_payment_credentials2_rb##
-              _extended: true
-      description: Array of Cardano payment credential(s) in hex format
-    tx_ids:
-      content:
-        application/json:
-          schema:
-            required:
-              - _tx_hashes
-            type: object
-            properties:
-              _tx_hashes:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano Transaction hashes
-            example:
-              _tx_hashes:
-                - ##tx_ids_tx_hashes1_rb##
-                - ##tx_ids_tx_hashes2_rb##
-      description: Array of Cardano Transaction hashes
-    tx_info:
-      content:
-        application/json:
-          schema:
-            required:
-              - _tx_hashes
-            type: object
-            properties:
-              _tx_hashes:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano Transaction hashes
-              _inputs:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction inputs in the result
-              _metadata:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction metadata in the result
-              _assets:
-                format: boolean
-                type: boolean
-                description: Controls whether to include assets involved within transaction the result
-              _withdrawals:
-                format: boolean
-                type: boolean
-                description: Controls whether to include any stake account reward withdrawals in the result
-              _certs:
-                format: boolean
-                type: boolean
-                description: Controls whether to include transaction certificates in the result
-              _scripts:
-                format: boolean
-                type: boolean
-                description: Controls whether to include any details regarding collateral/reference/datum/script objects in the result
-              _bytecode:
-                format: boolean
-                type: boolean
-                description: Controls whether to include bytecode for associated reference/plutus scripts
-              _governance:
-                format: boolean
-                type: boolean
-                description: Controls whether to include governance certificates, votes and proposals in the result
-            example:
-              _tx_hashes:
-                - ##tx_ids_tx_hashes1_rb##
-                - ##tx_ids_tx_hashes2_rb##
-              _inputs: false
-              _metadata: false
-              _assets: false
-              _withdrawals: false
-              _certs: false
-              _scripts: false
-              _bytecode: false
-      description: Array of Cardano Transaction hashes
-    txbin:
-      content:
-        application/cbor:
-          schema:
-            type: string
-            format: binary
-            example: ##txbin_rb##
-      description: Serialised Cardano Transaction
-    pool_ids:
-      content:
-        application/json:
-          schema:
-            required:
-              - _pool_bech32_ids
-            type: object
-            properties:
-              _pool_bech32_ids:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano pool IDs (bech32 format)
-            example:
-              _pool_bech32_ids:
-                - ##pool_ids_pool_bech32_ids1_rb##
-                - ##pool_ids_pool_bech32_ids2_rb##
-                - ##pool_ids_pool_bech32_ids3_rb##
-      description: Array of Cardano pool IDs (bech32 format)
-    pool_ids_optional:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              _pool_bech32_ids:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano pool IDs (bech32 format)
-            example:
-              _pool_bech32_ids:
-                - ##pool_ids_pool_bech32_ids1_rb##
-                - ##pool_ids_pool_bech32_ids2_rb##
-                - ##pool_ids_pool_bech32_ids3_rb##
-      description: Array of Cardano pool IDs (bech32 format) [Optional]
-    script_hashes:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              _script_hashes:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano script hashes
-            example:
-              _script_hashes:
-                  - ##script_hashes1_rb##
-                  - ##script_hashes2_rb##
-      description: Array of Cardano script hashes
-    datum_hashes:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              _datum_hashes:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano datum hashes
-            example:
-              _datum_hashes:
-                  - ##datum_hashes1_rb##
-                  - ##datum_hashes2_rb##
-      description: Array of Cardano datum hashes
-    asset_list:
-      content:
-        application/json:
-          schema:
-            required:
-              - _asset_list
-            type: object
-            properties:
-              _asset_list:
-                type: array
-                description: Array of array of policy ID and asset names (hex)
-                items:
-                  type: array
-                  items:
-                    type: string
-            example:
-              _asset_list:
-                - ##asset1_rb##
-                - ##asset2_rb##
-      description: Array of array of policyID and asset names (hex)
-    asset_list_with_extended:
-      content:
-        application/json:
-          schema:
-            required:
-              - _asset_list
-            type: object
-            properties:
-              _asset_list:
-                type: array
-                description: Array of array of policy ID and asset names (hex)
-                items:
-                  type: array
-                  items:
-                    type: string
-              _extended:
-                format: boolean
-                type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
-            example:
-              _asset_list:
-                - ##asset1_rb##
-                - ##asset2_rb##
-              _extended: true
-      description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
-    drep_id_bulk:
-      content:
-        application/json:
-          schema:
-            required:
-              - _drep_ids
-            type: object
-            properties:
-              _drep_ids:
-                type: array
-                descriptions: Array of DRep IDs in bech32 format
-                items:
-                  type: string
-            example:
-              _drep_ids:
-                - ##drep_ids1_rb##
-                - ##drep_ids2_rb##
-    utxo_refs_with_extended:
-      content:
-        application/json:
-          schema:
-            required:
-              - _utxo_refs
-            type: object
-            properties:
-              _utxo_refs:
-                type: array
-                items:
-                  type: string
-                description: Array of Cardano utxo references in the form "hash#index"
-              _extended:
-                format: boolean
-                type: boolean
-                description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call           
-            example:
-              _utxo_refs:
-                - ##utxo_ref1_rb##
-                - ##utxo_ref2_rb##
-              _extended: false
-      description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
-    ogmios:
-      content:
-        application/json:
-          schema:
-            required:
-              - jsonrpc
-              - method
-            type: object
-            properties:
-              jsonrpc:
+  block_hashes:
+    content:
+      application/json:
+        schema:
+          required:
+            - _block_hashes
+          type: object
+          properties:
+            _block_hashes:
+              type: array
+              items:
+                $ref: "#/components/schemas/blocks/items/properties/hash"
+          example:
+            _block_hashes:
+              -  ##block_info1_rb##
+              -  ##block_info2_rb##
+              -  ##block_info3_rb##
+    description: Array of block hashes
+  block_tx_info:
+    content:
+      application/json:
+        schema:
+          required:
+            - _block_hashes
+          type: object
+          properties:
+            _block_hashes:
+              type: array
+              items:
+                $ref: "#/components/schemas/blocks/items/properties/hash"
+            _inputs:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction inputs in the result
+            _metadata:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction metadata in the result
+            _assets:
+              format: boolean
+              type: boolean
+              description: Controls whether to include assets involved within transaction the result
+            _withdrawals:
+              format: boolean
+              type: boolean
+              description: Controls whether to include any stake account reward withdrawals in the result
+            _certs:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction certificates in the result
+            _scripts:
+              format: boolean
+              type: boolean
+              description: Controls whether to include any details regarding collateral/reference/datum/script objects in the result
+            _bytecode:
+              format: boolean
+              type: boolean
+              description: Controls whether to include bytecode for associated reference/plutus scripts
+          example:
+            _block_hashes:
+              -  ##block_info1_rb##
+              -  ##block_info2_rb##
+              -  ##block_info3_rb##
+            _inputs: false
+            _metadata: false
+            _assets: false
+            _withdrawals: false
+            _certs: false
+            _scripts: false
+            _bytecode: false
+    description: Array of block hashes
+  payment_addresses:
+    content:
+      application/json:
+        schema:
+          required:
+            - _addresses
+          type: object
+          properties:
+            _addresses:
+              type: array
+              items:
                 type: string
-                description: Identifier for JSON-RPC 2.0 standard
-                example: "2.0"
-              method:
+              description: Array of Cardano payment address(es) in bech32 format
+          example:
+            _addresses:
+              -  ##payment_addresses1_rb##
+              -  ##payment_addresses2_rb##
+    description: Array of Cardano payment address(es)
+  payment_addresses_with_extended:
+    content:
+      application/json:
+        schema:
+          required:
+            - _addresses
+          type: object
+          properties:
+            _addresses:
+              type: array
+              items:
                 type: string
-                description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
-                enum: ["queryNetwork/blockHeight","queryNetwork/genesisConfiguration","queryNetwork/startTime","queryNetwork/tip","queryLedgerState/epoch","queryLedgerState/eraStart","queryLedgerState/eraSummaries","queryLedgerState/liveStakeDistribution","queryLedgerState/protocolParameters","queryLedgerState/proposedProtocolParameters","queryLedgerState/stakePools","submitTransaction","evaluateTransaction"]
-                example: "queryNetwork/tip"
-              params:
-                type: object
-                description: Any parameters relevant to the specific method to be called
-                nullable: true
-          examples:
-            blockHeight:
-              description: Query the network’s highest block number.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
-            genesisConfiguration:
-              description: Query the genesis configuration of a given era.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/genesisConfiguration", "params": { "era": "shelley" } }
-            startTimeTime:
-              description: Query the network start time.
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
-            tip:
-              description: Query tip of the Network
-              value: { "jsonrpc": "2.0", "method": "queryNetwork/tip" }
-            epoch:
-              description: Query the current epoch of the ledger.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/epoch" }
-            eraStart:
-              description: Query information regarding the beginning of the current ledger era.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
-            eraSummaries:
-              description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
-            liveStakeDistribution:
-              description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/liveStakeDistribution" }
-            protocolParameters:
-              description: Query the current protocol parameters.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/protocolParameters" }
-            proposedProtocolParameters:
-              description: Query the last update proposal w.r.t. protocol parameters, if any.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/proposedProtocolParameters" }
-            StakePools:
-              description: Query the list of all stake pool identifiers currently registered and active.
-              value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
-            submitTransaction:
-              description: Submit a signed and serialized transaction to the network.
-              value: { "jsonrpc": "2.0", "method": "submitTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" } } }
-            evaluateTransaction:
-              description: Evaluate execution units of scripts in a well-formed transaction.
-              value: { "jsonrpc": "2.0", "method": "evaluateTransaction", "params": { "transaction": { "cbor": "<CBOR-serialized signed transaction (base16)>" }, "additionalUtxo": [ { ... } ] } }
-      description: JSON-RPC 2.0 standard request body
+              description: Array of Cardano payment address(es) in bech32 format
+            _extended:
+              format: boolean
+              type: boolean
+              description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+          example:
+            _addresses:
+              -  ##payment_addresses1_rb##
+              -  ##payment_addresses2_rb##
+            _extended: true
+    description: Array of Cardano payment address(es) with extended flag to toggle additional fields
+  address_txs:
+    content:
+      application/json:
+        schema:
+          required:
+            - _addresses
+          type: object
+          properties:
+            _addresses:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano payment address(es) in bech32 format
+            _after_block_height:
+              format: integer
+              type: number
+              description: Only fetch information after specific block height
+          example:
+            _addresses:
+              -  ##payment_addresses1_rb##
+              -  ##payment_addresses2_rb##
+            _after_block_height: ##address_txs_after_block_height_rb##
+    description: Array of Cardano payment address(es)
+  stake_addresses_with_epoch_no:
+    content:
+      application/json:
+        schema:
+          required:
+            - _stake_addresses
+          type: object
+          properties:
+            _stake_addresses:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano stake address(es) in bech32 format
+            _epoch_no:
+              format: integer
+              type: number
+              description: Only fetch information for a specific epoch
+          example:
+            _stake_addresses:
+              -  ##stake_addresses1_rb##
+              -  ##stake_addresses2_rb##
+            _epoch_no: ##epoch_no_rb##
+    description: Array of Cardano stake address(es) in bech32 format with optional epoch no to filter by
+  stake_addresses_with_first_only_and_empty:
+    content:
+      application/json:
+        schema:
+          required:
+            - _stake_addresses
+          type: object
+          properties:
+            _stake_addresses:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano stake address(es) in bech32 format
+            _first_only:
+              format: boolean
+              type: boolean
+              description: Only return the first result
+            _empty:
+              format: boolean
+              type: boolean
+              description: Include zero quantity entries
+          example:
+            _stake_addresses:
+              -  ##stake_addresses1_rb##
+              -  ##stake_addresses2_rb##
+            _first_only: false
+            _empty: false
+    description: Array of Cardano stake credential(s) in bech32 format alongwith flag to return first only or used UTxOs
+  stake_addresses_with_extended:
+    content:
+      application/json:
+        schema:
+          required:
+            - _stake_addresses
+          type: object
+          properties:
+            _stake_addresses:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano stake address(es) in bech32 format
+            _extended:
+              format: boolean
+              type: boolean
+              description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+          example:
+            _stake_addresses:
+              -  ##stake_addresses1_rb##
+              -  ##stake_addresses2_rb##
+            _extended: true
+    description: Array of Cardano stake credential(s) in bech32 format alongwith extended flag to return additional columns
+  stake_addresses:
+    content:
+      application/json:
+        schema:
+          required:
+            - _stake_addresses
+          type: object
+          properties:
+            _stake_addresses:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano stake address(es) in bech32 format
+          example:
+            _stake_addresses:
+              -  ##stake_addresses1_rb##
+              -  ##stake_addresses2_rb##
+    description: Array of Cardano stake credential(s) in bech32 format
+  credential_txs:
+    content:
+      application/json:
+        schema:
+          required:
+            - _payment_credentials
+          type: object
+          properties:
+            _payment_credentials:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano payment credential(s) in hex format
+            _after_block_height:
+              format: integer
+              type: number
+              description: Only fetch information after specific block height
+          example:
+            _payment_credentials:
+              -  ##credential_txs_payment_credentials1_rb##
+              -  ##credential_txs_payment_credentials2_rb##
+            _after_block_height: ##address_txs_after_block_height_rb##
+    description: Array of Cardano payment credential(s) in hex format alongwith filtering based on blockheight
+  credential_utxos:
+    content:
+      application/json:
+        schema:
+          required:
+            - _payment_credentials
+          type: object
+          properties:
+            _payment_credentials:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano payment credential(s) in hex format
+            _extended:
+              format: boolean
+              type: boolean
+              description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+          example:
+            _payment_credentials:
+              -  ##credential_txs_payment_credentials1_rb##
+              -  ##credential_txs_payment_credentials2_rb##
+            _extended: true
+    description: Array of Cardano payment credential(s) in hex format
+  tx_ids:
+    content:
+      application/json:
+        schema:
+          required:
+            - _tx_hashes
+          type: object
+          properties:
+            _tx_hashes:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano Transaction hashes
+          example:
+            _tx_hashes:
+              -  ##tx_ids_tx_hashes1_rb##
+              -  ##tx_ids_tx_hashes2_rb##
+    description: Array of Cardano Transaction hashes
+  tx_info:
+    content:
+      application/json:
+        schema:
+          required:
+            - _tx_hashes
+          type: object
+          properties:
+            _tx_hashes:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano Transaction hashes
+            _inputs:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction inputs in the result
+            _metadata:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction metadata in the result
+            _assets:
+              format: boolean
+              type: boolean
+              description: Controls whether to include assets involved within transaction the result
+            _withdrawals:
+              format: boolean
+              type: boolean
+              description: Controls whether to include any stake account reward withdrawals in the result
+            _certs:
+              format: boolean
+              type: boolean
+              description: Controls whether to include transaction certificates in the result
+            _scripts:
+              format: boolean
+              type: boolean
+              description: Controls whether to include any details regarding collateral/reference/datum/script objects in the result
+            _bytecode:
+              format: boolean
+              type: boolean
+              description: Controls whether to include bytecode for associated reference/plutus scripts
+            _governance:
+              format: boolean
+              type: boolean
+              description: Controls whether to include governance certificates, votes and proposals in the result
+          example:
+            _tx_hashes:
+              -  ##tx_ids_tx_hashes1_rb##
+              -  ##tx_ids_tx_hashes2_rb##
+            _inputs: false
+            _metadata: false
+            _assets: false
+            _withdrawals: false
+            _certs: false
+            _scripts: false
+            _bytecode: false
+    description: Array of Cardano Transaction hashes
+  txbin:
+    content:
+      application/cbor:
+        schema:
+          type: string
+          format: binary
+          example: ##txbin_rb##
+    description: Serialised Cardano Transaction
+  pool_ids:
+    content:
+      application/json:
+        schema:
+          required:
+            - _pool_bech32_ids
+          type: object
+          properties:
+            _pool_bech32_ids:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano pool IDs (bech32 format)
+          example:
+            _pool_bech32_ids:
+              -  ##pool_ids_pool_bech32_ids1_rb##
+              -  ##pool_ids_pool_bech32_ids2_rb##
+              -  ##pool_ids_pool_bech32_ids3_rb##
+    description: Array of Cardano pool IDs (bech32 format)
+  pool_ids_optional:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            _pool_bech32_ids:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano pool IDs (bech32 format)
+          example:
+            _pool_bech32_ids:
+              -  ##pool_ids_pool_bech32_ids1_rb##
+              -  ##pool_ids_pool_bech32_ids2_rb##
+              -  ##pool_ids_pool_bech32_ids3_rb##
+    description: Array of Cardano pool IDs (bech32 format) [Optional]
+  script_hashes:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            _script_hashes:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano script hashes
+          example:
+            _script_hashes:
+              -  ##script_hashes1_rb##
+              -  ##script_hashes2_rb##
+    description: Array of Cardano script hashes
+  datum_hashes:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            _datum_hashes:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano datum hashes
+          example:
+            _datum_hashes:
+              -  ##datum_hashes1_rb##
+              -  ##datum_hashes2_rb##
+    description: Array of Cardano datum hashes
+  asset_list:
+    content:
+      application/json:
+        schema:
+          required:
+            - _asset_list
+          type: object
+          properties:
+            _asset_list:
+              type: array
+              description: Array of array of policy ID and asset names (hex)
+              items:
+                type: array
+                items:
+                  type: string
+          example:
+            _asset_list:
+              -  ##asset1_rb##
+              -  ##asset2_rb##
+    description: Array of array of policyID and asset names (hex)
+  asset_list_with_extended:
+    content:
+      application/json:
+        schema:
+          required:
+            - _asset_list
+          type: object
+          properties:
+            _asset_list:
+              type: array
+              description: Array of array of policy ID and asset names (hex)
+              items:
+                type: array
+                items:
+                  type: string
+            _extended:
+              format: boolean
+              type: boolean
+              description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+          example:
+            _asset_list:
+              -  ##asset1_rb##
+              -  ##asset2_rb##
+            _extended: true
+    description: Array of array of policyID and asset names (hex) alongwith extended flag to return additional columns
+  drep_id_bulk:
+    content:
+      application/json:
+        schema:
+          required:
+            - _drep_ids
+          type: object
+          properties:
+            _drep_ids:
+              type: array
+              descriptions: Array of DRep IDs in bech32 format
+              items:
+                type: string
+          example:
+            _drep_ids:
+              -  ##drep_ids1_rb##
+              -  ##drep_ids2_rb##
+  utxo_refs_with_extended:
+    content:
+      application/json:
+        schema:
+          required:
+            - _utxo_refs
+          type: object
+          properties:
+            _utxo_refs:
+              type: array
+              items:
+                type: string
+              description: Array of Cardano utxo references in the form "hash#index"
+            _extended:
+              format: boolean
+              type: boolean
+              description: Controls whether or not certain optional fields supported by a given endpoint are populated as a part of the call
+          example:
+            _utxo_refs:
+              -  ##utxo_ref1_rb##
+              -  ##utxo_ref2_rb##
+            _extended: false
+    description: Array of Cardano UTxO references in the form "hash#index" with extended flag to toggle additional fields
+  ogmios:
+    content:
+      application/json:
+        schema:
+          required:
+            - jsonrpc
+            - method
+          type: object
+          properties:
+            jsonrpc:
+              type: string
+              description: Identifier for JSON-RPC 2.0 standard
+              example: "2.0"
+            method:
+              type: string
+              description: The Ogmios method to be called (see more details [here](#tag--Ogmios)) or browse examples tab
+              enum:
+                [
+                  "queryNetwork/blockHeight",
+                  "queryNetwork/genesisConfiguration",
+                  "queryNetwork/startTime",
+                  "queryNetwork/tip",
+                  "queryLedgerState/epoch",
+                  "queryLedgerState/eraStart",
+                  "queryLedgerState/eraSummaries",
+                  "queryLedgerState/liveStakeDistribution",
+                  "queryLedgerState/protocolParameters",
+                  "queryLedgerState/proposedProtocolParameters",
+                  "queryLedgerState/stakePools",
+                  "submitTransaction",
+                  "evaluateTransaction",
+                ]
+              example: "queryNetwork/tip"
+            params:
+              type: object
+              description: Any parameters relevant to the specific method to be called
+              nullable: true
+        examples:
+          blockHeight:
+            description: Query the network’s highest block number.
+            value: { "jsonrpc": "2.0", "method": "queryNetwork/blockHeight" }
+          genesisConfiguration:
+            description: Query the genesis configuration of a given era.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "queryNetwork/genesisConfiguration",
+                "params": { "era": "shelley" },
+              }
+          startTimeTime:
+            description: Query the network start time.
+            value: { "jsonrpc": "2.0", "method": "queryNetwork/startTime" }
+          tip:
+            description: Query tip of the Network
+            value: { "jsonrpc": "2.0", "method": "queryNetwork/tip" }
+          epoch:
+            description: Query the current epoch of the ledger.
+            value: { "jsonrpc": "2.0", "method": "queryLedgerState/epoch" }
+          eraStart:
+            description: Query information regarding the beginning of the current ledger era.
+            value: { "jsonrpc": "2.0", "method": "queryLedgerState/eraStart" }
+          eraSummaries:
+            description: Query era bounds and slot parameters details, required for proper sloting arithmetic.
+            value:
+              { "jsonrpc": "2.0", "method": "queryLedgerState/eraSummaries" }
+          liveStakeDistribution:
+            description: Query distribution of the stake across all known stake pools, relative to the total stake in the network.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "queryLedgerState/liveStakeDistribution",
+              }
+          protocolParameters:
+            description: Query the current protocol parameters.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "queryLedgerState/protocolParameters",
+              }
+          proposedProtocolParameters:
+            description: Query the last update proposal w.r.t. protocol parameters, if any.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "queryLedgerState/proposedProtocolParameters",
+              }
+          StakePools:
+            description: Query the list of all stake pool identifiers currently registered and active.
+            value: { "jsonrpc": "2.0", "method": "queryLedgerState/stakePools" }
+          submitTransaction:
+            description: Submit a signed and serialized transaction to the network.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "submitTransaction",
+                "params":
+                  {
+                    "transaction":
+                      {
+                        "cbor": "<CBOR-serialized signed transaction (base16)>",
+                      },
+                  },
+              }
+          evaluateTransaction:
+            description: Evaluate execution units of scripts in a well-formed transaction.
+            value:
+              {
+                "jsonrpc": "2.0",
+                "method": "evaluateTransaction",
+                "params":
+                  {
+                    "transaction":
+                      {
+                        "cbor": "<CBOR-serialized signed transaction (base16)>",
+                      },
+                    "additionalUtxo": [{ ... }],
+                  },
+              }
+    description: JSON-RPC 2.0 standard request body

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -1,3137 +1,2947 @@
 schemas:
-    tip:
-      description: Current tip of the chain
-      type: array
-      items:
-        properties:
-          hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          abs_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          block_no:
-            deprecated: true
-            type: number
-            description: DEPRECATED!! Use Block height instead
-            example: 1794506
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    genesis:
-      description: Array of genesis parameters used to start each era on chain
-      type: array
-      items:
-        properties:
-          networkmagic:
-            type: string
-            example: 764824073
-            description: Unique network identifier for chain
-          networkid:
-            type: string
-            example: Mainnet
-            description: Network ID used at various CLI identification to distinguish between Mainnet and other networks
-          epochlength:
-            type: string
-            example: 432000
-            description: Number of slots in an epoch
-          slotlength:
-            type: string
-            example: 1
-            description: Duration of a single slot (in seconds)
-          maxlovelacesupply:
-            type: string
-            example: 45000000000000000
-            description: Maximum smallest units (lovelaces) supply for the blockchain
-          systemstart:
-            type: number
-            description: UNIX timestamp of the first block (genesis) on chain
-            example: 1506203091
-          activeslotcoeff:
-            type: string
-            example: 0.05
-            description: "Active Slot Co-Efficient (f) - determines the _probability_ of number of slots in epoch that are expected to have blocks (so mainnet, this would be: 432000 * 0.05 = 21600 estimated blocks)"
-          slotsperkesperiod:
-            type: string
-            example: 129600
-            description: Number of slots that represent a single KES period (a unit used for validation of KES key evolutions)
-          maxkesrevolutions:
-            type: string
-            example: 62
-            description: Number of KES key evolutions that will automatically occur before a KES (hot) key is expired. This parameter is for security of a pool, in case an operator had access to his hot(online) machine compromised
-          securityparam:
-            type: string
-            example: 2160
-            description: A unit (k) used to divide epochs to determine stability window (used in security checks like ensuring atleast 1 block was created in 3*k/f period, or to finalize next epoch's nonce at 4*k/f slots before end of epoch)
-          updatequorum:
-            type: string
-            example: 5
-            description: Number of BFT members that need to approve (via vote) a Protocol Update Proposal
-          alonzogenesis:
-            type: string
-            example: '{\"lovelacePerUTxOWord\":34482,\"executionPrices\":{\"prSteps\":{\"numerator\":721,\"denominator\":10000000},...'
-            description: A JSON dump of Alonzo Genesis
-    totals:
-      description: Array of supply/reserves/utxo/fees/treasury stats
-      type: array
-      items:
-        properties:
-          epoch_no:
-            type: number
-            description: Epoch number
-            example: 294
-          circulation:
-            type: string
-            description: Circulating UTxOs for given epoch (in numbers)
-            example: 32081169442642320
-          treasury:
-            type: string
-            description: Funds in treasury for given epoch (in numbers)
-            example: 637024173474141
-          reward:
-            type: string
-            description: Rewards accumulated as of given epoch (in numbers)
-            example: 506871250479840
-          supply:
-            type: string
-            description: Total Active Supply (sum of treasury funds, rewards, UTxOs, deposits and fees) for given epoch (in numbers)
-            example: 33228495612391330
-          reserves:
-            type: string
-            description: Total Reserves yet to be unlocked on chain
-            example: 11771504387608670
-          fees:
-            type: string
-            description: The amount (in Lovelace) in the fee pot.
-            example: 92010214941
-          deposits_stake:
-            type: string
-            description: The amount (in Lovelace) in the obligation pot coming from stake key and pool deposits.
-            example: 3338702000000
-          deposits_drep:
-            type: string
-            description: The amount (in Lovelace) in the obligation pot coming from drep registrations deposits.
-            example: 0
-          deposits_proposal:
-            type: string
-            description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
-            example: 0
-    param_updates:
-      description: Array of unique param update proposals submitted on chain
-      type: array
-      items:
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          epoch_no:
-            $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          data:
-            type: string
-            description: JSON encoded data with details about the parameter update
-            example: {"decentralisation": 0.9}
-    cli_protocol_params:
-      description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
-      type: object
-      example:
-        {
-          "collateralPercentage": 150,
-          "maxBlockBodySize": 90112,
-          "maxBlockHeaderSize": 1100,
-          "maxCollateralInputs": 3,
-          "maxTxSize": 16384,
-          "maxValueSize": 5000,
-          "minPoolCost": 170000000,
-          "minUTxOValue": null,
-          "monetaryExpansion": 3.0e-3,
-          "poolPledgeInfluence": 0.3,
-          "poolRetireMaxEpoch": 18,
-          "protocolVersion": {
-            "major": 8,
-            "minor": 0
-          },
-          "...": "...",
-          "stakeAddressDeposit": 2000000,
-          "stakePoolDeposit": 500000000,
-          "stakePoolTargetNum": 500,
-          "treasuryCut": 0.2,
-          "txFeeFixed": 155381,
-          "txFeePerByte": 44,
-          "utxoCostPerByte": 4310
-        }
-    reserve_withdrawals:
-      description: Array of withdrawals from reserves/treasury against stake accounts
-      type: array
-      items:
-        properties:
-          epoch_no:
-            $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          amount:
-            $ref: "#/components/schemas/pool_delegators/items/properties/amount"
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          earned_epoch:
-            description: Epoch where amount is earned
-            allOf:
-              - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          spendable_epoch:
-            description: Epoch where the earned amount can be spent
-            allOf:
-              - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-    pool_list:
-      description: Array of pool IDs and tickers
-      type: array
-      items:
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          pool_id_hex:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_hex"
-          active_epoch_no:
-            $ref: "#/components/schemas/pool_info/items/properties/active_epoch_no"
-          margin:
-            $ref: "#/components/schemas/pool_info/items/properties/margin"
-          fixed_cost:
-            $ref: "#/components/schemas/pool_info/items/properties/fixed_cost"
-          pledge:
-            $ref: "#/components/schemas/pool_info/items/properties/pledge"
-          deposit:
-            $ref: "#/components/schemas/pool_info/items/properties/deposit"
-          reward_addr:
-            $ref: "#/components/schemas/pool_info/items/properties/reward_addr"
-          owners:
-            $ref: "#/components/schemas/pool_info/items/properties/owners"
-          relays:
-            $ref: "#/components/schemas/pool_info/items/properties/relays"
-          ticker:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool ticker
-            example: AHL
-          pool_group:
-            $ref: "#/components/schemas/pool_groups/items/properties/pool_group"
-          meta_url:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
-          pool_status:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_status"
-          active_stake:
-            $ref: "#/components/schemas/pool_info/items/properties/active_stake"
-          retiring_epoch:
-            $ref: "#/components/schemas/pool_info/items/properties/retiring_epoch"
-    pool_history_info:
-      description: Array of pool history information
-      type: array
-      items:
-        type: object
-        properties:
-          epoch_no:
-            type: number
-            description: Epoch for which the pool history data is shown
-            example: 312
-          active_stake:
-            $ref: "#/components/schemas/pool_info/items/properties/active_stake"
-          active_stake_pct:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Active stake for the pool, expressed as a percentage of total active stake on network
-            example: 13.512182543475783
-          saturation_pct:
-            type: number
-            description: Saturation percentage of a pool at the time of snapshot (2 decimals)
-            example: 45.32
-          block_cnt:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Number of blocks pool created in that epoch
-            example: 14
-          delegator_cnt:
-            type: number
-            description: Number of delegators to the pool for that epoch snapshot
-            example: 1432
-          margin:
-            type: number
-            description: Margin (decimal format)
-            example: 0.125
-          fixed_cost:
-            type: string
-            description: Pool fixed cost per epoch (in numbers)
-            example: "340000000"
-          pool_fees:
-            type: string
-            description: Total amount of fees earned by pool owners in that epoch (in numbers)
-            example: "123327382"
-          deleg_rewards:
-            type: string
-            description: Total amount of rewards earned by delegators in that epoch (in numbers)
-            example: "123456789123"
-          member_rewards:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
-            example: "123456780123"
-          epoch_ros:
-            type: number
-            description: Annualized ROS (return on staking) for delegators for this epoch
-            example: 3.000340466
-    pool_owner_history:
-      description: Array of pool owner's stake history
-      type: array
-      items:
-        type: object
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          stake_address:
-            type: string
-            description: Individual Stake account registered as (one of the) pool owner(s)
-            example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
-          declared_pledge:
-            $ref: "#/components/schemas/pool_info/items/properties/pledge"
-          epoch:
-            $ref: "#/components/schemas/pool_history_info/items/properties/epoch_no"
-          active_stake:
-            $ref: "#/components/schemas/pool_info/items/properties/active_stake"
-    pool_info:
-      description: Array of pool information
-      type: array
-      items:
-        type: object
-        properties:
-          pool_id_bech32:
-            type: string
-            description: Pool ID (bech32 format)
-            example: pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc
-          pool_id_hex:
-            type: string
-            description: Pool ID (Hex format)
-            example: a532904ca60e13e88437b58e7c6ff66b8d5e7ec8d3f4b9e4be7820ec
-          active_epoch_no:
-            $ref: "#/components/schemas/pool_updates/items/properties/active_epoch_no"
-          vrf_key_hash:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool VRF key hash
-            example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
-          margin:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Margin (decimal format)
-            example: 0.1
-          fixed_cost:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool fixed cost per epoch
-            example: "500000000"
-          pledge:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool pledge in number
-            example: "64000000000000"
-          deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool's registration deposit in number
-            example: "500000000"
-          reward_addr:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool reward address
-            example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
-          reward_addr_delegated_drep:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
-            example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
-          owners:
-            anyOf:
-              - type: array
-              - type: 'null'
-            items:
-              type: string
-              description: Pool (co)owner address
-              example: stake1u8088wvudd7dp3rxl0v9xgng8r3j50s65ge3l3jvgd94keqfm3nv3
-          relays:
-            type: array
-            items:
-              type: object
-              properties:
-                dns:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: DNS name of the relay (nullable)
-                  example: relays-new.cardano-mainnet.iohk.io
-                srv:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: DNS service name of the relay (nullable)
-                  example: biostakingpool3.hopto.org
-                ipv4:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: IPv4 address of the relay (nullable)
-                  example: "54.220.20.40"
-                ipv6:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: IPv6 address of the relay (nullable)
-                  example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
-                port:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-                  description: Port number of the relay (nullable)
-                  example: 6000
-          meta_url:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool metadata URL
-            example: https://pools.iohk.io/IOGP.json
-          meta_hash:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool metadata hash
-            example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
-          meta_json:
-            anyOf:
-              - type: object
-              - type: 'null'
-            properties:
-              name:
-                type: string
-                description: Pool name
-                example: Input Output Global (IOHK) - Private
-              ticker:
-                type: string
-                description: Pool ticker
-                example: IOGP
-              homepage:
-                type: string
-                description: Pool homepage URL
-                example: https://iohk.io
-              description:
-                type: string
-                description: Pool description
-                example: Our mission is to provide economic identity to the billions of people who lack it. IOHK will not use the IOHK ticker.
-          pool_status:
-            type: string
-            description: Pool status
-            enum: ["registered", "retiring", "retired"]
-            example: registered
-          retiring_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Announced retiring epoch (nullable)
-            example: null
-          op_cert:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool latest operational certificate hash
-            example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
-          op_cert_counter:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool latest operational certificate counter value
-            example: 8
-          active_stake:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Amount of delegated stake to this pool at the time of epoch snapshot
-            example: "64328627680963"
-          sigma:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool relative active stake share
-            example: 0.0034839235
-          block_count:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Total pool blocks on chain
-            example: 4509
-          live_pledge:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Summary of account balance for all pool owner's
-            example: "64328594406327"
-          live_stake:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool live stake
-            example: "64328627680963"
-          live_delegators:
-            type: number
-            description: Pool live delegator count
-            example: 5
-          live_saturation:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool live saturation (decimal format)
-            example: 94.52
-          voting_power:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Current voting power (lovelaces) of this stake pool
-            example: "123456789"
-    pool_snapshot:
-      type: array
-      items:
-        description: Array of pool stake information for 3 snapshots
-        type: object
-        properties:
-          snapshot:
-            type: string
-            description: Type of snapshot ("Mark", "Set" or "Go")
-            example: "Mark"
-          epoch_no:
-            type: number
-            description: Epoch number for the snapshot entry
-            example: 324
-          nonce:
-            $ref: "#/components/schemas/epoch_params/items/properties/nonce"
-          pool_stake:
-            type: string
-            description: Pool's Active Stake for the given epoch
-            example: "100000000000"
-          active_stake:
-            type: string
-            description: Total Active Stake for the given epoch
-            example: "103703246364020"
-    pool_delegators:
-      description: Array of live pool delegators
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          amount:
-            type: string
-            description: Current delegator live stake (in number)
-            example: "64328591517480"
-          active_epoch_no:
-            type: number
-            description: Epoch number in which the delegation becomes active
-            example: 324
-          latest_delegation_tx_hash:
-            type: string
-            description: Latest transaction hash used for delegation by the account
-            example: 368d08fe86804d637649341d3aec4a9baa7dffa6d00f16de2ba9dba814f1c948
-    pool_registrations:
-      description: Array of pool registrations/retirements
-      type: array
-      items:
-        type: object
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          epoch_no:
-            $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          active_epoch_no:
-            $ref: "#/components/schemas/pool_updates/items/properties/active_epoch_no"
-    pool_delegators_history:
-      description: Array of pool delegators (historical)
-      anyOf:
-        - type: array
-        - type: 'null'
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          amount:
-            $ref: "#/components/schemas/pool_delegators/items/properties/amount"
-          epoch_no:
-            type: number
-            description: Epoch number for the delegation history
-            example: 324
-    pool_blocks:
-      description: Array of blocks created by pool
-      type: array
-      items:
-        type: object
-        properties:
-          epoch_no:
-            $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          abs_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    pool_updates:
-      description: Array of historical pool updates
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          pool_id_hex:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_hex"
-          active_epoch_no:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Epoch number in which the update becomes active
-            example: 324
-          vrf_key_hash:
-            $ref: "#/components/schemas/pool_info/items/properties/vrf_key_hash"
-          margin:
-            $ref: "#/components/schemas/pool_info/items/properties/margin"
-          fixed_cost:
-            $ref: "#/components/schemas/pool_info/items/properties/fixed_cost"
-          pledge:
-            $ref: "#/components/schemas/pool_info/items/properties/pledge"
-          reward_addr:
-            $ref: "#/components/schemas/pool_info/items/properties/reward_addr"
-          owners:
-            $ref: "#/components/schemas/pool_info/items/properties/owners"
-          relays:
-            $ref: "#/components/schemas/pool_info/items/properties/relays"
-          meta_url:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
-          meta_json:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_json"
-          update_type:
-            type: string
-            description: Type of update task
-            enum: ["registration", "deregistration"]
-            example: registration
-          retiring_epoch:
-            $ref: "#/components/schemas/pool_info/items/properties/retiring_epoch"
-    pool_relays:
-      description: Array of pool relay information
-      type: array
-      items:
-        type: object
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          relays:
-            $ref: "#/components/schemas/pool_info/items/properties/relays"
-    pool_metadata:
-      description: Array of pool metadata
-      type: array
-      items:
-        type: object
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          meta_url:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
-          meta_json:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_json"
-    pool_calidus_keys:
-      description: Array of valid calidus keys for all pools
-      type: array
-      items:
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          pool_status:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_status"
-          calidus_nonce:
-            type: number
-            description: Unique nonce for pool's calidus key registration as per CIP-88
-            example: 150720822
-          calidus_pub_key:
-            type: string
-            description: Calidus public key as per CIP-88
-            example: "dea2d81424a285f7fd2846beb39320543ba1df27b890789b2c152b64a352e2df"
-          calidus_id_bech32:
-            type: string
-            description: Calidus key in bech32 format as per CIP-88
-            example: "calidus158w8ft8k4endw5q6m0rx2myl2ldvw5f5d8xmwyem6529fcgn575zh"
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          epoch_no:
-            $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    pool_groups:
-      description: Array of pools with their corresponding group information
-      type: array
-      items:
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          pool_group:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: A group that the pool was identified to be associated with
-            example: IOG
-          ticker:
-            $ref: "#/components/schemas/pool_info/items/properties/meta_json/properties/ticker"
-          adastat_group:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The pool's group identification as per adastat.net
-            example: iohk.io
-          balanceanalytics_group:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The pool's group identification as per balanceanalytics.io
-            example: IOG
-    epoch_info:
-      description: Array of detailed summary for each epoch
-      type: array
-      items:
-        type: object
-        properties:
-          epoch_no:
-            type: number
-            description: Epoch number
-            example: 294
-          out_sum:
-            type: string
-            description: Total output value across all transactions in epoch
-            example: "15432725054364942"
-          fees:
-            type: string
-            description: Total fees incurred by transactions in epoch
-            example: "74325855210"
-          tx_count:
-            type: number
-            description: Number of transactions submitted in epoch
-            example: 357919
-          blk_count:
-            type: number
-            description: Number of blocks created in epoch
-            example: 17321
-          start_time:
-            type: number
-            description: UNIX timestamp of the epoch start
-            example: 1506203091
-          end_time:
-            type: number
-            description: UNIX timestamp of the epoch end
-            example: 1506635091
-          first_block_time:
-            type: number
-            description: UNIX timestamp of the epoch's first block
-            example: 1506635091
-          last_block_time:
-            type: number
-            description: UNIX timestamp of the epoch's last block
-            example: 1506635091
-          active_stake:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
-            example: "23395112387185880"
-          total_rewards:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Total rewards earned in epoch (null for pre-Shelley epochs)
-            example: "252902897534230"
-          avg_blk_reward:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Average block reward for epoch (null for pre-Shelley epochs)
-            example: "660233450"
-    epoch_params:
-      description: Epoch parameters (all fields nullable for pre-Shelley/Gougen epochs except first block hash)
-      type: array
-      items:
-        properties:
-          epoch_no:
-            type: number
-            description: Epoch number
-            example: 294
-          min_fee_a:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The 'a' parameter to calculate the minimum transaction fee
-            example: 44
-          min_fee_b:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The 'b' parameter to calculate the minimum transaction fee
-            example: 155381
-          max_block_size:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum block size (in bytes)
-            example: 65536
-          max_tx_size:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum transaction size (in bytes)
-            example: 16384
-          max_bh_size:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum block header size (in bytes)
-            example: 1100
-          key_deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The amount (in number) required for a deposit to register a stake address
-            example: "2000000"
-          pool_deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The amount (in number) required for a deposit to register a stake pool
-            example: "500000000"
-          max_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
-            example: 18
-          optimal_pool_count:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The optimal number of stake pools
-            example: 500
-          influence:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The pledge influence on pool rewards
-            example: 0.3
-          monetary_expand_rate:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The monetary expansion rate
-            example: 0.003
-          treasury_growth_rate:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The treasury growth rate
-            example: 0.2
-          decentralisation:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
-            example: 0.1
-          extra_entropy:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
-            example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
-          protocol_major:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The protocol major version
-            example: 5
-          protocol_minor:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The protocol minor version
-            example: 0
-          min_utxo_value:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The minimum value of a UTxO entry
-            example: "34482"
-          min_pool_cost:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The minimum pool cost
-            example: "340000000"
-          nonce:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The nonce value for this epoch
-            example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
-          block_hash:
-            type: string
-            description: The hash of the first block where these parameters are valid
-            example: f9dc2a2fc3a2db09a71af007a740261de585afc9e3022b8e30535592ff4dd9e5
-          cost_models:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: The per language cost model in JSON
-            example: null
-          price_mem:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The per word cost of script memory usage
-            example: 0.0577
-          price_step:
-            anyOf:
-              - type: number
-              - type: 'null'
-            format: double
-            description: The cost of script execution step usage
-            example: 7.21e-05
-          max_tx_ex_mem:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of execution memory allowed to be used in a single transaction
-            example: 10000000
-          max_tx_ex_steps:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of execution steps allowed to be used in a single transaction
-            example: 10000000000
-          max_block_ex_mem:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of execution memory allowed to be used in a single block
-            example: 50000000
-          max_block_ex_steps:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of execution steps allowed to be used in a single block
-            example: 40000000000
-          max_val_size:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum Val size
-            example: 5000
-          collateral_percent:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
-            example: 150
-          max_collateral_inputs:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: The maximum number of collateral inputs allowed in a transaction
-            example: 3
-          coins_per_utxo_size:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The cost per UTxO size
-            example: "34482"
-          pvt_motion_no_confidence:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool Voting threshold for motion of no-confidence.
-            example: 0.6
-          pvt_committee_normal:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool Voting threshold for new committee/threshold (normal state).
-            example: 0.65
-          pvt_committee_no_confidence:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool Voting threshold for new committee/threshold (state of no-confidence).
-            example: 0.65
-          pvt_hard_fork_initiation:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool Voting threshold for hard-fork initiation.
-            example: 0.51
-          dvt_motion_no_confidence:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for motion of no-confidence.
-            example: 0.67
-          dvt_committee_normal:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for new committee/threshold (normal state).
-            example: 0.67
-          dvt_committee_no_confidence:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for new committee/threshold (state of no-confidence).
-            example: 0.65
-          dvt_update_to_constitution:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for update to the Constitution.
-            example: 0.75
-          dvt_hard_fork_initiation:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for hard-fork initiation.
-            example: 0.6
-          dvt_p_p_network_group:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for protocol parameter changes, network group.
-            example: 0.67
-          dvt_p_p_economic_group:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for protocol parameter changes, economic group.
-            example: 0.67
-          dvt_p_p_technical_group:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for protocol parameter changes, technical group.
-            example: 0.67
-          dvt_p_p_gov_group:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for protocol parameter changes, governance group.
-            example: 0.75
-          dvt_treasury_withdrawal:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep Vote threshold for treasury withdrawal.
-            example: 0.67
-          committee_min_size:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Minimal constitutional committee size.
-            example: 5
-          committee_max_term_length:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Constitutional committee term limits.
-            example: 146
-          gov_action_lifetime:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Governance action expiration.
-            example: 14
-          gov_action_deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Governance action deposit.
-            example: 100000000000
-          drep_deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: DRep deposit amount.
-            example: 500000000
-          drep_activity:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: DRep activity period.
-            example: 20
-          pvtpp_security_group:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Pool Voting threshold for protocol parameter changes, security group.
-            example: 0.6
-          min_fee_ref_script_cost_per_byte:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Minimum Fee for Reference Script cost pre byte
-            example: 15
-    epoch_block_protocols:
-      description: Array of distinct block protocol versions counts in epoch
-      type: array
-      items:
-        properties:
-          proto_major:
-            type: number
-            description: Protocol major version
-            example: 6
-          proto_minor:
-            type: number
-            description: Protocol major version
-            example: 2
-          blocks:
-            type: number
-            description: Amount of blocks with specified major and protocol combination
-            example: 2183
-    blocks:
-      description: Array of block information
-      type: array
-      items:
-        type: object
-        properties:
-          hash:
-            type: string
-            description: Hash of the block
-            example: 2fa5178c5be950c7f40d6c74efe9b3dd12c4836dc3f3dd052cd1c2a12edd477f
-          epoch_no:
-            type: number
-            description: Epoch number of the block
-            example: 117
-          abs_slot:
-            type: number
-            description: Absolute slot number of the block
-            example: 49073930
-          epoch_slot:
-            type: number
-            description: Slot number of the block in epoch
-            example: 171530
-          block_height:
-            type: number
-            description: Block height
-            example: 1794506
-          block_size:
-            type: number
-            description: Block size in bytes
-            example: 2433
-          block_time:
-            type: number
-            description: UNIX timestamp of the block
-            example: 1704757130
-          tx_count:
-            type: number
-            description: Number of transactions in the block
-            example: 2
-          vrf_key:
-            type: string
-            description: VRF key of the block producer
-            example: "vrf_vk1400ju08429se790upcvurdyqrhl8rhm7spm2jxg0lfnedqeaexfq7jsf2x"
-          pool:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Pool ID in bech32 format (null for pre-Shelley blocks)
-            example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
-          op_cert_counter:
-            type: number
-            description: Counter value of the operational certificate used to create this block
-            example: 5
-          proto_major:
-            $ref: "#/components/schemas/epoch_params/items/properties/protocol_major"
-          proto_minor:
-            $ref: "#/components/schemas/epoch_params/items/properties/protocol_minor"
-          parent_hash:
-            type: string
-            description: Previous Hash of the current block
-            example: 7eb8d62f9d6a5e7cf2d9635f0b531d2693fef55a717894e3a97baf6183b8d189
-    block_info:
-      description: Array of detailed block information
-      type: array
-      items:
-        type: object
-        properties:
-          hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          abs_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_size:
-            $ref: "#/components/schemas/blocks/items/properties/block_size"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          tx_count:
-            $ref: "#/components/schemas/blocks/items/properties/tx_count"
-          vrf_key:
-            $ref: "#/components/schemas/blocks/items/properties/vrf_key"
-          op_cert:
-            type: string
-            description: Hash of the block producers' operational certificate
-            example: "16bfc28a7127d11805fe02df67f8c3909ab7e2e2cd81b6954d90eeff1938614c"
-          op_cert_counter:
-            $ref: "#/components/schemas/blocks/items/properties/op_cert_counter"
-          pool:
-            $ref: "#/components/schemas/blocks/items/properties/pool"
-          proto_major:
-            $ref: "#/components/schemas/epoch_params/items/properties/protocol_major"
-          proto_minor:
-            $ref: "#/components/schemas/epoch_params/items/properties/protocol_minor"
-          total_output:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Total output of the block (in number)
-            example: "92384672389"
-          total_fees:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Total fees of the block (in number)
-            example: "2346834"
-          num_confirmations:
-            type: number
-            description: Number of confirmations for the block
-            example: 664275
-          parent_hash:
-            type: string
-            description: Hash of the parent of this block
-            example: "16bfc28a7127d11805fe02df67f8c3909ab7e2e2cd81b6954d90eeff1938614c"
-          child_hash:
-            type: string
-            description: Hash of the child of this block (if present)
-            example: "a3b525ba0747ce9daa928fa28fbc680f95e6927943a1fbd6fa5394d96c9dc2fa"
-    block_txs:
-      description: Array of transactions hashes
-      type: array
-      items:
-        type: object
-        properties:
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    block_tx_cbor:
-      description: Array of raw transaction(s) in CBOR format
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          absolute_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          tx_timestamp:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
-          cbor:
-            $ref: "#/components/schemas/tx_cbor/items/properties/cbor"
-    block_tx_info:
-      description: Array of detailed information about transaction(s)
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          absolute_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          tx_timestamp:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
-          tx_block_index:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
-          tx_size:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_size"
-          total_output:
-            $ref: "#/components/schemas/tx_info/items/properties/total_output"
-          fee:
-            $ref: "#/components/schemas/tx_info/items/properties/fee"
-          treasury_donation:
-            $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
-          deposit:
-            $ref: "#/components/schemas/tx_info/items/properties/deposit"
-          invalid_before:
-            $ref: "#/components/schemas/tx_info/items/properties/invalid_before"
-          invalid_after:
-            $ref: "#/components/schemas/tx_info/items/properties/invalid_after"
-          collateral_inputs:
-            $ref: "#/components/schemas/tx_info/items/properties/collateral_inputs"
-          collateral_output:
-            $ref: "#/components/schemas/tx_info/items/properties/collateral_output"
-          reference_inputs:
-            $ref: "#/components/schemas/tx_info/items/properties/reference_inputs"
-          inputs:
-            description: An array of UTxO inputs spent in the transaction
-            anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
-          outputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-          withdrawals:
-            $ref: "#/components/schemas/tx_info/items/properties/withdrawals"
-          assets_minted:
-            $ref: "#/components/schemas/tx_info/items/properties/assets_minted"
-          metadata:
-            $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
-          certificates:
-            $ref: "#/components/schemas/tx_info/items/properties/certificates"
-          native_scripts:
-            $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
-          plutus_contracts:
-            $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
-    address_info:
-      description: Array of information for address(es)
-      type: array
-      items:
-        type: object
-        properties:
-          address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          balance:
-            type: string
-            description: Sum of all UTxO values beloning to address
-            example: "10723473983"
-          stake_address:
-            anyOf:
-            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            - type: 'null'
-          script_address:
-            type: boolean
-            description: Signifies whether the address is a script address
-            example: true
-          utxo_set:
-            type: array
-            items:
-              type: object
-              properties:
-                tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                tx_index:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-                block_height:
-                  $ref: "#/components/schemas/blocks/items/properties/block_height"
-                block_time:
-                  $ref: "#/components/schemas/blocks/items/properties/block_time"
-                value:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-                datum_hash:
-                  $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-                inline_datum:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-                reference_script:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-                asset_list:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/asset_list"
-    address_txs:
-      description: Array of transaction hashes
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    address_outputs:
-      description: Array of basic transaction output information
-      type: array
-      items:
-        type: object
-        properties:
-          address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          tx_index:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-          value:
-            $ref: "#/components/schemas/utxo_infos/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/stake_address"
-          payment_cred:
-            $ref: "#/components/schemas/utxo_infos/items/properties/payment_cred"
-          epoch_no:
-            $ref: "#/components/schemas/utxo_infos/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/utxo_infos/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/utxo_infos/items/properties/block_time"
-          is_spent:
-            $ref: "#/components/schemas/utxo_infos/items/properties/is_spent"
-    address_assets:
-      description: Array of address-owned assets
-      type: array
-      items:
-        type: object
-        properties:
-          address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          decimals:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-          quantity:
-            $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
+  tip:
+    description: Current tip of the chain
+    type: array
+    items:
+      properties:
+        hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        abs_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        block_no:
+          deprecated: true
+          type: number
+          description: DEPRECATED!! Use Block height instead
+          example: 1794506
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  genesis:
+    description: Array of genesis parameters used to start each era on chain
+    type: array
+    items:
+      properties:
+        networkmagic:
+          type: string
+          example: 764824073
+          description: Unique network identifier for chain
+        networkid:
+          type: string
+          example: Mainnet
+          description: Network ID used at various CLI identification to distinguish between Mainnet and other networks
+        epochlength:
+          type: string
+          example: 432000
+          description: Number of slots in an epoch
+        slotlength:
+          type: string
+          example: 1
+          description: Duration of a single slot (in seconds)
+        maxlovelacesupply:
+          type: string
+          example: 45000000000000000
+          description: Maximum smallest units (lovelaces) supply for the blockchain
+        systemstart:
+          type: number
+          description: UNIX timestamp of the first block (genesis) on chain
+          example: 1506203091
+        activeslotcoeff:
+          type: string
+          example: 0.05
+          description: "Active Slot Co-Efficient (f) - determines the _probability_ of number of slots in epoch that are expected to have blocks (so mainnet, this would be: 432000 * 0.05 = 21600 estimated blocks)"
+        slotsperkesperiod:
+          type: string
+          example: 129600
+          description: Number of slots that represent a single KES period (a unit used for validation of KES key evolutions)
+        maxkesrevolutions:
+          type: string
+          example: 62
+          description: Number of KES key evolutions that will automatically occur before a KES (hot) key is expired. This parameter is for security of a pool, in case an operator had access to his hot(online) machine compromised
+        securityparam:
+          type: string
+          example: 2160
+          description: A unit (k) used to divide epochs to determine stability window (used in security checks like ensuring atleast 1 block was created in 3*k/f period, or to finalize next epoch's nonce at 4*k/f slots before end of epoch)
+        updatequorum:
+          type: string
+          example: 5
+          description: Number of BFT members that need to approve (via vote) a Protocol Update Proposal
+        alonzogenesis:
+          type: string
+          example: '{\"lovelacePerUTxOWord\":34482,\"executionPrices\":{\"prSteps\":{\"numerator\":721,\"denominator\":10000000},...'
+          description: A JSON dump of Alonzo Genesis
+  totals:
+    description: Array of supply/reserves/utxo/fees/treasury stats
+    type: array
+    items:
+      properties:
+        epoch_no:
+          type: number
+          description: Epoch number
+          example: 294
+        circulation:
+          type: string
+          description: Circulating UTxOs for given epoch (in numbers)
+          example: 32081169442642320
+        treasury:
+          type: string
+          description: Funds in treasury for given epoch (in numbers)
+          example: 637024173474141
+        reward:
+          type: string
+          description: Rewards accumulated as of given epoch (in numbers)
+          example: 506871250479840
+        supply:
+          type: string
+          description: Total Active Supply (sum of treasury funds, rewards, UTxOs, deposits and fees) for given epoch (in numbers)
+          example: 33228495612391330
+        reserves:
+          type: string
+          description: Total Reserves yet to be unlocked on chain
+          example: 11771504387608670
+        fees:
+          type: string
+          description: The amount (in Lovelace) in the fee pot.
+          example: 92010214941
+        deposits_stake:
+          type: string
+          description: The amount (in Lovelace) in the obligation pot coming from stake key and pool deposits.
+          example: 3338702000000
+        deposits_drep:
+          type: string
+          description: The amount (in Lovelace) in the obligation pot coming from drep registrations deposits.
+          example: 0
+        deposits_proposal:
+          type: string
+          description: The amount (in Lovelace) in the obligation pot coming from governance proposal deposits.
+          example: 0
+        treasury_donation:
+          type: string
+          description: The amount (in Lovelace) donated to the treasury.
+          example: 0
+        treasury_withdrawal:
+          type: string
+          description: The amount (in Lovelace) withdrawn from the treasury.
+          example: 0
+        reserves_withdrawal:
+          type: string
+          description: The amount (in Lovelace) withdrawn from reserves.
+          example: 0
+  param_updates:
+    description: Array of unique param update proposals submitted on chain
+    type: array
+    items:
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        epoch_no:
+          $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        data:
+          type: string
+          description: JSON encoded data with details about the parameter update
+          example: { "decentralisation": 0.9 }
+  cli_protocol_params:
+    description: Get Current Protocol Parameters from node as published by cardano-cli in JSON format
+    type: object
+    example:
+      {
+        "collateralPercentage": 150,
+        "maxBlockBodySize": 90112,
+        "maxBlockHeaderSize": 1100,
+        "maxCollateralInputs": 3,
+        "maxTxSize": 16384,
+        "maxValueSize": 5000,
+        "minPoolCost": 170000000,
+        "minUTxOValue": null,
+        "monetaryExpansion": 3.0e-3,
+        "poolPledgeInfluence": 0.3,
+        "poolRetireMaxEpoch": 18,
+        "protocolVersion": { "major": 8, "minor": 0 },
+        "...": "...",
+        "stakeAddressDeposit": 2000000,
+        "stakePoolDeposit": 500000000,
+        "stakePoolTargetNum": 500,
+        "treasuryCut": 0.2,
+        "txFeeFixed": 155381,
+        "txFeePerByte": 44,
+        "utxoCostPerByte": 4310,
+      }
+  reserve_withdrawals:
+    description: Array of withdrawals from reserves/treasury against stake accounts
+    type: array
+    items:
+      properties:
+        epoch_no:
+          $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        amount:
+          $ref: "#/components/schemas/pool_delegators/items/properties/amount"
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        earned_epoch:
+          description: Epoch where amount is earned
+          allOf:
+            - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        spendable_epoch:
+          description: Epoch where the earned amount can be spent
+          allOf:
+            - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
 
-    account_list:
-      description: Array of account (stake address) IDs
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          stake_address_hex:
-            type: string
-            description: Cardano staking address (reward account) in hex format
-            example: e1c865f10d66a2e375242b5ef9f05abc8840d413421982f62c35ce4fbf
-          script_hash:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Script hash in case the stake address is locked by a script
-            example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
-    account_info:
-      description: Array of stake account information
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          status:
-            type: string
-            description: Stake address status
-            enum: ["registered", "not registered"]
-            example: registered
-          delegated_drep:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
-            example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
-          delegated_pool:
-            anyOf:
-            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-            - type: 'null'
-          total_balance:
-            type: string
-            description: Total balance of the account including UTxO, rewards and MIRs (in number)
-            example: "207116800428"
-          utxo:
-            type: string
-            description: Total UTxO balance of the account
-            example: "162764177131"
-          rewards:
-            type: string
-            description: Total rewards earned by the account
-            example: "56457728047"
-          withdrawals:
-            type: string
-            description: Total rewards withdrawn by the account
-            example: "12105104750"
-          rewards_available:
-            type: string
-            description: Total rewards available for withdrawal
-            example: "44352623297"
-          deposit:
-            type: string
-            description: Total deposit available for withdrawal
-            example: "2000000"
-          reserves:
-            type: string
-            description: Total reserves MIR value of the account
-            example: "0"
-          treasury:
-            type: string
-            description: Total treasury MIR value of the account
-            example: "0"
-          proposal-refund:
-            type: string
-            description: Total proposal refund for this account
-            example: "0"
-    utxo_infos:
-      description: Array of complete UTxO information
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          inline_datum:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-          reference_script:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-          asset_list:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: An array of assets on the UTxO
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of assets on the UTxO
-                  example: "1"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    tx_outs_epoch:
-      description: List of transaction outputs with basic details for requested epoch
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            type: string
-            description: Hash identifier of the transaction
-            example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-          tx_index:
-            type: number
-            description: Index of UTxO in the transaction 
-            example: 0
-          address:
-            type: string
-            description: A Cardano payment/base address (bech32 encoded)
-            example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          payment_cred:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Payment credential
-            example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          value:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          is_spent:
-            type: boolean
-            description: True if the UTXO has been spent
-            example: true
-    account_rewards:
-      description: Array of reward history information
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          rewards:
-            type: array
-            items:
-              type: object
-              properties:
-                earned_epoch:
-                  $ref: "#/components/schemas/reserve_withdrawals/items/properties/earned_epoch"
-                spendable_epoch:
-                  $ref: "#/components/schemas/reserve_withdrawals/items/properties/spendable_epoch"
-                amount:
-                  type: string
-                  description: Amount of rewards earned (in number)
-                type:
-                  type: string
-                  description: The source of the rewards
-                  enum: [member, leader, treasury, reserves, refund]
-                  example: member
-                pool_id:
-                  anyOf:
-                    - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-                    - type: 'null'
-    account_reward_history:
-      description: Array of reward history information
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          earned_epoch:
-            $ref: "#/components/schemas/reserve_withdrawals/items/properties/earned_epoch"
-          spendable_epoch:
-            $ref: "#/components/schemas/reserve_withdrawals/items/properties/spendable_epoch"
-          amount:
-            type: string
-            description: Amount of rewards earned (in number)
-          type:
-            type: string
-            description: The source of the rewards
-            enum: [member, leader, treasury, reserves, refund]
-            example: member
-          pool_id_bech32:
-            anyOf:
-              - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
-              - type: 'null'
-    account_updates:
-      description: Array of account updates information
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          updates:
-            type: array
-            items:
-              type: object
-              properties:
-                action_type:
-                  type: string
-                  description: Type of certificate submitted
-                  enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
-                  example: "registration"
-                tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                epoch_no:
-                  $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-                epoch_slot:
-                  $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-                absolute_slot:
-                  $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-                block_time:
-                  $ref: "#/components/schemas/blocks/items/properties/block_time"
-    account_update_history:
-      description: Array of account update history information
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          action_type:
-            type: string
-            description: Type of certificate submitted
-            enum: ["registration", "delegation_pool", "delegation_drep", "withdrawal", "deregistration"]
-            example: "registration"
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          absolute_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-    account_addresses:
-      description: Array of payment addresses
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          addresses:
-            type: array
-            items:
-              $ref: "#/components/schemas/utxo_infos/items/properties/address"
-    account_assets:
-      description: Array of assets owned by account
-      type: array
-      items:
-        type: object
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_history/items/properties/stake_address"
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          decimals:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-          quantity:
-            $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
-    account_history:
-      description: Array of active stake values per epoch
-      type: array
-      items:
-        properties:
-          stake_address:
-            type: string
-            description: Cardano staking address (reward account) in bech32 format
-            example: stake1u8yxtugdv63wxafy9d00nuz6hjyyp4qnggvc9a3vxh8yl0ckml2uz
-          history:
-            type: array
-            items:
-              type: object
-              properties:
-                pool_id:
-                  type: string
-                  description: Bech32 representation of pool ID
-                  example: pool1z5uqdk7dzdxaae5633fqfcu2eqzy3a3rgtuvy087fdld7yws0xt
-                epoch_no:
-                  type: number
-                  description: Epoch number
-                  example: 301
-                active_stake:
-                  type: string
-                  description: Active stake amount (in numbers)
-                  example: 682334162
-    account_stake_history:
-      description: Array of active stake values per epoch
-      type: array
-      items:
-        properties:
-          stake_address:
-            type: string
-            description: Cardano staking address (reward account) in bech32 format
-            example: stake1u8yxtugdv63wxafy9d00nuz6hjyyp4qnggvc9a3vxh8yl0ckml2uz
-          pool_id_bech32:
-            type: string
-            description: Bech32 representation of pool ID
-            example: pool1z5uqdk7dzdxaae5633fqfcu2eqzy3a3rgtuvy087fdld7yws0xt
-          epoch_no:
-            type: number
-            description: Epoch number
-            example: 301
-          active_stake:
-            type: string
-            description: Active stake amount (in numbers)
-            example: 682334162
-    tx_info:
-      description: Array of detailed information about transaction(s)
-      type: array
-      items:
-        type: object
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          epoch_slot:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
-          absolute_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          tx_timestamp:
-            type: number
-            description: UNIX timestamp of the transaction
-            example: 1506635091
-          tx_block_index:
-            type: number
-            description: Index of transaction within block
-            example: 6
-          tx_size:
-            type: number
-            description: Size in bytes of transaction
-            example: 391
-          total_output:
-            type: string
-            description: Total sum of all transaction outputs (in numbers)
-            example: "157832856"
-          fee:
-            type: string
-            description: Total Transaction fee (in numbers)
-            example: "172761"
-          treasury_donation:
-            type: string
-            description: Total Donation to on-chain treasury (in numbers)
-            example: "0"
-          deposit:
-            type: string
-            description: Total Deposits included in transaction (for example, if it is registering a pool/key)
-            example: "0"
-          invalid_before:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Slot before which transaction cannot be validated (if supplied, else null)
-            example: "42331172"
-          invalid_after:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Slot after which transaction cannot be validated
-            example: "42332172"
-          collateral_inputs:
-            description: An array of collateral inputs needed for smart contracts in case of contract failure
-            anyOf:
-            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            - type: 'null'
-          collateral_output:
-            description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
-            anyOf:
-              - type: array
-              - type: 'null'
-            items:
-              properties:
-                payment_addr:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/payment_addr"
-                stake_addr:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/stake_addr"
-                tx_hash:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/tx_hash"
-                tx_index:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/tx_index"
-                value:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
-                datum_hash:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/datum_hash"
-                inline_datum:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
-                reference_script:
-                  $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
-                asset_list:
-                  type: array
-                  description: Brief asset description from ledger
-          reference_inputs:
-            description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
-            anyOf:
-              - $ref: "#/components/schemas/tx_info/items/properties/outputs"
-              - type: 'null'
-          inputs:
-            $ref: "#/components/schemas/tx_info/items/properties/outputs"
-            #description: An array of UTxO inputs spent in the transaction
-          outputs:
-            type: array
-            description: An array of UTxO outputs created by the transaction
-            items:
-              type: object
-              properties:
-                payment_addr:
-                  type: object
-                  properties:
-                    bech32:
-                      $ref: "#/components/schemas/utxo_infos/items/properties/address"
-                    cred:
-                      type: string
-                      description: Payment credential
-                      example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-                stake_addr:
-                  $ref: "#/components/schemas/address_info/items/properties/stake_address"
-                tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                tx_index:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-                value:
-                  type: string
-                  description: Total sum of ADA on the UTxO
-                  example: "157832856"
-                datum_hash:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: Hash of datum (if any) connected to UTxO 
-                  example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
-                inline_datum:
-                  anyOf:
-                    - type: object
-                    - type: 'null'
-                  description: Allows datums to be attached to UTxO (CIP-32)
-                  properties:
-                    bytes:
-                      type: string
-                      description: Datum bytes (hex)
-                      example: 19029a
-                    value:
-                      type: object
-                      description: Value (json)
-                      example: { "int": 666 }
-                reference_script:
-                  anyOf:
-                    - type: object
-                    - type: 'null'
-                  description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
-                  properties:
-                    hash:
-                      type: string
-                      description: Hash of referenced script
-                      example: 67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656
-                    size:
-                      type: number
-                      description: Size in bytes
-                      example: 14
-                    type:
-                      type: string
-                      description: Type of script
-                      example: plutusV1
-                    bytes:
-                      type: string
-                      description: Script bytes (hex)
-                      example: 4e4d01000033222220051200120011
-                    value:
-                      anyOf:
-                        - type: object
-                        - type: 'null'
-                      description: Value (json)
-                      example: null
-                asset_list:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/asset_list"
-          withdrawals:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Array of withdrawals with-in a transaction
-            items:
-              type: object
-              properties:
-                amount:
-                  type: string
-                  description: Withdrawal amount (in numbers)
-                  example: "9845162"
-                stake_addr:
-                  type: string
-                  description: A Cardano staking address (reward account, bech32 encoded)
-                  example: stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj
-          assets_minted:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Array of minted assets with-in a transaction
-            items:
-              properties:
-                policy_id:
-                  $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-                asset_name:
-                  $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-                fingerprint:
-                  $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-                decimals:
-                  $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-                quantity:
-                  type: string
-                  description: Quantity of minted assets (negative on burn)
-                  example: "1"
-          metadata:
-            $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
-          certificates:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Certificates present with-in a transaction (if any)
-            items:
-              properties:
-                index:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-                  description: Certificate index
-                  example: 0
-                type:
-                  type: string
-                  description: Type of certificate (could be delegation, stake_registration, stake_deregistraion, pool_update, pool_retire, param_proposal, reserve_MIR, treasury_MIR)
-                  example: delegation
-                info:
-                  anyOf:
-                    - type: object
-                    - type: 'null'
-                  description: A JSON array containing information from the certificate
-                  example:
-                    {
-                      "stake_address": "stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj",
-                      "pool": "pool1k53pf4wzn263c08e3wr3gttndfecm9f4uzekgctcx947vt7fh2p",
-                    }
-          native_scripts:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Native scripts present in a transaction (if any)
-            items:
-              properties:
-                script_hash:
-                  $ref: "#/components/schemas/script_info/items/properties/script_hash"
-                script_json:
-                  type: object
-                  description: JSON representation of the timelock script (null for other script types)
-                  example:
-                    {
-                      "type": "all",
-                      "scripts":
-                        [
-                          {
-                            "type": "sig",
-                            "keyHash": "a96da581c39549aeda81f539ac3940ac0cb53657e774ca7e68f15ed9",
-                          },
-                          {
-                            "type": "sig",
-                            "keyHash": "ccfcb3fed004562be1354c837a4a4b9f4b1c2b6705229efeedd12d4d",
-                          },
-                          {
-                            "type": "sig",
-                            "keyHash": "74fcd61aecebe36aa6b6cd4314027282fa4b41c3ce8af17d9b77d0d1",
-                          },
-                        ],
-                    }
-          plutus_contracts:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Plutus contracts present in transaction (if any)
-            items:
-              properties:
-                address:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: Plutus script address
-                  example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
-                spends_input:
-                  anyOf:
-                    - type: object
-                    - type: 'null'
-                  properties:
-                    tx_hash:
-                      $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                    tx_index:
-                      $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-                  description: Input utxo this contract spends
-                script_hash:
-                  $ref: "#/components/schemas/script_info/items/properties/script_hash"
-                bytecode:
-                  $ref: "#/components/schemas/script_info/items/properties/bytes"
-                size:
-                  $ref: "#/components/schemas/script_info/items/properties/size"
-                valid_contract:
-                  type: boolean
-                  description: True if the contract is valid or there is no contract
-                  example: true
-                input:
-                  type: object
-                  properties:
-                    redeemer:
-                      type: object
-                      properties:
-                        purpose:
-                          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/purpose"
-                        fee:
-                          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/fee"
-                        unit:
-                          type: object
-                          properties:
-                            steps:
-                              $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/unit_steps"
-                            mem:
-                              $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/unit_mem"
-                        datum:
-                          type: object
-                          properties:
-                            hash:
-                              $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-                            value:
-                              $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_value"
-                    datum:
-                      type: object
-                      properties:
-                        hash:
-                          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-                        value:
-                          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_value"
-          voting_procedures:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Governance votes in a transaction (if any)
-            items:
-              properties:
-                proposal_tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                proposal_index:
-                  $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
-                voter_role:
-                  $ref: "#/components/schemas/proposal_votes/items/properties/voter_role"
-                voter:
-                  $ref: "#/components/schemas/proposal_votes/items/properties/voter_id"
-                voter_hex:
-                  $ref: "#/components/schemas/proposal_votes/items/properties/voter_hex"
-                vote:
-                  $ref: "#/components/schemas/drep_votes/items/properties/vote"
-          proposal_procedures:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Governance proposals in a transaction (if any)
-            items:
-              properties:
-                index:
-                  $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
-                type:
-                  $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
-                description:
-                  $ref: "#/components/schemas/proposal_list/items/properties/proposal_description"
-                deposit:
-                  $ref: "#/components/schemas/drep_info/items/properties/deposit"
-                return_address:
-                  $ref: "#/components/schemas/proposal_list/items/properties/return_address"
-                expiration:
-                  $ref: "#/components/schemas/proposal_list/items/properties/expiration"
-                meta_url:
-                  $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-                meta_hash:
-                  $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-                withdrawal:
-                  $ref: "#/components/schemas/proposal_list/items/properties/withdrawal"
-                param_proposal:
-                  $ref: "#/components/schemas/proposal_list/items/properties/param_proposal"
-    tx_cbor:
-      description: Raw Transaction(s) in CBOR format
-      items:
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          block_hash:
-            $ref: "#/components/schemas/blocks/items/properties/hash"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          absolute_slot:
-            $ref: "#/components/schemas/blocks/items/properties/abs_slot"
-          tx_timestamp:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
-          cbor:
-            type: string
-            description: CBOR encoded raw transaction.
-    tx_utxos:
-      description: Array of inputs and outputs for given transaction(s)
-      type: array
-      items:
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
-          inputs:
-            type: array
-            description: An array of UTxO inputs used by the transaction
-            items:
-              type: object
-              properties:
-                payment_addr:
-                  type: object
-                  properties:
-                    bech32:
-                      type: string
-                      description: A Cardano payment/base address (bech32 encoded) where funds were sent or change to be returned
-                      example: addr1q80rc8zj06yzdwwdyqc03rm4l3zv6n89rxuaak0t099n09yssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqad9mkw
-                    cred:
-                      type: string
-                      description: Payment credential
-                      example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
-                stake_addr:
-                  $ref: "#/components/schemas/address_info/items/properties/stake_address"
-                tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                tx_index:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-                value:
-                  type: string
-                  description: Total sum of ADA on the UTxO
-                  example: 157832856
-          outputs:
-            description: An array of UTxO outputs created by the transaction
-            allOf:
-              - $ref: "#/components/schemas/tx_utxos/items/properties/inputs"
-    tx_metadata:
-      description: Array of metadata information present in each of the transactions queried
-      anyOf:
-        - type: array
-        - type: 'null'
-      items:
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          metadata:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: A JSON array containing details about metadata within transaction
-            example:
-              {
-                "721":
-                  {
-                    "version": 1,
-                    "copyright": "...",
-                    "publisher": ["p...o"],
-                    "4bf184e01e0f163296ab253edd60774e2d34367d0e7b6cbc689b567d":
-                      {},
-                  },
-              }
-    tx_status:
-      description: Array of transaction confirmation counts
-      type: array
-      items:
-        properties:
-          tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          num_confirmations:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Number of block confirmations
-            example: 17
-    tx_metalabels:
-      description: Array of known metadata labels
-      type: array
-      items:
-        properties:
-          key:
-            type: string
-            description: A distinct known metalabel
-            example: "721"
-    asset_list:
-      description: Array of policy IDs and asset names
-      type: array
-      items:
-        type: object
-        properties:
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          asset_name_ascii:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-    asset_token_registry:
-      description: An array of token registry information (registered via github) for each asset
-      type: array
-      items:
-        type: object
-        properties:
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          asset_name_ascii:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
-          ticker:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/ticker"
-          description:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/description"
-          url:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/url"
-          decimals:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-          logo:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/logo"
-    asset_addresses:
-      description: An array of payment addresses holding the given token (including balances)
-      type: array
-      items:
-        properties:
-          payment_address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          quantity:
-            type: string
-            description: Asset balance on the payment address
-            example: "23"
-    asset_nft_address:
-      description: An array of payment addresses holding the given token
-      type: array
-      items:
-        properties:
-          payment_address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-    asset_summary:
-      description: Array of asset summary information
-      type: array
-      items:
-        properties:
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          total_transactions:
-            type: number
-            description: Total number of transactions including the given asset
-            example: 89416
-          staked_wallets:
-            type: number
-            description: Total number of registered wallets holding the given asset
-            example: 548
-          unstaked_addresses:
-            type: number
-            description: Total number of payment addresses (not belonging to registered wallets) holding the given asset
-            example: 245
-          addresses:
-            type: number
-            description: Total number of unique addresses holding the given asset
-            example: 812
-    asset_info:
-      description: Array of detailed asset information
-      type: array
-      items:
-        properties:
-          policy_id:
-            type: string
-            description: Asset Policy ID (hex)
-            example: d3501d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff
-          asset_name:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Asset Name (hex)
-            example: 444f4e545350414d
-          asset_name_ascii:
-            type: string
-            description: Asset Name (ASCII)
-            example: DONTSPAM
-          fingerprint:
-            type: string
-            description: The CIP14 fingerprint of the asset
-            example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
-          minting_tx_hash:
-            type: string
-            description: Hash of the latest mint transaction (with metadata if found for asset)
-            example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
-          total_supply:
-            type: string
-            description: Total supply for the asset
-            example: "35000"
-          mint_cnt:
-            type: number
-            description: Count of total mint transactions
-            example: 1
-          burn_cnt:
-            type: number
-            description: Count of total burn transactions
-            example: 5
-          creation_time:
-            type: number
-            description: UNIX timestamp of the first asset mint
-            example: 1506635091
-          minting_tx_metadata:
-            allOf:
-              - $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
-            description: Latest minting transaction metadata (aligns with CIP-25)
-          token_registry_metadata:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: Asset metadata registered on the Cardano Token Registry
-            properties:
-              name:
-                anyOf:
-                  - type: string
-                  - type: 'null'
-                example: Rackmob
-              description:
-                anyOf:
-                  - type: string
-                  - type: 'null'
-                example: Metaverse Blockchain Cryptocurrency.
-              ticker:
-                anyOf:
-                  - type: string
-                  - type: 'null'
-                example: MOB
-              url:
-                anyOf:
-                  - type: string
-                  - type: 'null'
-                example: https://www.rackmob.com/
-              logo:
-                anyOf:
-                  - type: string
-                  - type: 'null'
-                description: A PNG image file as a byte string
-                example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
-              decimals:
-                type: number
-                example: 0
-          cip68_metadata:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: CIP 68 metadata if present for asset
-            example: {"222": {"fields": [{"map": [{"k": {"bytes": "6e616d65"}, "v": {"bytes": "74657374"}}]}], "constructor": 0}}
-    asset_history:
-      description: Array of asset mint/burn history
-      type: array
-      items:
-        properties:
-          policy_id:
-            $ref: "#/components/schemas/asset_info/items/properties/policy_id"
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          minting_txs:
-            anyOf:
-              - type: array
-              - type: 'null'
-            description: Array of all mint/burn transactions for an asset
-            items:
-              type: object
-              properties:
-                tx_hash:
-                  type: string
-                  description: Hash of minting/burning transaction
-                  example: e1ecc517f95715bb87681cfde2c594dbc971739f84f8bfda16170b35d63d0ddf
-                block_time:
-                  $ref: "#/components/schemas/blocks/items/properties/block_time"
-                quantity:
-                  type: string
-                  description: Quantity minted/burned (negative numbers indicate burn transactions)
-                  example: "-10"
-                metadata:
-                  type: array
-                  description: Array of Transaction Metadata for given transaction
-                  items:
-                    $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
-    policy_asset_addresses:
-      description: Array of asset names and payment addresses for the given policy (including balances)
-      type: array
-      items:
-        properties:
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          payment_address:
-            $ref: "#/components/schemas/utxo_infos/items/properties/address"
-          stake_address:
-            $ref: "#/components/schemas/address_info/items/properties/stake_address"
-          quantity:
-            $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
-    policy_asset_info:
-      description: Array of detailed information of assets under requested policies
-      type: array
-      items:
-        properties:
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          asset_name_ascii:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          minting_tx_hash:
-            $ref: "#/components/schemas/asset_info/items/properties/minting_tx_hash"
-          total_supply:
-            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
-          mint_cnt:
-            $ref: "#/components/schemas/asset_info/items/properties/mint_cnt"
-          burn_cnt:
-            $ref: "#/components/schemas/asset_info/items/properties/burn_cnt"
-          creation_time:
-            $ref: "#/components/schemas/asset_info/items/properties/creation_time"
-          minting_tx_metadata:
-            $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
-          token_registry_metadata:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata"
-    policy_asset_mints:
-      description: Array of mint information for assets under requested policies
-      type: array
-      items:
-        properties:
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          asset_name_ascii:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          minting_tx_hash:
-            $ref: "#/components/schemas/asset_info/items/properties/minting_tx_hash"
-          total_supply:
-            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
-          mint_cnt:
-            $ref: "#/components/schemas/asset_info/items/properties/mint_cnt"
-          burn_cnt:
-            $ref: "#/components/schemas/asset_info/items/properties/burn_cnt"
-          creation_time:
-            $ref: "#/components/schemas/asset_info/items/properties/creation_time"
-          minting_tx_metadata:
-            $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
-          decimals:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-    policy_asset_list:
-      description: Array of brief information of assets under the same policy
-      type: array
-      items:
-        properties:
-          asset_name:
-            $ref: "#/components/schemas/asset_info/items/properties/asset_name"
-          fingerprint:
-            $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
-          total_supply:
-            $ref: "#/components/schemas/asset_info/items/properties/total_supply"
-          decimals:
-            $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
-    drep_info:
-      description: Get detailed information about requested delegated representatives (DReps)
-      type: array
-      items:
-        properties:
-          drep_id:
-            type: string
-            description: DRep ID in CIP-129 bech32 format
-            example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
-          hex:
-            type: string
-            description: DRep ID in hex format
-            example: 6e4069625cad00002da7d1fc444352e67613e895ca610bd3506bfafd
-          has_script:
-            type: boolean
-            description: Flag which shows if this credential is a script hash
-            example: false
-          registered:
-            type: boolean
-            description: Flag to show if the DRep is currently registered
-            example: false
-          deposit:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: DRep's registration deposit  in number
-            example: "500000000"
-          active:
-            type: boolean
-            description: Flag to show if the DRep is  (i.e. not expired)
-            example: true
-          expires_epoch_no:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: After which epoch DRep is considered inactive.
-            example: 410
-          amount:
-            type: string
-            description: The total amount of voting power this DRep is delegated.
-            example: "599496769641"
-          meta_url:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: A URL to a JSON payload of metadata
-            example: "https://hornan7.github.io/Vote_Context.jsonld"
-          meta_hash:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: A hash of the contents of the metadata URL
-            example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
-    drep_epoch_summary:
-      description: Summary of voting power and DRep count for each epoch
-      type: array
-      items:
-        properties:
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          amount:
-            type: string
-            description: The total amount of voting power between all DReps including pre-defined roles for the epoch.
-            example: "599496769641"
-          dreps:
-            type: number
-            description: The total number of DReps with vote power for the epoch.
-            example: 324
-    drep_list:
-      description: List of all active delegated representatives (DReps)
-      type: array
-      items:
-        properties:
-          drep_id:
-            $ref: "#/components/schemas/drep_info/items/properties/drep_id"
-          hex:
-            $ref: "#/components/schemas/drep_info/items/properties/hex"
-          has_script:
-            $ref: "#/components/schemas/drep_info/items/properties/has_script"
-          registered:
-            $ref: "#/components/schemas/drep_info/items/properties/registered"
-    drep_delegators:
-      description: List of all delegators by requested delegated representative (DRep)
-      type: array
-      items:
-        properties:
-          stake_address:
-            $ref: "#/components/schemas/account_list/items/properties/stake_address"
-          stake_address_hex:
-            $ref: "#/components/schemas/account_list/items/properties/stake_address_hex"
-          script_hash:
-            $ref: "#/components/schemas/account_list/items/properties/script_hash"
-          epoch_no:
-            description: Epoch when vote delegation was made
-            allOf:
-              - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
-          amount:
-            $ref: "#/components/schemas/account_info/items/properties/total_balance"
-    drep_metadata:
-      description: List metadata for requested delegated representatives (DReps)
-      type: array
-      items:
-        properties:
-          drep_id:
-            $ref: "#/components/schemas/drep_info/items/properties/drep_id"
-          hex:
-            $ref: "#/components/schemas/drep_info/items/properties/hex"
-          has_script:
-            $ref: "#/components/schemas/drep_info/items/properties/has_script"
-          meta_url:
-            $ref: "#/components/schemas/drep_info/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_info/items/properties/meta_hash"
-          meta_json:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: The payload as JSON
-            example:
-              {"body": {"title": "...", "...": "...", "references": [{"uri": "...", "@type": "Other", "label": "Hardfork to PV10"}]}, "authors": [{"name": "...", "witness": {"publicKey": "...", "signature": "...", "witnessAlgorithm": "ed25519"}}], "@context": {"body": {"@id": "CIP108:body", "@context": {"title": "CIP108:title", "abstract": "CIP108:abstract", "rationale": "CIP108:rationale", "motivation": "CIP108:motivation", "references": {"@id": "CIP108:references", "@context": {"uri": "CIP100:reference-uri", "Other": "CIP100:OtherReference", "label": "CIP100:reference-label", "referenceHash": {"@id": "CIP108:referenceHash", "@context": {"hashDigest": "CIP108:hashDigest", "hashAlgorithm": "CIP100:hashAlgorithm"}}, "GovernanceMetadata": "CIP100:GovernanceMetadataReference"}, "@container": "@set"}}}, "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#", "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#", "authors": {"@id": "CIP100:authors", "@context": {"name": "http://xmlns.com/foaf/0.1/name", "witness": {"@id": "CIP100:witness", "@context": {"publicKey": "CIP100:publicKey", "signature": "CIP100:signature", "witnessAlgorithm": "CIP100:witnessAlgorithm"}}}, "@container": "@set"}, "@language": "en-us", "hashAlgorithm": "CIP100:hashAlgorithm"}, "hashAlgorithm": "blake2b-256"}
-          bytes:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The raw bytes of the payload
-            example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
-          warning:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: A warning that occured while validating the metadata
-          language:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: The language described in the context of the metadata as per CIP-100
-            example: en-us
-          comment:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Comment attached to the metadata
-          is_valid:
-            anyOf:
-              - type: boolean
-              - type: 'null'
-            description: Indicate whether data is invalid (currently returns null for all as per dbsync)
-            example: null
-    drep_updates:
-      description: List of updates for requested (or all) delegated representatives (DReps)
-      type: array
-      items:
-        properties:
-          drep_id:
-            $ref: "#/components/schemas/drep_info/items/properties/drep_id"
-          hex:
-            $ref: "#/components/schemas/drep_info/items/properties/hex"
-          has_script:
-            $ref: "#/components/schemas/drep_info/items/properties/has_script"
-          update_tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          cert_index:
-            type: number
-            description: The index of this certificate within the the transaction.
-            example: 1
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          action:
-            type: string
-            description: Effective action for this DRep Update certificate
-            enum: ["updated","registered","deregistered"]
-            example: registered
-          deposit:
-            $ref: "#/components/schemas/drep_info/items/properties/deposit"
-          meta_url:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-          meta_json:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
-    drep_voting_power_history:
-      description: History of DReps voting power against each (or requested) epoch
-      type: array
-      items:
-        properties:
-          drep_id:
-            $ref: "#/components/schemas/drep_info/items/properties/drep_id"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          amount:
-            anyOf:
+  pool_list:
+    description: Array of pool IDs and tickers
+    type: array
+    items:
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        pool_id_hex:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_hex"
+        active_epoch_no:
+          $ref: "#/components/schemas/pool_info/items/properties/active_epoch_no"
+        margin:
+          $ref: "#/components/schemas/pool_info/items/properties/margin"
+        fixed_cost:
+          $ref: "#/components/schemas/pool_info/items/properties/fixed_cost"
+        pledge:
+          $ref: "#/components/schemas/pool_info/items/properties/pledge"
+        deposit:
+          $ref: "#/components/schemas/pool_info/items/properties/deposit"
+        reward_addr:
+          $ref: "#/components/schemas/pool_info/items/properties/reward_addr"
+        owners:
+          $ref: "#/components/schemas/pool_info/items/properties/owners"
+        relays:
+          $ref: "#/components/schemas/pool_info/items/properties/relays"
+        ticker:
+          anyOf:
             - type: string
-            - type: 'null'
-            description: The voting power for the DRep
-            example: "14231445553"
-    drep_votes:
-      description: List of all votes casted by requested delegated representative (DRep)
-      type: array
-      items:
-        properties:
-          proposal_id:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_id"
-          proposal_tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          proposal_index:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
-          vote_tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          vote:
-            type: string
-            enum: ["Yes","No","Abstain"]
-            description: Actual Vote casted
-            example: "Yes"
-          meta_url:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-    pool_voting_power_history:
-      description: History of Pool's voting power against each (or requested) epoch
-      type: array
-      items:
-        properties:
-          pool_id_bech32:
-            $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          amount:
-            anyOf:
+            - type: "null"
+          description: Pool ticker
+          example: AHL
+        pool_group:
+          $ref: "#/components/schemas/pool_groups/items/properties/pool_group"
+        meta_url:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
+        pool_status:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_status"
+        active_stake:
+          $ref: "#/components/schemas/pool_info/items/properties/active_stake"
+        retiring_epoch:
+          $ref: "#/components/schemas/pool_info/items/properties/retiring_epoch"
+  pool_history_info:
+    description: Array of pool history information
+    type: array
+    items:
+      type: object
+      properties:
+        epoch_no:
+          type: number
+          description: Epoch for which the pool history data is shown
+          example: 312
+        active_stake:
+          $ref: "#/components/schemas/pool_info/items/properties/active_stake"
+        active_stake_pct:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Active stake for the pool, expressed as a percentage of total active stake on network
+          example: 13.512182543475783
+        saturation_pct:
+          type: number
+          description: Saturation percentage of a pool at the time of snapshot (2 decimals)
+          example: 45.32
+        block_cnt:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Number of blocks pool created in that epoch
+          example: 14
+        delegator_cnt:
+          type: number
+          description: Number of delegators to the pool for that epoch snapshot
+          example: 1432
+        margin:
+          type: number
+          description: Margin (decimal format)
+          example: 0.125
+        fixed_cost:
+          type: string
+          description: Pool fixed cost per epoch (in numbers)
+          example: "340000000"
+        pool_fees:
+          type: string
+          description: Total amount of fees earned by pool owners in that epoch (in numbers)
+          example: "123327382"
+        deleg_rewards:
+          type: string
+          description: Total amount of rewards earned by delegators in that epoch (in numbers)
+          example: "123456789123"
+        member_rewards:
+          anyOf:
             - type: string
-            - type: 'null'
-            description: The voting power for the pool for the epoch
-            example: "11231445553"
-    pool_votes:
-      description: List of all votes casted by requested pool
-      type: array
-      items:
-        $ref: "#/components/schemas/drep_votes/items"
-    committee_votes:
-      description: List of all votes casted by requested delegated representative (DRep)
-      type: array
-      items:
-        $ref: "#/components/schemas/drep_votes/items"
-    proposal_list:
-      description: List of all governance action proposals
-      type: array
-      items:
-        properties:
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          proposal_id:
+            - type: "null"
+          description: Total amount of rewards earned by members (delegator - owner) in that epoch (in numbers)
+          example: "123456780123"
+        epoch_ros:
+          type: number
+          description: Annualized ROS (return on staking) for delegators for this epoch
+          example: 3.000340466
+  pool_owner_history:
+    description: Array of pool owner's stake history
+    type: array
+    items:
+      type: object
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        stake_address:
+          type: string
+          description: Individual Stake account registered as (one of the) pool owner(s)
+          example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
+        declared_pledge:
+          $ref: "#/components/schemas/pool_info/items/properties/pledge"
+        epoch:
+          $ref: "#/components/schemas/pool_history_info/items/properties/epoch_no"
+        active_stake:
+          $ref: "#/components/schemas/pool_info/items/properties/active_stake"
+  pool_info:
+    description: Array of pool information
+    type: array
+    items:
+      type: object
+      properties:
+        pool_id_bech32:
+          type: string
+          description: Pool ID (bech32 format)
+          example: pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc
+        pool_id_hex:
+          type: string
+          description: Pool ID (Hex format)
+          example: a532904ca60e13e88437b58e7c6ff66b8d5e7ec8d3f4b9e4be7820ec
+        active_epoch_no:
+          $ref: "#/components/schemas/pool_updates/items/properties/active_epoch_no"
+        vrf_key_hash:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool VRF key hash
+          example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
+        margin:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Margin (decimal format)
+          example: 0.1
+        fixed_cost:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool fixed cost per epoch
+          example: "500000000"
+        pledge:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool pledge in number
+          example: "64000000000000"
+        deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool's registration deposit in number
+          example: "500000000"
+        reward_addr:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool reward address
+          example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
+        reward_addr_delegated_drep:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Reward address' current delegation status to DRep ID in CIP-129 Bech32 format
+          example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
+        owners:
+          anyOf:
+            - type: array
+            - type: "null"
+          items:
             type: string
-            description: Proposal Action ID in accordance with CIP-129 format
-            example: 'gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh'
-          proposal_tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          proposal_index:
-            type: number
-            description: Index of governance proposal in transaction
-            example: 0
-          proposal_type:
-            type: string
-            enum: ["ParameterChange", "HardForkInitiation", "TreasuryWithdrawals", "NoConfidence", "NewCommittee", "NewConstitution", "InfoAction"]
-            description: Proposal Action Type
-            example: ParameterChange
-          proposal_description:
+            description: Pool (co)owner address
+            example: stake1u8088wvudd7dp3rxl0v9xgng8r3j50s65ge3l3jvgd94keqfm3nv3
+        relays:
+          type: array
+          items:
             type: object
-            description: Description for Proposal Action
-            example: '{"tag": "InfoAction"}'
-          deposit:
-            $ref: "#/components/schemas/drep_info/items/properties/deposit"
-          return_address:
-            type: string
-            description: The StakeAddress index of the reward address to receive the deposit when it is repaid.
-            example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
-          proposed_epoch:
-            type: number
-            description: Shows the epoch at which this governance action was proposed.
-            example: 660
-          ratified_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: If not null, then this proposal has been ratified at the specfied epoch.
-            example: 670
-          enacted_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: If not null, then this proposal has been enacted at the specfied epoch.
-            example: 675
-          dropped_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
-            example: 680
-          expired_epoch:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: If not null, then this proposal has been expired at the specfied epoch.
-            example: 680
-          expiration:
-            anyOf:
-              - type: number
-              - type: 'null'
-            description: Shows the epoch at which this governance action is expected to expire.
-          meta_url:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-          meta_json:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
-          meta_comment:
-            $ref: "#/components/schemas/drep_metadata/items/properties/comment"
-          meta_language:
-            $ref: "#/components/schemas/drep_metadata/items/properties/language"
-          meta_is_valid:
-            $ref: "#/components/schemas/drep_metadata/items/properties/is_valid"
-          withdrawal:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: If not null, the amount withdrawn from treasury into stake address by this this proposal
             properties:
-              stake_address:
-                $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              dns:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: DNS name of the relay (nullable)
+                example: relays-new.cardano-mainnet.iohk.io
+              srv:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: DNS service name of the relay (nullable)
+                example: biostakingpool3.hopto.org
+              ipv4:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: IPv4 address of the relay (nullable)
+                example: "54.220.20.40"
+              ipv6:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: IPv6 address of the relay (nullable)
+                example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
+              port:
+                anyOf:
+                  - type: number
+                  - type: "null"
+                description: Port number of the relay (nullable)
+                example: 6000
+        meta_url:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool metadata URL
+          example: https://pools.iohk.io/IOGP.json
+        meta_hash:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool metadata hash
+          example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
+        meta_json:
+          anyOf:
+            - type: object
+            - type: "null"
+          properties:
+            name:
+              type: string
+              description: Pool name
+              example: Input Output Global (IOHK) - Private
+            ticker:
+              type: string
+              description: Pool ticker
+              example: IOGP
+            homepage:
+              type: string
+              description: Pool homepage URL
+              example: https://iohk.io
+            description:
+              type: string
+              description: Pool description
+              example: Our mission is to provide economic identity to the billions of people who lack it. IOHK will not use the IOHK ticker.
+        pool_status:
+          type: string
+          description: Pool status
+          enum: ["registered", "retiring", "retired"]
+          example: registered
+        retiring_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Announced retiring epoch (nullable)
+          example: null
+        op_cert:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool latest operational certificate hash
+          example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
+        op_cert_counter:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool latest operational certificate counter value
+          example: 8
+        active_stake:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Amount of delegated stake to this pool at the time of epoch snapshot
+          example: "64328627680963"
+        sigma:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool relative active stake share
+          example: 0.0034839235
+        block_count:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Total pool blocks on chain
+          example: 4509
+        live_pledge:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Summary of account balance for all pool owner's
+          example: "64328594406327"
+        live_stake:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool live stake
+          example: "64328627680963"
+        live_delegators:
+          type: number
+          description: Pool live delegator count
+          example: 5
+        live_saturation:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool live saturation (decimal format)
+          example: 94.52
+        voting_power:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Current voting power (lovelaces) of this stake pool
+          example: "123456789"
+  pool_snapshot:
+    type: array
+    items:
+      description: Array of pool stake information for 3 snapshots
+      type: object
+      properties:
+        snapshot:
+          type: string
+          description: Type of snapshot ("Mark", "Set" or "Go")
+          example: "Mark"
+        epoch_no:
+          type: number
+          description: Epoch number for the snapshot entry
+          example: 324
+        nonce:
+          $ref: "#/components/schemas/epoch_params/items/properties/nonce"
+        pool_stake:
+          type: string
+          description: Pool's Active Stake for the given epoch
+          example: "100000000000"
+        active_stake:
+          type: string
+          description: Total Active Stake for the given epoch
+          example: "103703246364020"
+  pool_delegators:
+    description: Array of live pool delegators
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        amount:
+          type: string
+          description: Current delegator live stake (in number)
+          example: "64328591517480"
+        active_epoch_no:
+          type: number
+          description: Epoch number in which the delegation becomes active
+          example: 324
+        latest_delegation_tx_hash:
+          type: string
+          description: Latest transaction hash used for delegation by the account
+          example: 368d08fe86804d637649341d3aec4a9baa7dffa6d00f16de2ba9dba814f1c948
+  pool_registrations:
+    description: Array of pool registrations/retirements
+    type: array
+    items:
+      type: object
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        epoch_no:
+          $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        active_epoch_no:
+          $ref: "#/components/schemas/pool_updates/items/properties/active_epoch_no"
+  pool_delegators_history:
+    description: Array of pool delegators (historical)
+    anyOf:
+      - type: array
+      - type: "null"
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        amount:
+          $ref: "#/components/schemas/pool_delegators/items/properties/amount"
+        epoch_no:
+          type: number
+          description: Epoch number for the delegation history
+          example: 324
+  pool_blocks:
+    description: Array of blocks created by pool
+    type: array
+    items:
+      type: object
+      properties:
+        epoch_no:
+          $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        abs_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  pool_updates:
+    description: Array of historical pool updates
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        pool_id_hex:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_hex"
+        active_epoch_no:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Epoch number in which the update becomes active
+          example: 324
+        vrf_key_hash:
+          $ref: "#/components/schemas/pool_info/items/properties/vrf_key_hash"
+        margin:
+          $ref: "#/components/schemas/pool_info/items/properties/margin"
+        fixed_cost:
+          $ref: "#/components/schemas/pool_info/items/properties/fixed_cost"
+        pledge:
+          $ref: "#/components/schemas/pool_info/items/properties/pledge"
+        reward_addr:
+          $ref: "#/components/schemas/pool_info/items/properties/reward_addr"
+        owners:
+          $ref: "#/components/schemas/pool_info/items/properties/owners"
+        relays:
+          $ref: "#/components/schemas/pool_info/items/properties/relays"
+        meta_url:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
+        meta_json:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_json"
+        update_type:
+          type: string
+          description: Type of update task
+          enum: ["registration", "deregistration"]
+          example: registration
+        retiring_epoch:
+          $ref: "#/components/schemas/pool_info/items/properties/retiring_epoch"
+  pool_relays:
+    description: Array of pool relay information
+    type: array
+    items:
+      type: object
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        relays:
+          $ref: "#/components/schemas/pool_info/items/properties/relays"
+  pool_metadata:
+    description: Array of pool metadata
+    type: array
+    items:
+      type: object
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        meta_url:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_hash"
+        meta_json:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_json"
+  pool_calidus_keys:
+    description: Array of valid calidus keys for all pools
+    type: array
+    items:
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        pool_status:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_status"
+        calidus_nonce:
+          type: number
+          description: Unique nonce for pool's calidus key registration as per CIP-88
+          example: 150720822
+        calidus_pub_key:
+          type: string
+          description: Calidus public key as per CIP-88
+          example: "dea2d81424a285f7fd2846beb39320543ba1df27b890789b2c152b64a352e2df"
+        calidus_id_bech32:
+          type: string
+          description: Calidus key in bech32 format as per CIP-88
+          example: "calidus158w8ft8k4endw5q6m0rx2myl2ldvw5f5d8xmwyem6529fcgn575zh"
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        epoch_no:
+          $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  pool_groups:
+    description: Array of pools with their corresponding group information
+    type: array
+    items:
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        pool_group:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: A group that the pool was identified to be associated with
+          example: IOG
+        ticker:
+          $ref: "#/components/schemas/pool_info/items/properties/meta_json/properties/ticker"
+        adastat_group:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The pool's group identification as per adastat.net
+          example: iohk.io
+        balanceanalytics_group:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The pool's group identification as per balanceanalytics.io
+          example: IOG
+
+  epoch_info:
+    description: Array of detailed summary for each epoch
+    type: array
+    items:
+      type: object
+      properties:
+        epoch_no:
+          type: number
+          description: Epoch number
+          example: 294
+        out_sum:
+          type: string
+          description: Total output value across all transactions in epoch
+          example: "15432725054364942"
+        fees:
+          type: string
+          description: Total fees incurred by transactions in epoch
+          example: "74325855210"
+        tx_count:
+          type: number
+          description: Number of transactions submitted in epoch
+          example: 357919
+        blk_count:
+          type: number
+          description: Number of blocks created in epoch
+          example: 17321
+        start_time:
+          type: number
+          description: UNIX timestamp of the epoch start
+          example: 1506203091
+        end_time:
+          type: number
+          description: UNIX timestamp of the epoch end
+          example: 1506635091
+        first_block_time:
+          type: number
+          description: UNIX timestamp of the epoch's first block
+          example: 1506635091
+        last_block_time:
+          type: number
+          description: UNIX timestamp of the epoch's last block
+          example: 1506635091
+        active_stake:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Total active stake in epoch stake snapshot (null for pre-Shelley epochs)
+          example: "23395112387185880"
+        total_rewards:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Total rewards earned in epoch (null for pre-Shelley epochs)
+          example: "252902897534230"
+        avg_blk_reward:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Average block reward for epoch (null for pre-Shelley epochs)
+          example: "660233450"
+  epoch_params:
+    description: Epoch parameters (all fields nullable for pre-Shelley/Gougen epochs except first block hash)
+    type: array
+    items:
+      properties:
+        epoch_no:
+          type: number
+          description: Epoch number
+          example: 294
+        min_fee_a:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The 'a' parameter to calculate the minimum transaction fee
+          example: 44
+        min_fee_b:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The 'b' parameter to calculate the minimum transaction fee
+          example: 155381
+        max_block_size:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum block size (in bytes)
+          example: 65536
+        max_tx_size:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum transaction size (in bytes)
+          example: 16384
+        max_bh_size:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum block header size (in bytes)
+          example: 1100
+        key_deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The amount (in number) required for a deposit to register a stake address
+          example: "2000000"
+        pool_deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The amount (in number) required for a deposit to register a stake pool
+          example: "500000000"
+        max_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of epochs in the future that a pool retirement is allowed to be scheduled for
+          example: 18
+        optimal_pool_count:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The optimal number of stake pools
+          example: 500
+        influence:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The pledge influence on pool rewards
+          example: 0.3
+        monetary_expand_rate:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The monetary expansion rate
+          example: 0.003
+        treasury_growth_rate:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The treasury growth rate
+          example: 0.2
+        decentralisation:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The decentralisation parameter (1 fully centralised, 0 fully decentralised)
+          example: 0.1
+        extra_entropy:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The hash of 32-byte string of extra random-ness added into the protocol's entropy pool
+          example: d982e06fd33e7440b43cefad529b7ecafbaa255e38178ad4189a37e4ce9bf1fa
+        protocol_major:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The protocol major version
+          example: 5
+        protocol_minor:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The protocol minor version
+          example: 0
+        min_utxo_value:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The minimum value of a UTxO entry
+          example: "34482"
+        min_pool_cost:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The minimum pool cost
+          example: "340000000"
+        nonce:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The nonce value for this epoch
+          example: 01304ddf5613166be96fce27be110747f2c8fcb38776618ee79225ccb59b81e2
+        block_hash:
+          type: string
+          description: The hash of the first block where these parameters are valid
+          example: f9dc2a2fc3a2db09a71af007a740261de585afc9e3022b8e30535592ff4dd9e5
+        cost_models:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: The per language cost model in JSON
+          example: null
+        price_mem:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The per word cost of script memory usage
+          example: 0.0577
+        price_step:
+          anyOf:
+            - type: number
+            - type: "null"
+          format: double
+          description: The cost of script execution step usage
+          example: 7.21e-05
+        max_tx_ex_mem:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of execution memory allowed to be used in a single transaction
+          example: 10000000
+        max_tx_ex_steps:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of execution steps allowed to be used in a single transaction
+          example: 10000000000
+        max_block_ex_mem:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of execution memory allowed to be used in a single block
+          example: 50000000
+        max_block_ex_steps:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of execution steps allowed to be used in a single block
+          example: 40000000000
+        max_val_size:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum Val size
+          example: 5000
+        collateral_percent:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The percentage of the tx fee which must be provided as collateral when including non-native scripts
+          example: 150
+        max_collateral_inputs:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: The maximum number of collateral inputs allowed in a transaction
+          example: 3
+        coins_per_utxo_size:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The cost per UTxO size
+          example: "34482"
+        pvt_motion_no_confidence:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool Voting threshold for motion of no-confidence.
+          example: 0.6
+        pvt_committee_normal:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool Voting threshold for new committee/threshold (normal state).
+          example: 0.65
+        pvt_committee_no_confidence:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool Voting threshold for new committee/threshold (state of no-confidence).
+          example: 0.65
+        pvt_hard_fork_initiation:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool Voting threshold for hard-fork initiation.
+          example: 0.51
+        dvt_motion_no_confidence:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for motion of no-confidence.
+          example: 0.67
+        dvt_committee_normal:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for new committee/threshold (normal state).
+          example: 0.67
+        dvt_committee_no_confidence:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for new committee/threshold (state of no-confidence).
+          example: 0.65
+        dvt_update_to_constitution:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for update to the Constitution.
+          example: 0.75
+        dvt_hard_fork_initiation:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for hard-fork initiation.
+          example: 0.6
+        dvt_p_p_network_group:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for protocol parameter changes, network group.
+          example: 0.67
+        dvt_p_p_economic_group:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for protocol parameter changes, economic group.
+          example: 0.67
+        dvt_p_p_technical_group:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for protocol parameter changes, technical group.
+          example: 0.67
+        dvt_p_p_gov_group:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for protocol parameter changes, governance group.
+          example: 0.75
+        dvt_treasury_withdrawal:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep Vote threshold for treasury withdrawal.
+          example: 0.67
+        committee_min_size:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Minimal constitutional committee size.
+          example: 5
+        committee_max_term_length:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Constitutional committee term limits.
+          example: 146
+        gov_action_lifetime:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Governance action expiration.
+          example: 14
+        gov_action_deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Governance action deposit.
+          example: 100000000000
+        drep_deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: DRep deposit amount.
+          example: 500000000
+        drep_activity:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: DRep activity period.
+          example: 20
+        pvtpp_security_group:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Pool Voting threshold for protocol parameter changes, security group.
+          example: 0.6
+        min_fee_ref_script_cost_per_byte:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Minimum Fee for Reference Script cost pre byte
+          example: 15
+  epoch_block_protocols:
+    description: Array of distinct block protocol versions counts in epoch
+    type: array
+    items:
+      properties:
+        proto_major:
+          type: number
+          description: Protocol major version
+          example: 6
+        proto_minor:
+          type: number
+          description: Protocol major version
+          example: 2
+        blocks:
+          type: number
+          description: Amount of blocks with specified major and protocol combination
+          example: 2183
+
+  blocks:
+    description: Array of block information
+    type: array
+    items:
+      type: object
+      properties:
+        hash:
+          type: string
+          description: Hash of the block
+          example: 2fa5178c5be950c7f40d6c74efe9b3dd12c4836dc3f3dd052cd1c2a12edd477f
+        epoch_no:
+          type: number
+          description: Epoch number of the block
+          example: 117
+        abs_slot:
+          type: number
+          description: Absolute slot number of the block
+          example: 49073930
+        epoch_slot:
+          type: number
+          description: Slot number of the block in epoch
+          example: 171530
+        block_height:
+          type: number
+          description: Block height
+          example: 1794506
+        block_size:
+          type: number
+          description: Block size in bytes
+          example: 2433
+        block_time:
+          type: number
+          description: UNIX timestamp of the block
+          example: 1704757130
+        tx_count:
+          type: number
+          description: Number of transactions in the block
+          example: 2
+        vrf_key:
+          type: string
+          description: VRF key of the block producer
+          example: "vrf_vk1400ju08429se790upcvurdyqrhl8rhm7spm2jxg0lfnedqeaexfq7jsf2x"
+        pool:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Pool ID in bech32 format (null for pre-Shelley blocks)
+          example: pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v
+        op_cert_counter:
+          type: number
+          description: Counter value of the operational certificate used to create this block
+          example: 5
+        proto_major:
+          $ref: "#/components/schemas/epoch_params/items/properties/protocol_major"
+        proto_minor:
+          $ref: "#/components/schemas/epoch_params/items/properties/protocol_minor"
+        parent_hash:
+          type: string
+          description: Previous Hash of the current block
+          example: 7eb8d62f9d6a5e7cf2d9635f0b531d2693fef55a717894e3a97baf6183b8d189
+  block_info:
+    description: Array of detailed block information
+    type: array
+    items:
+      type: object
+      properties:
+        hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        abs_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_size:
+          $ref: "#/components/schemas/blocks/items/properties/block_size"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        tx_count:
+          $ref: "#/components/schemas/blocks/items/properties/tx_count"
+        vrf_key:
+          $ref: "#/components/schemas/blocks/items/properties/vrf_key"
+        op_cert:
+          type: string
+          description: Hash of the block producers' operational certificate
+          example: "16bfc28a7127d11805fe02df67f8c3909ab7e2e2cd81b6954d90eeff1938614c"
+        op_cert_counter:
+          $ref: "#/components/schemas/blocks/items/properties/op_cert_counter"
+        pool:
+          $ref: "#/components/schemas/blocks/items/properties/pool"
+        proto_major:
+          $ref: "#/components/schemas/epoch_params/items/properties/protocol_major"
+        proto_minor:
+          $ref: "#/components/schemas/epoch_params/items/properties/protocol_minor"
+        total_output:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Total output of the block (in number)
+          example: "92384672389"
+        total_fees:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Total fees of the block (in number)
+          example: "2346834"
+        num_confirmations:
+          type: number
+          description: Number of confirmations for the block
+          example: 664275
+        parent_hash:
+          type: string
+          description: Hash of the parent of this block
+          example: "16bfc28a7127d11805fe02df67f8c3909ab7e2e2cd81b6954d90eeff1938614c"
+        child_hash:
+          type: string
+          description: Hash of the child of this block (if present)
+          example: "a3b525ba0747ce9daa928fa28fbc680f95e6927943a1fbd6fa5394d96c9dc2fa"
+  block_txs:
+    description: Array of transactions hashes
+    type: array
+    items:
+      type: object
+      properties:
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  block_tx_cbor:
+    description: Array of raw transaction(s) in CBOR format
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        absolute_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        tx_timestamp:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
+        cbor:
+          $ref: "#/components/schemas/tx_cbor/items/properties/cbor"
+  block_tx_info:
+    description: Array of detailed information about transaction(s)
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        absolute_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        tx_timestamp:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
+        tx_block_index:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+        tx_size:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_size"
+        total_output:
+          $ref: "#/components/schemas/tx_info/items/properties/total_output"
+        fee:
+          $ref: "#/components/schemas/tx_info/items/properties/fee"
+        treasury_donation:
+          $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+        deposit:
+          $ref: "#/components/schemas/tx_info/items/properties/deposit"
+        invalid_before:
+          $ref: "#/components/schemas/tx_info/items/properties/invalid_before"
+        invalid_after:
+          $ref: "#/components/schemas/tx_info/items/properties/invalid_after"
+        collateral_inputs:
+          $ref: "#/components/schemas/tx_info/items/properties/collateral_inputs"
+        collateral_output:
+          $ref: "#/components/schemas/tx_info/items/properties/collateral_output"
+        reference_inputs:
+          $ref: "#/components/schemas/tx_info/items/properties/reference_inputs"
+        inputs:
+          description: An array of UTxO inputs spent in the transaction
+          anyOf:
+            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+            - type: "null"
+        outputs:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs"
+        withdrawals:
+          $ref: "#/components/schemas/tx_info/items/properties/withdrawals"
+        assets_minted:
+          $ref: "#/components/schemas/tx_info/items/properties/assets_minted"
+        metadata:
+          $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
+        certificates:
+          $ref: "#/components/schemas/tx_info/items/properties/certificates"
+        native_scripts:
+          $ref: "#/components/schemas/tx_info/items/properties/native_scripts"
+        plutus_contracts:
+          $ref: "#/components/schemas/tx_info/items/properties/plutus_contracts"
+
+  address_info:
+    description: Array of information for address(es)
+    type: array
+    items:
+      type: object
+      properties:
+        address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        balance:
+          type: string
+          description: Sum of all UTxO values beloning to address
+          example: "10723473983"
+        stake_address:
+          anyOf:
+            - $ref: "#/components/schemas/account_history/items/properties/stake_address"
+            - type: "null"
+        script_address:
+          type: boolean
+          description: Signifies whether the address is a script address
+          example: true
+        utxo_set:
+          type: array
+          items:
+            type: object
+            properties:
+              tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              tx_index:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+              block_height:
+                $ref: "#/components/schemas/blocks/items/properties/block_height"
+              block_time:
+                $ref: "#/components/schemas/blocks/items/properties/block_time"
+              value:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+              datum_hash:
+                $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+              inline_datum:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+              reference_script:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+              asset_list:
+                $ref: "#/components/schemas/utxo_infos/items/properties/asset_list"
+  address_txs:
+    description: Array of transaction hashes
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  address_outputs:
+    description: Array of basic transaction output information
+    type: array
+    items:
+      type: object
+      properties:
+        address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        tx_index:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+        value:
+          $ref: "#/components/schemas/utxo_infos/items/properties/value"
+        stake_address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/stake_address"
+        payment_cred:
+          $ref: "#/components/schemas/utxo_infos/items/properties/payment_cred"
+        epoch_no:
+          $ref: "#/components/schemas/utxo_infos/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/utxo_infos/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/utxo_infos/items/properties/block_time"
+        is_spent:
+          $ref: "#/components/schemas/utxo_infos/items/properties/is_spent"
+  address_assets:
+    description: Array of address-owned assets
+    type: array
+    items:
+      type: object
+      properties:
+        address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        decimals:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+        quantity:
+          $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
+
+  account_list:
+    description: Array of account (stake address) IDs
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        stake_address_hex:
+          type: string
+          description: Cardano staking address (reward account) in hex format
+          example: e1c865f10d66a2e375242b5ef9f05abc8840d413421982f62c35ce4fbf
+        script_hash:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Script hash in case the stake address is locked by a script
+          example: bf357f5de69e4aad71954bebd64357a4813ea5233df12fce4a9de582
+  account_info:
+    description: Array of stake account information
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        status:
+          type: string
+          description: Stake address status
+          enum: ["registered", "not registered"]
+          example: registered
+        delegated_drep:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Account's current delegation status to DRep ID in CIP-129 Bech32 format
+          example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
+        delegated_pool:
+          anyOf:
+            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+            - type: "null"
+        total_balance:
+          type: string
+          description: Total balance of the account including UTxO, rewards and MIRs (in number)
+          example: "207116800428"
+        utxo:
+          type: string
+          description: Total UTxO balance of the account
+          example: "162764177131"
+        rewards:
+          type: string
+          description: Total rewards earned by the account
+          example: "56457728047"
+        withdrawals:
+          type: string
+          description: Total rewards withdrawn by the account
+          example: "12105104750"
+        rewards_available:
+          type: string
+          description: Total rewards available for withdrawal
+          example: "44352623297"
+        deposit:
+          type: string
+          description: Total deposit available for withdrawal
+          example: "2000000"
+        reserves:
+          type: string
+          description: Total reserves MIR value of the account
+          example: "0"
+        treasury:
+          type: string
+          description: Total treasury MIR value of the account
+          example: "0"
+        proposal-refund:
+          type: string
+          description: Total proposal refund for this account
+          example: "0"
+  account_rewards:
+    description: Array of reward history information
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        rewards:
+          type: array
+          items:
+            type: object
+            properties:
+              earned_epoch:
+                $ref: "#/components/schemas/reserve_withdrawals/items/properties/earned_epoch"
+              spendable_epoch:
+                $ref: "#/components/schemas/reserve_withdrawals/items/properties/spendable_epoch"
               amount:
                 type: string
-                example: "31235800000"
-          param_proposal:
-            description: If not null, the proposed new parameter set
-            anyOf:
-              - type: object
-              - type: 'null'
-            example: {"key_deposit": 1000000}
-    voter_proposal_list:
-      description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
-      type: array
-      items:
-        $ref: "#/components/schemas/proposal_list/items"
-    proposal_voting_summary:
-      description: Summary of votes for given proposal
-      type: array
-      items:
-        properties:
-          proposal_type:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
-          epoch_no:
-            type: number
-            description: Epoch for which data was collated
-            example: 441
-          drep_yes_votes_cast:
-            type: number
-            description: Number of 'yes' votes casted by dreps
-            example: 7
-          drep_active_yes_vote_power:
-            type: string
-            description: Power of 'yes' votes that were explicitly cast
-            example: "31231231231"
-          drep_yes_vote_power:
-            type: string
-            description: Power of 'yes' votes from dreps (includes explicit yes and inferred via other means)
-            example: "31146839512742"
-          drep_yes_pct:
-            type: number
-            description: Percentage of 'yes' votes from dreps
-            example: 60.72
-          drep_no_votes_cast:
-            type: number
-            description: Number of 'no' votes casted by dreps
-            example: 0
-          drep_active_no_vote_power:
-            type: string
-            description: Power of 'no' votes that were explicitly cast
-            example: "2012312393392"
-          drep_no_vote_power:
-            type: string
-            description: Power of 'no' votes from dreps (includes explicit no and inferred via other means)
-            example: "20148194577715"
-          drep_no_pct:
-            type: number
-            description: Percentage of 'no' votes from dreps
-            example: 39.28
-          drep_abstain_votes_cast:
-            type: number
-            description: Number of active 'abstain' votes from dreps
-            example: 5
-          drep_active_abstain_vote_power:
-            type: string
-            description: Power of 'abstain' votes that were explicitly cast
-            example: "123321123321"
-          drep_always_no_confidence_vote_power:
-            type: string
-            description: Power of votes delegated to 'always_no_confidence' predefined drep
-            example: "9999"
-          drep_always_abstain_vote_power:
-            type: string
-            description: Power of votes delegated to 'always_abstain' predefined drep
-            example: "87654321"
-          pool_yes_votes_cast:
-            type: number
-            description: Number of 'yes' votes casted by pools
-            example: 1
-          pool_active_yes_vote_power:
-            type: string
-            description: Power of 'yes' pool votes that were explicitly cast
-            example: "123123123"
-          pool_yes_vote_power:
-            type: string
-            description: Power of 'yes' votes from pools (includes explicit yes and inferred via other means)
-            example: "5234000000"
-          pool_yes_pct:
-            type: number
-            description: Percentage of 'yes' votes from pools
-            example: 13.12
-          pool_no_votes_cast:
-            type: number
-            description: Number of 'no' votes casted by pools
-            example: 0
-          pool_active_no_vote_power:
-            type: string
-            description: Power of 'no' pool votes that were explicitly cast
-            example: "0"
-          pool_no_vote_power:
-            type: string
-            description: Power of 'no' votes from pools (includes explicit no and inferred via other means)
-            example: "0"
-          pool_no_pct:
-            type: number
-            description: Percentage of 'no' votes from pools
-            example: 0
-          pool_abstain_votes_cast:
-            type: number
-            description: Percentage of 'abstain' votes from pools
-            example: 0
-          pool_active_abstain_vote_power:
-            type: string
-            description: Power of 'abstain' pool votes that were explicitly cast
-            example: "12312312312"
-          pool_passive_always_abstain_votes_assigned:
-            type: number
-            description: Number of non-voting SPO pool reward addresses delegating to 'always_abstain' drep
-            example: 1
-          pool_passive_always_abstain_vote_power:
-            type: string
-            description: Combined power of non-voting SPO pool votes where reward addresses delegate to 'always_abstain'
-            example: "12312312"
-          pool_passive_always_no_confidence_votes_assigned:
-            type: number
-            description: Number of non-voting SPO pool reward addresses delegating to 'always_no_confidence' drep
-            example: 10
-          pool_passive_always_no_confidence_vote_power:
-            type: string
-            description: Combined power of non-voting SPO pool votes where reward addresses delegate to 'always_no_confidence'
-            example: "321321"
-          committee_yes_votes_cast:
-            type: number
-            description: Number of 'yes' votes casted by committee
-            example: 5
-          committee_yes_pct:
-            type: number
-            description: Percentage of 'yes' votes from committee
-            example: 71.43
-          committee_no_votes_cast:
-            type: number
-            description: Number of 'no' votes casted by committee
-            example: 1
-          committee_no_pct:
-            type: number
-            description: Percentage of 'no' votes from committee
-            example: 28.57
-          committee_abstain_votes_cast:
-            type: number
-            description: Percentage of 'abstain' votes from committee
-    proposal_votes:
-      type: array
-      description: List of all votes cast on specified governance action
-      items:
-        properties:
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          voter_role:
-            type: string
-            description: The role of the voter
-            enum: ["ConstitutionalCommittee", "DRep", "SPO"]
-            example: DRep
-          voter_id:
-            type: string
-            description: Voter's DRep ID (CIP-129 bech32 format), pool ID (bech32 format) or committee hot ID (CIP-129 bech32 format)
-            example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
-          voter_hex:
-            type: string
-            description: Voter's DRep ID , pool ID or committee hash in hex format
-            example: 6e4069625cad00002da7d1fc444352e67613e895ca610bd3506bfafd
-          voter_has_script:
-            $ref: "#/components/schemas/drep_info/items/properties/has_script"
-          vote:
-            $ref: "#/components/schemas/drep_votes/items/properties/vote"
-          meta_url:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-    vote_list:
-      type: array
-      description: List of all votes cast on specified governance action
-      items:
-        properties:
-          vote_tx_hash:
-            type: string
-            description: The transaction hash where-in vote was posted
-            example: e239058473ab5ab1f5829b9058a93cbd0daaf72f9252cc16b34925cd87b37d35
-          voter_role:
-            $ref: "#/components/schemas/proposal_votes/items/properties/voter_role"
-          voter_id:
-            $ref: "#/components/schemas/proposal_votes/items/properties/voter_id"
-          proposal_id:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_id"
-          proposal_tx_hash:
-            $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-          proposal_index:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
-          proposal_type:
-            $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
-          epoch_no:
-            $ref: "#/components/schemas/blocks/items/properties/epoch_no"
-          block_height:
-            $ref: "#/components/schemas/blocks/items/properties/block_height"
-          block_time:
-            $ref: "#/components/schemas/blocks/items/properties/block_time"
-          vote:
-            $ref: "#/components/schemas/drep_votes/items/properties/vote"
-          meta_url:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
-          meta_hash:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
-          meta_json:
-            $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
-    committee_info:
-      description: Current governance committee
+                description: Amount of rewards earned (in number)
+              type:
+                type: string
+                description: The source of the rewards
+                enum: [member, leader, treasury, reserves, refund]
+                example: member
+              pool_id:
+                anyOf:
+                  - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+                  - type: "null"
+  account_reward_history:
+    description: Array of reward history information
+    type: array
+    items:
       type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        earned_epoch:
+          $ref: "#/components/schemas/reserve_withdrawals/items/properties/earned_epoch"
+        spendable_epoch:
+          $ref: "#/components/schemas/reserve_withdrawals/items/properties/spendable_epoch"
+        amount:
+          type: string
+          description: Amount of rewards earned (in number)
+        type:
+          type: string
+          description: The source of the rewards
+          enum: [member, leader, treasury, reserves, refund]
+          example: member
+        pool_id_bech32:
+          anyOf:
+            - $ref: "#/components/schemas/pool_list/items/properties/pool_id_bech32"
+            - type: "null"
+  account_updates:
+    description: Array of account updates information
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        updates:
+          type: array
+          items:
+            type: object
+            properties:
+              action_type:
+                type: string
+                description: Type of certificate submitted
+                enum:
+                  [
+                    "registration",
+                    "delegation_pool",
+                    "delegation_drep",
+                    "withdrawal",
+                    "deregistration",
+                  ]
+                example: "registration"
+              tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              epoch_no:
+                $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+              epoch_slot:
+                $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+              absolute_slot:
+                $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+              block_time:
+                $ref: "#/components/schemas/blocks/items/properties/block_time"
+  account_update_history:
+    description: Array of account update history information
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        action_type:
+          type: string
+          description: Type of certificate submitted
+          enum:
+            [
+              "registration",
+              "delegation_pool",
+              "delegation_drep",
+              "withdrawal",
+              "deregistration",
+            ]
+          example: "registration"
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        absolute_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+  account_addresses:
+    description: Array of payment addresses
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        addresses:
+          type: array
+          items:
+            $ref: "#/components/schemas/utxo_infos/items/properties/address"
+  account_assets:
+    description: Array of assets owned by account
+    type: array
+    items:
+      type: object
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_history/items/properties/stake_address"
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        decimals:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+        quantity:
+          $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
+  account_history:
+    description: Array of active stake values per epoch
+    type: array
+    items:
+      properties:
+        stake_address:
+          type: string
+          description: Cardano staking address (reward account) in bech32 format
+          example: stake1u8yxtugdv63wxafy9d00nuz6hjyyp4qnggvc9a3vxh8yl0ckml2uz
+        history:
+          type: array
+          items:
+            type: object
+            properties:
+              pool_id:
+                type: string
+                description: Bech32 representation of pool ID
+                example: pool1z5uqdk7dzdxaae5633fqfcu2eqzy3a3rgtuvy087fdld7yws0xt
+              epoch_no:
+                type: number
+                description: Epoch number
+                example: 301
+              active_stake:
+                type: string
+                description: Active stake amount (in numbers)
+                example: 682334162
+  account_stake_history:
+    description: Array of active stake values per epoch
+    type: array
+    items:
+      properties:
+        stake_address:
+          type: string
+          description: Cardano staking address (reward account) in bech32 format
+          example: stake1u8yxtugdv63wxafy9d00nuz6hjyyp4qnggvc9a3vxh8yl0ckml2uz
+        pool_id_bech32:
+          type: string
+          description: Bech32 representation of pool ID
+          example: pool1z5uqdk7dzdxaae5633fqfcu2eqzy3a3rgtuvy087fdld7yws0xt
+        epoch_no:
+          type: number
+          description: Epoch number
+          example: 301
+        active_stake:
+          type: string
+          description: Active stake amount (in numbers)
+          example: 682334162
+
+  tx_info:
+    description: Array of detailed information about transaction(s)
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        epoch_slot:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_slot"
+        absolute_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        tx_timestamp:
+          type: number
+          description: UNIX timestamp of the transaction
+          example: 1506635091
+        tx_block_index:
+          type: number
+          description: Index of transaction within block
+          example: 6
+        tx_size:
+          type: number
+          description: Size in bytes of transaction
+          example: 391
+        total_output:
+          type: string
+          description: Total sum of all transaction outputs (in numbers)
+          example: "157832856"
+        fee:
+          type: string
+          description: Total Transaction fee (in numbers)
+          example: "172761"
+        treasury_donation:
+          type: string
+          description: Total Donation to on-chain treasury (in numbers)
+          example: "0"
+        deposit:
+          type: string
+          description: Total Deposits included in transaction (for example, if it is registering a pool/key)
+          example: "0"
+        invalid_before:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Slot before which transaction cannot be validated (if supplied, else null)
+          example: "42331172"
+        invalid_after:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Slot after which transaction cannot be validated
+          example: "42332172"
+        collateral_inputs:
+          description: An array of collateral inputs needed for smart contracts in case of contract failure
+          anyOf:
+            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+            - type: "null"
+        collateral_output:
+          description: A collateral output for change if the smart contract fails to execute and collateral inputs are spent. (CIP-40)
+          anyOf:
+            - type: array
+            - type: "null"
+          items:
+            properties:
+              payment_addr:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/payment_addr"
+              stake_addr:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/stake_addr"
+              tx_hash:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/tx_hash"
+              tx_index:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/tx_index"
+              value:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+              datum_hash:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/datum_hash"
+              inline_datum:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+              reference_script:
+                $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+              asset_list:
+                type: array
+                description: Brief asset description from ledger
+        reference_inputs:
+          description: An array of reference inputs. A reference input allows looking at an output without spending it. (CIP-31)
+          anyOf:
+            - $ref: "#/components/schemas/tx_info/items/properties/outputs"
+            - type: "null"
+        inputs:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs"
+          #description: An array of UTxO inputs spent in the transaction
+        outputs:
+          type: array
+          description: An array of UTxO outputs created by the transaction
+          items:
+            type: object
+            properties:
+              payment_addr:
+                type: object
+                properties:
+                  bech32:
+                    $ref: "#/components/schemas/utxo_infos/items/properties/address"
+                  cred:
+                    type: string
+                    description: Payment credential
+                    example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+              stake_addr:
+                $ref: "#/components/schemas/address_info/items/properties/stake_address"
+              tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              tx_index:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+              value:
+                type: string
+                description: Total sum of ADA on the UTxO
+                example: "157832856"
+              datum_hash:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: Hash of datum (if any) connected to UTxO
+                example: 30c16dd243324cf9d90ffcf211b9e0f2117a7dc28d17e85927dfe2af3328e5c9
+              inline_datum:
+                anyOf:
+                  - type: object
+                  - type: "null"
+                description: Allows datums to be attached to UTxO (CIP-32)
+                properties:
+                  bytes:
+                    type: string
+                    description: Datum bytes (hex)
+                    example: 19029a
+                  value:
+                    type: object
+                    description: Value (json)
+                    example: { "int": 666 }
+              reference_script:
+                anyOf:
+                  - type: object
+                  - type: "null"
+                description: Allow reference scripts to be used to satisfy script requirements during validation, rather than requiring the spending transaction to do so. (CIP-33)
+                properties:
+                  hash:
+                    type: string
+                    description: Hash of referenced script
+                    example: 67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656
+                  size:
+                    type: number
+                    description: Size in bytes
+                    example: 14
+                  type:
+                    type: string
+                    description: Type of script
+                    example: plutusV1
+                  bytes:
+                    type: string
+                    description: Script bytes (hex)
+                    example: 4e4d01000033222220051200120011
+                  value:
+                    anyOf:
+                      - type: object
+                      - type: "null"
+                    description: Value (json)
+                    example: null
+              asset_list:
+                $ref: "#/components/schemas/utxo_infos/items/properties/asset_list"
+        withdrawals:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Array of withdrawals with-in a transaction
+          items:
+            type: object
+            properties:
+              amount:
+                type: string
+                description: Withdrawal amount (in numbers)
+                example: "9845162"
+              stake_addr:
+                type: string
+                description: A Cardano staking address (reward account, bech32 encoded)
+                example: stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj
+        assets_minted:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Array of minted assets with-in a transaction
+          items:
+            properties:
+              policy_id:
+                $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+              asset_name:
+                $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+              fingerprint:
+                $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+              decimals:
+                $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+              quantity:
+                type: string
+                description: Quantity of minted assets (negative on burn)
+                example: "1"
+        metadata:
+          $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
+        certificates:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Certificates present with-in a transaction (if any)
+          items:
+            properties:
+              index:
+                anyOf:
+                  - type: number
+                  - type: "null"
+                description: Certificate index
+                example: 0
+              type:
+                type: string
+                description: Type of certificate (could be delegation, stake_registration, stake_deregistraion, pool_update, pool_retire, param_proposal, reserve_MIR, treasury_MIR)
+                example: delegation
+              info:
+                anyOf:
+                  - type: object
+                  - type: "null"
+                description: A JSON array containing information from the certificate
+                example:
+                  {
+                    "stake_address": "stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj",
+                    "pool": "pool1k53pf4wzn263c08e3wr3gttndfecm9f4uzekgctcx947vt7fh2p",
+                  }
+        native_scripts:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Native scripts present in a transaction (if any)
+          items:
+            properties:
+              script_hash:
+                $ref: "#/components/schemas/script_info/items/properties/script_hash"
+              script_json:
+                type: object
+                description: JSON representation of the timelock script (null for other script types)
+                example:
+                  {
+                    "type": "all",
+                    "scripts":
+                      [
+                        {
+                          "type": "sig",
+                          "keyHash": "a96da581c39549aeda81f539ac3940ac0cb53657e774ca7e68f15ed9",
+                        },
+                        {
+                          "type": "sig",
+                          "keyHash": "ccfcb3fed004562be1354c837a4a4b9f4b1c2b6705229efeedd12d4d",
+                        },
+                        {
+                          "type": "sig",
+                          "keyHash": "74fcd61aecebe36aa6b6cd4314027282fa4b41c3ce8af17d9b77d0d1",
+                        },
+                      ],
+                  }
+        plutus_contracts:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Plutus contracts present in transaction (if any)
+          items:
+            properties:
+              address:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: Plutus script address
+                example: addr1w999n67e86jn6xal07pzxtrmqynspgx0fwmcmpua4wc6yzsxpljz3
+              spends_input:
+                anyOf:
+                  - type: object
+                  - type: "null"
+                properties:
+                  tx_hash:
+                    $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+                  tx_index:
+                    $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+                description: Input utxo this contract spends
+              script_hash:
+                $ref: "#/components/schemas/script_info/items/properties/script_hash"
+              bytecode:
+                $ref: "#/components/schemas/script_info/items/properties/bytes"
+              size:
+                $ref: "#/components/schemas/script_info/items/properties/size"
+              valid_contract:
+                type: boolean
+                description: True if the contract is valid or there is no contract
+                example: true
+              input:
+                type: object
+                properties:
+                  redeemer:
+                    type: object
+                    properties:
+                      purpose:
+                        $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/purpose"
+                      fee:
+                        $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/fee"
+                      unit:
+                        type: object
+                        properties:
+                          steps:
+                            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/unit_steps"
+                          mem:
+                            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/unit_mem"
+                      datum:
+                        type: object
+                        properties:
+                          hash:
+                            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+                          value:
+                            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_value"
+                  datum:
+                    type: object
+                    properties:
+                      hash:
+                        $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+                      value:
+                        $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_value"
+        voting_procedures:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Governance votes in a transaction (if any)
+          items:
+            properties:
+              proposal_tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              proposal_index:
+                $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
+              voter_role:
+                $ref: "#/components/schemas/proposal_votes/items/properties/voter_role"
+              voter:
+                $ref: "#/components/schemas/proposal_votes/items/properties/voter_id"
+              voter_hex:
+                $ref: "#/components/schemas/proposal_votes/items/properties/voter_hex"
+              vote:
+                $ref: "#/components/schemas/drep_votes/items/properties/vote"
+        proposal_procedures:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Governance proposals in a transaction (if any)
+          items:
+            properties:
+              index:
+                $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
+              type:
+                $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
+              description:
+                $ref: "#/components/schemas/proposal_list/items/properties/proposal_description"
+              deposit:
+                $ref: "#/components/schemas/drep_info/items/properties/deposit"
+              return_address:
+                $ref: "#/components/schemas/proposal_list/items/properties/return_address"
+              expiration:
+                $ref: "#/components/schemas/proposal_list/items/properties/expiration"
+              meta_url:
+                $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+              meta_hash:
+                $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+              withdrawal:
+                $ref: "#/components/schemas/proposal_list/items/properties/withdrawal"
+              param_proposal:
+                $ref: "#/components/schemas/proposal_list/items/properties/param_proposal"
+  tx_cbor:
+    description: Raw Transaction(s) in CBOR format
+    items:
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        absolute_slot:
+          $ref: "#/components/schemas/blocks/items/properties/abs_slot"
+        tx_timestamp:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_timestamp"
+        cbor:
+          type: string
+          description: CBOR encoded raw transaction.
+  tx_utxos:
+    description: Array of inputs and outputs for given transaction(s)
+    type: array
+    items:
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_hash"
+        inputs:
+          type: array
+          description: An array of UTxO inputs used by the transaction
+          items:
+            type: object
+            properties:
+              payment_addr:
+                type: object
+                properties:
+                  bech32:
+                    type: string
+                    description: A Cardano payment/base address (bech32 encoded) where funds were sent or change to be returned
+                    example: addr1q80rc8zj06yzdwwdyqc03rm4l3zv6n89rxuaak0t099n09yssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqad9mkw
+                  cred:
+                    type: string
+                    description: Payment credential
+                    example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+              stake_addr:
+                $ref: "#/components/schemas/address_info/items/properties/stake_address"
+              tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              tx_index:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+              value:
+                type: string
+                description: Total sum of ADA on the UTxO
+                example: 157832856
+        outputs:
+          description: An array of UTxO outputs created by the transaction
+          allOf:
+            - $ref: "#/components/schemas/tx_utxos/items/properties/inputs"
+  tx_metadata:
+    description: Array of metadata information present in each of the transactions queried
+    anyOf:
+      - type: array
+      - type: "null"
+    items:
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        metadata:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: A JSON array containing details about metadata within transaction
+          example:
+            {
+              "721":
+                {
+                  "version": 1,
+                  "copyright": "...",
+                  "publisher": ["p...o"],
+                  "4bf184e01e0f163296ab253edd60774e2d34367d0e7b6cbc689b567d":
+                    {},
+                },
+            }
+  tx_status:
+    description: Array of transaction confirmation counts
+    type: array
+    items:
+      properties:
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        num_confirmations:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Number of block confirmations
+          example: 17
+  tx_metalabels:
+    description: Array of known metadata labels
+    type: array
+    items:
+      properties:
+        key:
+          type: string
+          description: A distinct known metalabel
+          example: "721"
+  utxo_infos:
+    description: Array of complete UTxO information
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          type: string
+          description: Hash identifier of the transaction
+          example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+        tx_index:
+          type: number
+          description: Index of UTxO in the transaction
+          example: 0
+        address:
+          type: string
+          description: A Cardano payment/base address (bech32 encoded)
+          example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+        value:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+        stake_address:
+          $ref: "#/components/schemas/address_info/items/properties/stake_address"
+        payment_cred:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Payment credential
+          example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        datum_hash:
+          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+        inline_datum:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/inline_datum"
+        reference_script:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/reference_script"
+        asset_list:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: An array of assets on the UTxO
+          items:
+            properties:
+              policy_id:
+                $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+              asset_name:
+                $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+              fingerprint:
+                $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+              decimals:
+                $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+              quantity:
+                type: string
+                description: Quantity of assets on the UTxO
+                example: "1"
+        is_spent:
+          type: boolean
+          description: True if the UTXO has been spent
+          example: true
+  tx_outs_epoch:
+    description: List of transaction outputs with basic details for requested epoch
+    type: array
+    items:
+      type: object
+      properties:
+        tx_hash:
+          type: string
+          description: Hash identifier of the transaction
+          example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+        tx_index:
+          type: number
+          description: Index of UTxO in the transaction
+          example: 0
+        address:
+          type: string
+          description: A Cardano payment/base address (bech32 encoded)
+          example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+        stake_address:
+          $ref: "#/components/schemas/address_info/items/properties/stake_address"
+        payment_cred:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Payment credential
+          example: de3c1c527e8826b9cd2030f88f75fc44cd4ce519b9ded9eb794b3794
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        value:
+          $ref: "#/components/schemas/tx_info/items/properties/outputs/items/properties/value"
+        datum_hash:
+          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+        is_spent:
+          type: boolean
+          description: True if the UTXO has been spent
+          example: true
+  tx_treasury_donations_epoch:
+    description: List of treasury donation transactions for requested epoch
+    type: array
+    items:
+      type: object
+      properties:
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        block_hash:
+          $ref: "#/components/schemas/blocks/items/properties/hash"
+        tx_block_index:
+          $ref: "#/components/schemas/tx_info/items/properties/tx_block_index"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        treasury_donation:
+          $ref: "#/components/schemas/tx_info/items/properties/treasury_donation"
+
+  asset_list:
+    description: Array of policy IDs and asset names
+    type: array
+    items:
+      type: object
+      properties:
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        asset_name_ascii:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+  asset_token_registry:
+    description: An array of token registry information (registered via github) for each asset
+    type: array
+    items:
+      type: object
+      properties:
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        asset_name_ascii:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
+        ticker:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/ticker"
+        description:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/description"
+        url:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/url"
+        decimals:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+        logo:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/logo"
+  asset_addresses:
+    description: An array of payment addresses holding the given token (including balances)
+    type: array
+    items:
+      properties:
+        payment_address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        stake_address:
+          $ref: "#/components/schemas/address_info/items/properties/stake_address"
+        quantity:
+          type: string
+          description: Asset balance on the payment address
+          example: "23"
+  asset_nft_address:
+    description: An array of payment addresses holding the given token
+    type: array
+    items:
+      properties:
+        payment_address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        stake_address:
+          $ref: "#/components/schemas/address_info/items/properties/stake_address"
+  asset_summary:
+    description: Array of asset summary information
+    type: array
+    items:
+      properties:
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        total_transactions:
+          type: number
+          description: Total number of transactions including the given asset
+          example: 89416
+        staked_wallets:
+          type: number
+          description: Total number of registered wallets holding the given asset
+          example: 548
+        unstaked_addresses:
+          type: number
+          description: Total number of payment addresses (not belonging to registered wallets) holding the given asset
+          example: 245
+        addresses:
+          type: number
+          description: Total number of unique addresses holding the given asset
+          example: 812
+  asset_info:
+    description: Array of detailed asset information
+    type: array
+    items:
+      properties:
+        policy_id:
+          type: string
+          description: Asset Policy ID (hex)
+          example: d3501d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff
+        asset_name:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Asset Name (hex)
+          example: 444f4e545350414d
+        asset_name_ascii:
+          type: string
+          description: Asset Name (ASCII)
+          example: DONTSPAM
+        fingerprint:
+          type: string
+          description: The CIP14 fingerprint of the asset
+          example: asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9
+        minting_tx_hash:
+          type: string
+          description: Hash of the latest mint transaction (with metadata if found for asset)
+          example: cb07b7e51b77079776c4a78f2daf8f14f9945d2b047da7bfcb71d7fbb9f86712
+        total_supply:
+          type: string
+          description: Total supply for the asset
+          example: "35000"
+        mint_cnt:
+          type: number
+          description: Count of total mint transactions
+          example: 1
+        burn_cnt:
+          type: number
+          description: Count of total burn transactions
+          example: 5
+        creation_time:
+          type: number
+          description: UNIX timestamp of the first asset mint
+          example: 1506635091
+        minting_tx_metadata:
+          allOf:
+            - $ref: "#/components/schemas/tx_metadata/items/properties/metadata"
+          description: Latest minting transaction metadata (aligns with CIP-25)
+        token_registry_metadata:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: Asset metadata registered on the Cardano Token Registry
+          properties:
+            name:
+              anyOf:
+                - type: string
+                - type: "null"
+              example: Rackmob
+            description:
+              anyOf:
+                - type: string
+                - type: "null"
+              example: Metaverse Blockchain Cryptocurrency.
+            ticker:
+              anyOf:
+                - type: string
+                - type: "null"
+              example: MOB
+            url:
+              anyOf:
+                - type: string
+                - type: "null"
+              example: https://www.rackmob.com/
+            logo:
+              anyOf:
+                - type: string
+                - type: "null"
+              description: A PNG image file as a byte string
+              example: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADnmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4KPHg6eG1wbWV0YSB4bWxuczp4PSdhZG9iZTpuczptZXRhLyc
+            decimals:
+              type: number
+              example: 0
+        cip68_metadata:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: CIP 68 metadata if present for asset
+          example:
+            {
+              "222":
+                {
+                  "fields":
+                    [
+                      {
+                        "map":
+                          [
+                            {
+                              "k": { "bytes": "6e616d65" },
+                              "v": { "bytes": "74657374" },
+                            },
+                          ],
+                      },
+                    ],
+                  "constructor": 0,
+                },
+            }
+  asset_history:
+    description: Array of asset mint/burn history
+    type: array
+    items:
+      properties:
+        policy_id:
+          $ref: "#/components/schemas/asset_info/items/properties/policy_id"
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        minting_txs:
+          anyOf:
+            - type: array
+            - type: "null"
+          description: Array of all mint/burn transactions for an asset
+          items:
+            type: object
+            properties:
+              tx_hash:
+                type: string
+                description: Hash of minting/burning transaction
+                example: e1ecc517f95715bb87681cfde2c594dbc971739f84f8bfda16170b35d63d0ddf
+              block_time:
+                $ref: "#/components/schemas/blocks/items/properties/block_time"
+              quantity:
+                type: string
+                description: Quantity minted/burned (negative numbers indicate burn transactions)
+                example: "-10"
+              metadata:
+                type: array
+                description: Array of Transaction Metadata for given transaction
+                items:
+                  $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+
+  policy_asset_addresses:
+    description: Array of asset names and payment addresses for the given policy (including balances)
+    type: array
+    items:
+      properties:
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        payment_address:
+          $ref: "#/components/schemas/utxo_infos/items/properties/address"
+        stake_address:
+          $ref: "#/components/schemas/address_info/items/properties/stake_address"
+        quantity:
+          $ref: "#/components/schemas/asset_addresses/items/properties/quantity"
+  policy_asset_info:
+    description: Array of detailed information of assets under requested policies
+    type: array
+    items:
+      properties:
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        asset_name_ascii:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        minting_tx_hash:
+          $ref: "#/components/schemas/asset_info/items/properties/minting_tx_hash"
+        total_supply:
+          $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+        mint_cnt:
+          $ref: "#/components/schemas/asset_info/items/properties/mint_cnt"
+        burn_cnt:
+          $ref: "#/components/schemas/asset_info/items/properties/burn_cnt"
+        creation_time:
+          $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+        minting_tx_metadata:
+          $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+        token_registry_metadata:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata"
+  policy_asset_mints:
+    description: Array of mint information for assets under requested policies
+    type: array
+    items:
+      properties:
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        asset_name_ascii:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name_ascii"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        minting_tx_hash:
+          $ref: "#/components/schemas/asset_info/items/properties/minting_tx_hash"
+        total_supply:
+          $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+        mint_cnt:
+          $ref: "#/components/schemas/asset_info/items/properties/mint_cnt"
+        burn_cnt:
+          $ref: "#/components/schemas/asset_info/items/properties/burn_cnt"
+        creation_time:
+          $ref: "#/components/schemas/asset_info/items/properties/creation_time"
+        minting_tx_metadata:
+          $ref: "#/components/schemas/asset_info/items/properties/minting_tx_metadata"
+        decimals:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+  policy_asset_list:
+    description: Array of brief information of assets under the same policy
+    type: array
+    items:
+      properties:
+        asset_name:
+          $ref: "#/components/schemas/asset_info/items/properties/asset_name"
+        fingerprint:
+          $ref: "#/components/schemas/asset_info/items/properties/fingerprint"
+        total_supply:
+          $ref: "#/components/schemas/asset_info/items/properties/total_supply"
+        decimals:
+          $ref: "#/components/schemas/asset_info/items/properties/token_registry_metadata/properties/decimals"
+
+  drep_info:
+    description: Get detailed information about requested delegated representatives (DReps)
+    type: array
+    items:
+      properties:
+        drep_id:
+          type: string
+          description: DRep ID in CIP-129 bech32 format
+          example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
+        hex:
+          type: string
+          description: DRep ID in hex format
+          example: 6e4069625cad00002da7d1fc444352e67613e895ca610bd3506bfafd
+        has_script:
+          type: boolean
+          description: Flag which shows if this credential is a script hash
+          example: false
+        registered:
+          type: boolean
+          description: Flag to show if the DRep is currently registered
+          example: false
+        deposit:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: DRep's registration deposit  in number
+          example: "500000000"
+        active:
+          type: boolean
+          description: Flag to show if the DRep is  (i.e. not expired)
+          example: true
+        expires_epoch_no:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: After which epoch DRep is considered inactive.
+          example: 410
+        amount:
+          type: string
+          description: The total amount of voting power this DRep is delegated.
+          example: "599496769641"
+        meta_url:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: A URL to a JSON payload of metadata
+          example: "https://hornan7.github.io/Vote_Context.jsonld"
+        meta_hash:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: A hash of the contents of the metadata URL
+          example: dc208474e195442d07a5b6d42af19bb2db02229427dfb53ab23122e6b0e2487d
+  drep_epoch_summary:
+    description: Summary of voting power and DRep count for each epoch
+    type: array
+    items:
+      properties:
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        amount:
+          type: string
+          description: The total amount of voting power between all DReps including pre-defined roles for the epoch.
+          example: "599496769641"
+        dreps:
+          type: number
+          description: The total number of DReps with vote power for the epoch.
+          example: 324
+  drep_list:
+    description: List of all active delegated representatives (DReps)
+    type: array
+    items:
+      properties:
+        drep_id:
+          $ref: "#/components/schemas/drep_info/items/properties/drep_id"
+        hex:
+          $ref: "#/components/schemas/drep_info/items/properties/hex"
+        has_script:
+          $ref: "#/components/schemas/drep_info/items/properties/has_script"
+        registered:
+          $ref: "#/components/schemas/drep_info/items/properties/registered"
+  drep_delegators:
+    description: List of all delegators by requested delegated representative (DRep)
+    type: array
+    items:
+      properties:
+        stake_address:
+          $ref: "#/components/schemas/account_list/items/properties/stake_address"
+        stake_address_hex:
+          $ref: "#/components/schemas/account_list/items/properties/stake_address_hex"
+        script_hash:
+          $ref: "#/components/schemas/account_list/items/properties/script_hash"
+        epoch_no:
+          description: Epoch when vote delegation was made
+          allOf:
+            - $ref: "#/components/schemas/epoch_info/items/properties/epoch_no"
+        amount:
+          $ref: "#/components/schemas/account_info/items/properties/total_balance"
+  drep_metadata:
+    description: List metadata for requested delegated representatives (DReps)
+    type: array
+    items:
+      properties:
+        drep_id:
+          $ref: "#/components/schemas/drep_info/items/properties/drep_id"
+        hex:
+          $ref: "#/components/schemas/drep_info/items/properties/hex"
+        has_script:
+          $ref: "#/components/schemas/drep_info/items/properties/has_script"
+        meta_url:
+          $ref: "#/components/schemas/drep_info/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_info/items/properties/meta_hash"
+        meta_json:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: The payload as JSON
+          example:
+            {
+              "body":
+                {
+                  "title": "...",
+                  "...": "...",
+                  "references":
+                    [
+                      {
+                        "uri": "...",
+                        "@type": "Other",
+                        "label": "Hardfork to PV10",
+                      },
+                    ],
+                },
+              "authors":
+                [
+                  {
+                    "name": "...",
+                    "witness":
+                      {
+                        "publicKey": "...",
+                        "signature": "...",
+                        "witnessAlgorithm": "ed25519",
+                      },
+                  },
+                ],
+              "@context":
+                {
+                  "body":
+                    {
+                      "@id": "CIP108:body",
+                      "@context":
+                        {
+                          "title": "CIP108:title",
+                          "abstract": "CIP108:abstract",
+                          "rationale": "CIP108:rationale",
+                          "motivation": "CIP108:motivation",
+                          "references":
+                            {
+                              "@id": "CIP108:references",
+                              "@context":
+                                {
+                                  "uri": "CIP100:reference-uri",
+                                  "Other": "CIP100:OtherReference",
+                                  "label": "CIP100:reference-label",
+                                  "referenceHash":
+                                    {
+                                      "@id": "CIP108:referenceHash",
+                                      "@context":
+                                        {
+                                          "hashDigest": "CIP108:hashDigest",
+                                          "hashAlgorithm": "CIP100:hashAlgorithm",
+                                        },
+                                    },
+                                  "GovernanceMetadata": "CIP100:GovernanceMetadataReference",
+                                },
+                              "@container": "@set",
+                            },
+                        },
+                    },
+                  "CIP100": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#",
+                  "CIP108": "https://github.com/cardano-foundation/CIPs/blob/master/CIP-0108/README.md#",
+                  "authors":
+                    {
+                      "@id": "CIP100:authors",
+                      "@context":
+                        {
+                          "name": "http://xmlns.com/foaf/0.1/name",
+                          "witness":
+                            {
+                              "@id": "CIP100:witness",
+                              "@context":
+                                {
+                                  "publicKey": "CIP100:publicKey",
+                                  "signature": "CIP100:signature",
+                                  "witnessAlgorithm": "CIP100:witnessAlgorithm",
+                                },
+                            },
+                        },
+                      "@container": "@set",
+                    },
+                  "@language": "en-us",
+                  "hashAlgorithm": "CIP100:hashAlgorithm",
+                },
+              "hashAlgorithm": "blake2b-256",
+            }
+        bytes:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The raw bytes of the payload
+          example: 7b0a20202240636f6e74657874223a207b0a2020202022406c616e6775616765223a2022656e2d7573222c0a2020202022434950313030223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130302f524541444d452e6d6423222c0a2020202022434950313038223a202268747470733a2f2f6769746875622e636f6d2f63617264616e6f2d666f756e646174696f6e2f434950732f626c6f622f6d61737465722f4349502d303130382f524541444d452e6d6423222c0a202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d222c0a2020202022626f6479223a207b0a20202020202022406964223a20224349503130383a626f6479222c0a2020202020202240636f6e74657874223a207b0a2020202020202020227265666572656e636573223a207b0a2020202020202020202022406964223a20224349503130383a7265666572656e636573222c0a202020202020202020202240636f6e7461696e6572223a202240736574222c0a202020202020202020202240636f6e74657874223a207b0a20202020202020202020202022476f7665726e616e63654d65746164617461223a20224349503130303a476f7665726e616e63654d657461646174615265666572656e6365222c0a202020202020202020202020224f74686572223a20224349503130303a4f746865725265666572656e6365222c0a202020202020202020202020226c6162656c223a20224349503130303a7265666572656e63652d6c6162656c222c0a20202020202020202020202022757269223a20224349503130303a7265666572656e63652d757269222c0a202020202020202020202020227265666572656e636548617368223a207b0a202020202020202020202020202022406964223a20224349503130383a7265666572656e636548617368222c0a20202020202020202020202020202240636f6e74657874223a207b0a202020202020202020202020202020202268617368446967657374223a20224349503130383a68617368446967657374222c0a202020202020202020202020202020202268617368416c676f726974686d223a20224349503130303a68617368416c676f726974686d220a20202020202020202020202020207d0a2020202020202020202020207d0a202020202020202020207d0a20202020202020207d2c0a2020202020202020227469746c65223a20224349503130383a7469746c65222c0a2020202020202020226162737472616374223a20224349503130383a6162737472616374222c0a2020202020202020226d6f7469766174696f6e223a20224349503130383a6d6f7469766174696f6e222c0a202020202020202022726174696f6e616c65223a20224349503130383a726174696f6e616c65220a2020202020207d0a202020207d2c0a2020202022617574686f7273223a207b0a20202020202022406964223a20224349503130303a617574686f7273222c0a2020202020202240636f6e7461696e6572223a202240736574222c0a2020202020202240636f6e74657874223a207b0a2020202020202020226e616d65223a2022687474703a2f2f786d6c6e732e636f6d2f666f61662f302e312f6e616d65222c0a2020202020202020227769746e657373223a207b0a2020202020202020202022406964223a20224349503130303a7769746e657373222c0a202020202020202020202240636f6e74657874223a207b0a202020202020202020202020227769746e657373416c676f726974686d223a20224349503130303a7769746e657373416c676f726974686d222c0a202020202020202020202020227075626c69634b6579223a20224349503130303a7075626c69634b6579222c0a202020202020202020202020227369676e6174757265223a20224349503130303a7369676e6174757265220a202020202020202020207d0a20202020202020207d0a2020202020207d0a202020207d0a20207d2c0a20202268617368416c676f726974686d223a2022626c616b6532622d323536222c0a202022626f6479223a207b0a20202020227469746c65223a202248617264666f726b20746f2050726f746f636f6c2076657273696f6e203130222c0a20202020226162737472616374223a20224c6574277320686176652073616e63686f4e657420696e2066756c6c20676f7665726e616e636520617320736f6f6e20617320706f737369626c65222c0a20202020226d6f7469766174696f6e223a2022505639206973206e6f742061732066756e2061732050563130222c0a2020202022726174696f6e616c65223a20224c65742773206b6565702074657374696e67207374756666222c0a20202020227265666572656e636573223a205b0a2020202020207b0a2020202020202020224074797065223a20224f74686572222c0a2020202020202020226c6162656c223a202248617264666f726b20746f2050563130222c0a202020202020202022757269223a2022220a2020202020207d0a202020205d0a20207d2c0a202022617574686f7273223a205b0a202020207b0a202020202020226e616d65223a20224361726c6f73222c0a202020202020227769746e657373223a207b0a2020202020202020227769746e657373416c676f726974686d223a202265643235353139222c0a2020202020202020227075626c69634b6579223a202237656130396133346165626231336339383431633731333937623163616266656335646466393530343035323933646565343936636163326634333734383061222c0a2020202020202020227369676e6174757265223a20226134373639383562346363306434353766323437373937363131373939613666366138306663386362376563396463623561383232333838386430363138653330646531363566336438363963346130643931303764386135623631326164376335653432343431393037663562393137393666306437313837643634613031220a2020202020207d0a202020207d0a20205d0a7d
+        warning:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: A warning that occured while validating the metadata
+        language:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The language described in the context of the metadata as per CIP-100
+          example: en-us
+        comment:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Comment attached to the metadata
+        is_valid:
+          anyOf:
+            - type: boolean
+            - type: "null"
+          description: Indicate whether data is invalid (currently returns null for all as per dbsync)
+          example: null
+  drep_updates:
+    description: List of updates for requested (or all) delegated representatives (DReps)
+    type: array
+    items:
+      properties:
+        drep_id:
+          $ref: "#/components/schemas/drep_info/items/properties/drep_id"
+        hex:
+          $ref: "#/components/schemas/drep_info/items/properties/hex"
+        has_script:
+          $ref: "#/components/schemas/drep_info/items/properties/has_script"
+        update_tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        cert_index:
+          type: number
+          description: The index of this certificate within the the transaction.
+          example: 1
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        action:
+          type: string
+          description: Effective action for this DRep Update certificate
+          enum: ["updated", "registered", "deregistered"]
+          example: registered
+        deposit:
+          $ref: "#/components/schemas/drep_info/items/properties/deposit"
+        meta_url:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+        meta_json:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
+  drep_voting_power_history:
+    description: History of DReps voting power against each (or requested) epoch
+    type: array
+    items:
+      properties:
+        drep_id:
+          $ref: "#/components/schemas/drep_info/items/properties/drep_id"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        amount:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The voting power for the DRep
+          example: "14231445553"
+  drep_votes:
+    description: List of all votes casted by requested delegated representative (DRep)
+    type: array
+    items:
       properties:
         proposal_id:
           $ref: "#/components/schemas/proposal_list/items/properties/proposal_id"
@@ -3139,185 +2949,544 @@ schemas:
           $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
         proposal_index:
           $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
-        quorum_numerator:
+        vote_tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        vote:
+          type: string
+          enum: ["Yes", "No", "Abstain"]
+          description: Actual Vote casted
+          example: "Yes"
+        meta_url:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+  pool_voting_power_history:
+    description: History of Pool's voting power against each (or requested) epoch
+    type: array
+    items:
+      properties:
+        pool_id_bech32:
+          $ref: "#/components/schemas/pool_info/items/properties/pool_id_bech32"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        amount:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: The voting power for the pool for the epoch
+          example: "11231445553"
+  pool_votes:
+    description: List of all votes casted by requested pool
+    type: array
+    items:
+      $ref: "#/components/schemas/drep_votes/items"
+  committee_votes:
+    description: List of all votes casted by requested delegated representative (DRep)
+    type: array
+    items:
+      $ref: "#/components/schemas/drep_votes/items"
+  proposal_list:
+    description: List of all governance action proposals
+    type: array
+    items:
+      properties:
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        proposal_id:
+          type: string
+          description: Proposal Action ID in accordance with CIP-129 format
+          example: "gov_action17m93skslaxyd45gpr6ernkdzs852h564wsterr8l6lheu7hu7kvsqecyqdh"
+        proposal_tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        proposal_index:
           type: number
-          example: 67
-        quorum_denominator:
+          description: Index of governance proposal in transaction
+          example: 0
+        proposal_type:
+          type: string
+          enum:
+            [
+              "ParameterChange",
+              "HardForkInitiation",
+              "TreasuryWithdrawals",
+              "NoConfidence",
+              "NewCommittee",
+              "NewConstitution",
+              "InfoAction",
+            ]
+          description: Proposal Action Type
+          example: ParameterChange
+        proposal_description:
+          type: object
+          description: Description for Proposal Action
+          example: '{"tag": "InfoAction"}'
+        deposit:
+          $ref: "#/components/schemas/drep_info/items/properties/deposit"
+        return_address:
+          type: string
+          description: The StakeAddress index of the reward address to receive the deposit when it is repaid.
+          example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
+        proposed_epoch:
           type: number
-          example: 100
-        members:
-          description: Array of all members part of active governance committee
+          description: Shows the epoch at which this governance action was proposed.
+          example: 660
+        ratified_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: If not null, then this proposal has been ratified at the specfied epoch.
+          example: 670
+        enacted_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: If not null, then this proposal has been enacted at the specfied epoch.
+          example: 675
+        dropped_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
+          example: 680
+        expired_epoch:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: If not null, then this proposal has been expired at the specfied epoch.
+          example: 680
+        expiration:
+          anyOf:
+            - type: number
+            - type: "null"
+          description: Shows the epoch at which this governance action is expected to expire.
+        meta_url:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+        meta_json:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
+        meta_comment:
+          $ref: "#/components/schemas/drep_metadata/items/properties/comment"
+        meta_language:
+          $ref: "#/components/schemas/drep_metadata/items/properties/language"
+        meta_is_valid:
+          $ref: "#/components/schemas/drep_metadata/items/properties/is_valid"
+        withdrawal:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: If not null, the amount withdrawn from treasury into stake address by this this proposal
+          properties:
+            stake_address:
+              $ref: "#/components/schemas/account_history/items/properties/stake_address"
+            amount:
+              type: string
+              example: "31235800000"
+        param_proposal:
+          description: If not null, the proposed new parameter set
+          anyOf:
+            - type: object
+            - type: "null"
+          example: { "key_deposit": 1000000 }
+  voter_proposal_list:
+    description: List of all governance action proposals where specified credential(DRep, SPO or Committee member) has cast a vote
+    type: array
+    items:
+      $ref: "#/components/schemas/proposal_list/items"
+  proposal_voting_summary:
+    description: Summary of votes for given proposal
+    type: array
+    items:
+      properties:
+        proposal_type:
+          $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
+        epoch_no:
+          type: number
+          description: Epoch for which data was collated
+          example: 441
+        drep_yes_votes_cast:
+          type: number
+          description: Number of 'yes' votes casted by dreps
+          example: 7
+        drep_active_yes_vote_power:
+          type: string
+          description: Power of 'yes' votes that were explicitly cast
+          example: "31231231231"
+        drep_yes_vote_power:
+          type: string
+          description: Power of 'yes' votes from dreps (includes explicit yes and inferred via other means)
+          example: "31146839512742"
+        drep_yes_pct:
+          type: number
+          description: Percentage of 'yes' votes from dreps
+          example: 60.72
+        drep_no_votes_cast:
+          type: number
+          description: Number of 'no' votes casted by dreps
+          example: 0
+        drep_active_no_vote_power:
+          type: string
+          description: Power of 'no' votes that were explicitly cast
+          example: "2012312393392"
+        drep_no_vote_power:
+          type: string
+          description: Power of 'no' votes from dreps (includes explicit no and inferred via other means)
+          example: "20148194577715"
+        drep_no_pct:
+          type: number
+          description: Percentage of 'no' votes from dreps
+          example: 39.28
+        drep_abstain_votes_cast:
+          type: number
+          description: Number of active 'abstain' votes from dreps
+          example: 5
+        drep_active_abstain_vote_power:
+          type: string
+          description: Power of 'abstain' votes that were explicitly cast
+          example: "123321123321"
+        drep_always_no_confidence_vote_power:
+          type: string
+          description: Power of votes delegated to 'always_no_confidence' predefined drep
+          example: "9999"
+        drep_always_abstain_vote_power:
+          type: string
+          description: Power of votes delegated to 'always_abstain' predefined drep
+          example: "87654321"
+        pool_yes_votes_cast:
+          type: number
+          description: Number of 'yes' votes casted by pools
+          example: 1
+        pool_active_yes_vote_power:
+          type: string
+          description: Power of 'yes' pool votes that were explicitly cast
+          example: "123123123"
+        pool_yes_vote_power:
+          type: string
+          description: Power of 'yes' votes from pools (includes explicit yes and inferred via other means)
+          example: "5234000000"
+        pool_yes_pct:
+          type: number
+          description: Percentage of 'yes' votes from pools
+          example: 13.12
+        pool_no_votes_cast:
+          type: number
+          description: Number of 'no' votes casted by pools
+          example: 0
+        pool_active_no_vote_power:
+          type: string
+          description: Power of 'no' pool votes that were explicitly cast
+          example: "0"
+        pool_no_vote_power:
+          type: string
+          description: Power of 'no' votes from pools (includes explicit no and inferred via other means)
+          example: "0"
+        pool_no_pct:
+          type: number
+          description: Percentage of 'no' votes from pools
+          example: 0
+        pool_abstain_votes_cast:
+          type: number
+          description: Percentage of 'abstain' votes from pools
+          example: 0
+        pool_active_abstain_vote_power:
+          type: string
+          description: Power of 'abstain' pool votes that were explicitly cast
+          example: "12312312312"
+        pool_passive_always_abstain_votes_assigned:
+          type: number
+          description: Number of non-voting SPO pool reward addresses delegating to 'always_abstain' drep
+          example: 1
+        pool_passive_always_abstain_vote_power:
+          type: string
+          description: Combined power of non-voting SPO pool votes where reward addresses delegate to 'always_abstain'
+          example: "12312312"
+        pool_passive_always_no_confidence_votes_assigned:
+          type: number
+          description: Number of non-voting SPO pool reward addresses delegating to 'always_no_confidence' drep
+          example: 10
+        pool_passive_always_no_confidence_vote_power:
+          type: string
+          description: Combined power of non-voting SPO pool votes where reward addresses delegate to 'always_no_confidence'
+          example: "321321"
+        committee_yes_votes_cast:
+          type: number
+          description: Number of 'yes' votes casted by committee
+          example: 5
+        committee_yes_pct:
+          type: number
+          description: Percentage of 'yes' votes from committee
+          example: 71.43
+        committee_no_votes_cast:
+          type: number
+          description: Number of 'no' votes casted by committee
+          example: 1
+        committee_no_pct:
+          type: number
+          description: Percentage of 'no' votes from committee
+          example: 28.57
+        committee_abstain_votes_cast:
+          type: number
+          description: Percentage of 'abstain' votes from committee
+  proposal_votes:
+    type: array
+    description: List of all votes cast on specified governance action
+    items:
+      properties:
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        voter_role:
+          type: string
+          description: The role of the voter
+          enum: ["ConstitutionalCommittee", "DRep", "SPO"]
+          example: DRep
+        voter_id:
+          type: string
+          description: Voter's DRep ID (CIP-129 bech32 format), pool ID (bech32 format) or committee hot ID (CIP-129 bech32 format)
+          example: drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3
+        voter_hex:
+          type: string
+          description: Voter's DRep ID , pool ID or committee hash in hex format
+          example: 6e4069625cad00002da7d1fc444352e67613e895ca610bd3506bfafd
+        voter_has_script:
+          $ref: "#/components/schemas/drep_info/items/properties/has_script"
+        vote:
+          $ref: "#/components/schemas/drep_votes/items/properties/vote"
+        meta_url:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+  vote_list:
+    type: array
+    description: List of all votes cast on specified governance action
+    items:
+      properties:
+        vote_tx_hash:
+          type: string
+          description: The transaction hash where-in vote was posted
+          example: e239058473ab5ab1f5829b9058a93cbd0daaf72f9252cc16b34925cd87b37d35
+        voter_role:
+          $ref: "#/components/schemas/proposal_votes/items/properties/voter_role"
+        voter_id:
+          $ref: "#/components/schemas/proposal_votes/items/properties/voter_id"
+        proposal_id:
+          $ref: "#/components/schemas/proposal_list/items/properties/proposal_id"
+        proposal_tx_hash:
+          $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+        proposal_index:
+          $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
+        proposal_type:
+          $ref: "#/components/schemas/proposal_list/items/properties/proposal_type"
+        epoch_no:
+          $ref: "#/components/schemas/blocks/items/properties/epoch_no"
+        block_height:
+          $ref: "#/components/schemas/blocks/items/properties/block_height"
+        block_time:
+          $ref: "#/components/schemas/blocks/items/properties/block_time"
+        vote:
+          $ref: "#/components/schemas/drep_votes/items/properties/vote"
+        meta_url:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_url"
+        meta_hash:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_hash"
+        meta_json:
+          $ref: "#/components/schemas/drep_metadata/items/properties/meta_json"
+  committee_info:
+    description: Current governance committee
+    type: object
+    properties:
+      proposal_id:
+        $ref: "#/components/schemas/proposal_list/items/properties/proposal_id"
+      proposal_tx_hash:
+        $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+      proposal_index:
+        $ref: "#/components/schemas/proposal_list/items/properties/proposal_index"
+      quorum_numerator:
+        type: number
+        example: 67
+      quorum_denominator:
+        type: number
+        example: 100
+      members:
+        description: Array of all members part of active governance committee
+        type: array
+        items:
+          type: object
+          properties:
+            status:
+              type: string
+              description: Member authentication status
+              enum: ["authorized", "not_authorized", "resigned"]
+              example: authorized
+            cc_cold_hex:
+              type: string
+              description: Committee member cold key hash in hex format
+              example: 6095e643ea6f1cccb6e463ec34349026b3a48621aac5d512655ab1bf
+            cc_cold_has_script:
+              type: boolean
+              description: Flag which shows if this credential is a script hash
+              example: false
+            cc_hot_hex:
+              anyOf:
+                - type: string
+                - type: "null"
+              description: Committee member key hash from last valid hot key authorization certificate in hex format
+              example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
+            cc_hot_has_script:
+              anyOf:
+                - type: boolean
+                - type: "null"
+              description: Flag which shows if this credential is a script hash
+              example: false
+            expiration_epoch:
+              type: number
+              description: Epoch number in which the committee member vote rights expire
+              example: 324
+
+  script_info:
+    type: array
+    items:
+      description: Array of information for scripts
+      properties:
+        script_hash:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Hash of a script
+          example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
+        creation_tx_hash:
+          type: string
+          description: Hash of the script creation transaction
+          example: 255f061502ad83230351fbcf2d9fade1b5d118d332f92c9861075010a1fe3fbe
+        type:
+          type: string
+          description: Type of the script
+          enum: ["plutusV1", "plutusV2", "timelock", "multisig"]
+          example: plutusV1
+        value:
+          anyOf:
+            - type: object
+            - type: "null"
+          description: Data in JSON format
+          example: null
+        bytes:
+          anyOf:
+            - type: string
+            - type: "null"
+          description: Script bytes (cborSeq)
+          example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
+        size:
+          type: number
+          description: The size of the CBOR serialised script (in bytes)
+          example: 2039
+  script_list:
+    description: List of script and creation tx hash pairs
+    type: array
+    items:
+      properties:
+        script_hash:
+          $ref: "#/components/schemas/script_info/items/properties/script_hash"
+        creation_tx_hash:
+          $ref: "#/components/schemas/script_info/items/properties/creation_tx_hash"
+        type:
+          $ref: "#/components/schemas/script_info/items/properties/type"
+        size:
+          $ref: "#/components/schemas/script_info/items/properties/size"
+  script_redeemers:
+    description: Array of all redeemers for a given script hash
+    type: array
+    items:
+      type: object
+      properties:
+        script_hash:
+          $ref: "#/components/schemas/script_info/items/properties/script_hash"
+        redeemers:
           type: array
           items:
             type: object
             properties:
-              status:
-                type: string
-                description: Member authentication status
-                enum: [ "authorized", "not_authorized", "resigned" ]
-                example: authorized
-              cc_cold_hex:
-                type: string
-                description: Committee member cold key hash in hex format
-                example: 6095e643ea6f1cccb6e463ec34349026b3a48621aac5d512655ab1bf
-              cc_cold_has_script:
-                type: boolean
-                description: Flag which shows if this credential is a script hash
-                example: false
-              cc_hot_hex:
+              tx_hash:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
+              tx_index:
+                $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
+              unit_mem:
                 anyOf:
                   - type: string
-                  - type: 'null'
-                description: Committee member key hash from last valid hot key authorization certificate in hex format
-                example: 65d497b875c56ab213586a4006d4f6658970573ea8e2398893857472
-              cc_hot_has_script:
+                  - type: number
+                  - type: "null"
+                description: The budget in Memory to run a script
+                example: 520448
+              unit_steps:
                 anyOf:
-                  - type: boolean
-                  - type: 'null'
-                description: Flag which shows if this credential is a script hash
-                example: false
-              expiration_epoch:
-                type: number
-                description: Epoch number in which the committee member vote rights expire
-                example: 324
-    script_info:
-      type: array
-      items:
-        description: Array of information for scripts
-        properties:
-          script_hash:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Hash of a script
-            example: bfa7ffa9b2e164873db6ac6d0528c82e212963bc62e10fd1d81da4af
-          creation_tx_hash:
-            type: string
-            description: Hash of the script creation transaction
-            example: 255f061502ad83230351fbcf2d9fade1b5d118d332f92c9861075010a1fe3fbe
-          type:
-            type: string
-            description: Type of the script
-            enum: ["plutusV1","plutusV2","timelock","multisig"]
-            example: plutusV1
-          value:
-            anyOf:
-              - type: object
-              - type: 'null'
-            description: Data in JSON format
-            example: null
-          bytes:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Script bytes (cborSeq)
-            example: 5907f4010000332323232323232323233223232323232332232323232322223232533532533533355300712001323212330012233350052200200200100235001220011233001225335002101710010142325335333573466e3cd400488008d4020880080580544ccd5cd19b873500122001350082200101601510153500122002353500122002222222222200a101413357389201115554784f206e6f7420636f6e73756d6564000133333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008cd40508c8c8cccd5cd19b8735573aa0049000119910919800801801180f9aba150023019357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854028cd4050054d5d0a804999aa80bbae501635742a010666aa02eeb94058d5d0a80399a80a0109aba15006335014335502402275a6ae854014c8c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233502575a6ae854008c098d5d09aba2500223263533573805e05c05a05826aae7940044dd50009aba150023232323333573466e1cd55cea8012400046644246600200600466a04aeb4d5d0a80118131aba135744a004464c6a66ae700bc0b80b40b04d55cf280089baa001357426ae8940088c98d4cd5ce01581501481409aab9e5001137540026ae854010cd4051d71aba15003335014335502475c40026ae854008c070d5d09aba2500223263533573804e04c04a04826ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053019357426aae79400c8cccd5cd19b875002480108c848888c008014c06cd5d09aab9e500423333573466e1d400d20022321222230010053015357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7008808408007c0780740704d55cea80089baa001357426ae8940088c98d4cd5ce00d80d00c80c080c89931a99ab9c4910350543500019018135573ca00226ea8004c8004d5405888448894cd40044d400c88004884ccd401488008c010008ccd54c01c4800401401000448c88c008dd6000990009aa80b111999aab9f00125009233500830043574200460066ae880080548c8c8c8cccd5cd19b8735573aa00690001199911091998008020018011919191999ab9a3370e6aae7540092000233221233001003002301735742a00466a01c02c6ae84d5d1280111931a99ab9c01b01a019018135573ca00226ea8004d5d0a801999aa803bae500635742a00466a014eb8d5d09aba2500223263533573802e02c02a02826ae8940044d55cf280089baa0011335500175ceb44488c88c008dd5800990009aa80a11191999aab9f0022500823350073355017300635573aa004600a6aae794008c010d5d100180a09aba100111220021221223300100400312232323333573466e1d4005200023212230020033005357426aae79400c8cccd5cd19b8750024800884880048c98d4cd5ce00980900880800789aab9d500113754002464646666ae68cdc39aab9d5002480008cc8848cc00400c008c014d5d0a8011bad357426ae8940088c98d4cd5ce00800780700689aab9e5001137540024646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7003803403002c4dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6a66ae7004404003c0380340304d55cea80089baa0012323333573466e1d40052002200523333573466e1d40092000200523263533573801a01801601401226aae74dd5000891001091000919191919191999ab9a3370ea002900610911111100191999ab9a3370ea004900510911111100211999ab9a3370ea00690041199109111111198008048041bae35742a00a6eb4d5d09aba2500523333573466e1d40112006233221222222233002009008375c6ae85401cdd71aba135744a00e46666ae68cdc3a802a400846644244444446600c01201060186ae854024dd71aba135744a01246666ae68cdc3a8032400446424444444600e010601a6ae84d55cf280591999ab9a3370ea00e900011909111111180280418071aba135573ca018464c6a66ae7004c04804404003c03803403002c0284d55cea80209aab9e5003135573ca00426aae7940044dd50009191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc020d5d09aab9e500623263533573801801601401201026aae75400c4d5d1280089aab9e500113754002464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c009008007006005135573aa00226ea800444888c8c8cccd5cd19b8735573aa0049000119aa80518031aba150023005357426ae8940088c98d4cd5ce00480400380309aab9e5001137540029309000a490350543100112212330010030021123230010012233003300200200133512233002489209366f09fe40eaaeb17d3cb6b0b61e087d664174c39a48a986f86b2b0ba6e2a7b00480008848cc00400c0088005
-          size:
-            type: number
-            description: The size of the CBOR serialised script (in bytes)
-            example: 2039
-    script_list:
-      description: List of script and creation tx hash pairs
-      type: array
-      items:
-        properties:
-          script_hash:
-            $ref: "#/components/schemas/script_info/items/properties/script_hash"
-          creation_tx_hash:
-            $ref: "#/components/schemas/script_info/items/properties/creation_tx_hash"
-          type:
-            $ref: "#/components/schemas/script_info/items/properties/type"
-          size:
-            $ref: "#/components/schemas/script_info/items/properties/size"
-    script_redeemers:
-      description: Array of all redeemers for a given script hash
-      type: array
-      items:
-        type: object
-        properties:
-          script_hash:
-            $ref: "#/components/schemas/script_info/items/properties/script_hash"
-          redeemers:
-            type: array
-            items:
-              type: object
-              properties:
-                tx_hash:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_hash"
-                tx_index:
-                  $ref: "#/components/schemas/utxo_infos/items/properties/tx_index"
-                unit_mem:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: 'null'
-                  description: The budget in Memory to run a script
-                  example: 520448
-                unit_steps:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: 'null'
-                  description: The budget in Cpu steps to run a script
-                  example: 211535239
-                fee:
-                  type: string
-                  description: The budget in fees to run a script - the fees depend on the ExUnits and the current prices
-                  example: "45282"
-                purpose:
-                  type: string
-                  description: What kind of validation this redeemer is used for
-                  enum: ["spend", "mint", "cert", "reward"]
-                  example: spend
-                datum_hash:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                  description: The Hash of the Plutus Data
-                  example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
-                datum_value:
-                  $ref: "#/components/schemas/script_info/items/properties/value"
-    datum_info:
-      description: Array of datum information for given datum hashes
-      type: array
-      items:
-        type: object
-        properties:
-          datum_hash:
-            $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
-          creation_tx_hash:
-            $ref: "#/components/schemas/script_info/items/properties/creation_tx_hash"
-          value:
-            $ref: "#/components/schemas/script_info/items/properties/value"
-          bytes:
-            $ref: "#/components/schemas/script_info/items/properties/bytes"
-    ogmiostip:
-      description: Current tip of the chain, identified by a slot and a block header hash.
+                  - type: string
+                  - type: number
+                  - type: "null"
+                description: The budget in Cpu steps to run a script
+                example: 211535239
+              fee:
+                type: string
+                description: The budget in fees to run a script - the fees depend on the ExUnits and the current prices
+                example: "45282"
+              purpose:
+                type: string
+                description: What kind of validation this redeemer is used for
+                enum: ["spend", "mint", "cert", "reward"]
+                example: spend
+              datum_hash:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                description: The Hash of the Plutus Data
+                example: 5a595ce795815e81d22a1a522cf3987d546dc5bb016de61b002edd63a5413ec4
+              datum_value:
+                $ref: "#/components/schemas/script_info/items/properties/value"
+  datum_info:
+    description: Array of datum information for given datum hashes
+    type: array
+    items:
       type: object
       properties:
-        jsonrpc:
-          type: string
-          description: Identifier for JSON-RPC 2.0 standard
-          example: "2.0"
-        method:
-          type: string
-          description: The Ogmios method that was called in the request
-          example: "queryNetwork/tip"
-        result:
-          anyOf:
-            - type: string
-            - type: number
-            - type: array
-            - type: object
-            - type: 'null'
-          description: Result of the query
-          properties:
-            slot:
-              type: number
-              description: Absolute slot number on chain
-              example: 59886800
-            id:
-              type: string
-              description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
-              example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
-          example: {"slot": 59886800, "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"}
+        datum_hash:
+          $ref: "#/components/schemas/script_redeemers/items/properties/redeemers/items/properties/datum_hash"
+        creation_tx_hash:
+          $ref: "#/components/schemas/script_info/items/properties/creation_tx_hash"
+        value:
+          $ref: "#/components/schemas/script_info/items/properties/value"
+        bytes:
+          $ref: "#/components/schemas/script_info/items/properties/bytes"
+
+  ogmiostip:
+    description: Current tip of the chain, identified by a slot and a block header hash.
+    type: object
+    properties:
+      jsonrpc:
+        type: string
+        description: Identifier for JSON-RPC 2.0 standard
+        example: "2.0"
+      method:
+        type: string
+        description: The Ogmios method that was called in the request
+        example: "queryNetwork/tip"
+      result:
+        anyOf:
+          - type: string
+          - type: number
+          - type: array
+          - type: object
+          - type: "null"
+        description: Result of the query
+        properties:
+          slot:
+            type: number
+            description: Absolute slot number on chain
+            example: 59886800
+          id:
+            type: string
+            description: Block Hash (Blake2b 32-byte hash digest, encoded in base16)
+            example: "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1"
+        example:
+          {
+            "slot": 59886800,
+            "id": "df5678c9774b7bc8c60a4c83b63c3676e618640ad05f7d1ee775b68939cf77d1",
+          }

--- a/specs/templates/api-main.yaml
+++ b/specs/templates/api-main.yaml
@@ -12,7 +12,6 @@ servers:
   - url: https://sancho.koios.rest/api/v1
     description: Sanchonet Network
 paths:
-
   /tip: #RPC
     get:
       tags:
@@ -345,7 +344,7 @@ paths:
       operationId: block_tx_info
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /utxo_info: #RPC
     post:
@@ -555,7 +554,7 @@ paths:
       operationId: tx_utxos
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
 
   /address_info: #RPC
     post:
@@ -847,7 +846,7 @@ paths:
       operationId: account_rewards
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_reward_history: #RPC
     post:
       tags:
@@ -988,7 +987,7 @@ paths:
       operationId: account_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /account_stake_history: #RPC
     post:
       tags:
@@ -1163,8 +1162,8 @@ paths:
           $ref: "#/components/responses/NotFound"
       summary: Asset Addresses
       description: Get the list of all addresses holding a given asset <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: asset_addresses
   /asset_nft_address: #RPC
@@ -1210,9 +1209,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Policy Asset Address List
-      description: Get the list of addresses with quantity for each asset on the given policy <br><br>
-        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects 
-        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to 
+      description:
+        Get the list of addresses with quantity for each asset on the given policy <br><br>
+        `Note - Due to cardano's UTxO design and usage from projects, asset to addresses map can be infinite. Thus, for a small subset of active projects
+        with millions of transactions, these might end up with timeouts (HTTP code 504) on free layer. Such large-scale projects are free to subscribe to
         query layers to have a dedicated cache table for themselves served via Koios.`
       operationId: policy_asset_addresses
   /policy_asset_info: #RPC
@@ -1442,7 +1442,7 @@ paths:
       operationId: drep_history
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_voting_power_history: #RPC
     get:
       tags:
@@ -1491,7 +1491,7 @@ paths:
       operationId: drep_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
+          label: "Deprecated"
   /drep_delegators: #RPC
     get:
       tags:
@@ -1645,7 +1645,7 @@ paths:
   /vote_list: #RPC
     get:
       tags:
-        - Governance      
+        - Governance
       responses:
         "200":
           description: Success!!
@@ -1979,8 +1979,8 @@ paths:
       operationId: pool_votes
       x-badges:
         - color: red
-          label: 'Deprecated'
-  
+          label: "Deprecated"
+
   /pool_groups: #RPC
     get:
       tags:
@@ -2198,7 +2198,7 @@ paths:
         We do support transparent forwarding for various methods from Ogmios, you can read about those <a href="#tag--Ogmios">here</a>.
         </div>
       operationId: ogmios
-        
+
 components:
   #!params!#
   #!requestBodies!#


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Formats the API specs so that everything uses double quotes, removes trailing whitespaces etc.

Updates the `createspecs.py` to automatically detect the correct indentation so that individual spec placeholder files can be correctly indented, e.g. `2-api-params.yaml` can use the regular two space indentation now:

```
parameters:
  _after_block_height:
    ...
```

```
parameters:
    _after_block_height:
      ...
```

