### PR TITLE
fix: average block reward for epoch insert

### DIFF
--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -119,7 +119,7 @@ BEGIN
         ELSE NULL
       END AS i_total_rewards,
       CASE -- populated in epoch n + 2
-        WHEN e.no <= _curr_epoch THEN ROUND(reward_pot.amount / e.blk_count)
+        WHEN e.no <= _curr_epoch - 2 THEN ROUND(reward_pot.amount / e.blk_count)
         ELSE NULL
       END AS i_avg_blk_reward,
       (


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Epoch info cache rule for average block reward insert was wrong - should follow the same insert rule as total_rewards.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
Closes #371
