### PR TITLE
Proposal list spec change to use array for withdrawal information

### DIFF
--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -893,7 +893,7 @@ BEGIN
                     ),
                     'amount', tw.amount::text
                   ))::jsonb, '[]'::jsonb)
-                  FROM public.treasury_withdrawal tw where tw.gov_action_proposal_id = gap.id),
+                  FROM public.treasury_withdrawal tw WHERE tw.gov_action_proposal_id = gap.id),
               'param_proposal', CASE
                 WHEN pp.id IS NULL THEN NULL
                 ELSE ( SELECT JSONB_STRIP_NULLS(TO_JSONB(pp.*)) - array['id','registered_tx_id','epoch_no'] )

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -3082,10 +3082,8 @@ schemas:
         meta_is_valid:
           $ref: "#/components/schemas/drep_metadata/items/properties/is_valid"
         withdrawal:
-          anyOf:
-            - type: array
-            - type: "null"
-          description: If not null, the array of amounts withdrawn from treasury into specified stake addresses by this proposal
+          type: array
+          description: The array of amounts withdrawn from treasury into specified stake addresses by this proposal
           items:
             properties:
               stake_address:

--- a/specs/templates/4-api-schemas.yaml
+++ b/specs/templates/4-api-schemas.yaml
@@ -3044,25 +3044,25 @@ schemas:
           anyOf:
             - type: number
             - type: "null"
-          description: If not null, then this proposal has been ratified at the specfied epoch.
+          description: If not null, then this proposal has been ratified at the specified epoch.
           example: 670
         enacted_epoch:
           anyOf:
             - type: number
             - type: "null"
-          description: If not null, then this proposal has been enacted at the specfied epoch.
+          description: If not null, then this proposal has been enacted at the specified epoch.
           example: 675
         dropped_epoch:
           anyOf:
             - type: number
             - type: "null"
-          description: If not null, then this proposal has been dropped (expired/enacted) at the specfied epoch.
+          description: If not null, then this proposal has been dropped (expired/enacted) at the specified epoch.
           example: 680
         expired_epoch:
           anyOf:
             - type: number
             - type: "null"
-          description: If not null, then this proposal has been expired at the specfied epoch.
+          description: If not null, then this proposal has been expired at the specified epoch.
           example: 680
         expiration:
           anyOf:
@@ -3083,15 +3083,16 @@ schemas:
           $ref: "#/components/schemas/drep_metadata/items/properties/is_valid"
         withdrawal:
           anyOf:
-            - type: object
+            - type: array
             - type: "null"
-          description: If not null, the amount withdrawn from treasury into stake address by this this proposal
-          properties:
-            stake_address:
-              $ref: "#/components/schemas/account_history/items/properties/stake_address"
-            amount:
-              type: string
-              example: "31235800000"
+          description: If not null, the array of amounts withdrawn from treasury into specified stake addresses by this proposal
+          items:
+            properties:
+              stake_address:
+                $ref: "#/components/schemas/account_history/items/properties/stake_address"
+              amount:
+                type: string
+                example: "31235800000"
         param_proposal:
           description: If not null, the proposed new parameter set
           anyOf:


### PR DESCRIPTION
## Description
withdrawal information for gov action is now always an array instead of null or array; 

updated tx_info endpoint's _governance output building to use json array syntax to match earlier change to proposal_list endpoint

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
