### PR TITLE
Pool info cache fixes

### DIFF
--- a/files/grest/rpc/01_cached_tables/pool_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_info_cache.sql
@@ -63,7 +63,7 @@ BEGIN
         pr.hash_id = pu.hash_id AND
         pr.announced_tx_id > pu.registered_tx_id
       WHERE pu.registered_tx_id > _pool_info_cache_last_tx_id
-      ORDER BY hash_id, registered_tx_id, cert_index DESC
+      ORDER BY hash_id, registered_tx_id DESC, cert_index DESC
     )
 
     INSERT INTO grest.pool_info_cache (

--- a/files/grest/rpc/01_cached_tables/pool_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_info_cache.sql
@@ -198,7 +198,7 @@ BEGIN
 
   Raise NOTICE 'Last pool info cache was % blocks ago...', _last_update_block_diff;
     IF (
-      _last_update_block_diff >= 45 
+      _last_update_block_diff >= 1
       OR _last_update_block_diff < 0 -- Special case for db-sync restart rollback to epoch start
     ) THEN
       RAISE NOTICE 'Re-running...';

--- a/files/grest/rpc/pool/pool_calidus_keys.sql
+++ b/files/grest/rpc/pool/pool_calidus_keys.sql
@@ -48,7 +48,6 @@ AS $$
       AND (tm.json->>'0') IN ('2','3') -- Filter for records using CIP-0088 version 2 (and placeholder 3)
       AND (tm.json->'1'->'1'->>0) ='1' -- Filter for Pool ID registrations only
       AND (tm.json->'1'->'3'->>0) = '2' -- Ensure Signature validation method is CIP-0008
-    ORDER BY tm.id DESC, pic.tx_id DESC
   ) AS x
   WHERE is_valid=true
     AND length(x.calidus_key)=64

--- a/files/grest/rpc/pool/pool_calidus_keys.sql
+++ b/files/grest/rpc/pool/pool_calidus_keys.sql
@@ -48,7 +48,7 @@ AS $$
       AND (tm.json->>'0') IN ('2','3') -- Filter for records using CIP-0088 version 2 (and placeholder 3)
       AND (tm.json->'1'->'1'->>0) ='1' -- Filter for Pool ID registrations only
       AND (tm.json->'1'->'3'->>0) = '2' -- Ensure Signature validation method is CIP-0008
-    ORDER BY tm.id DESC
+    ORDER BY tm.id DESC, pic.tx_id DESC
   ) AS x
   WHERE is_valid=true
     AND length(x.calidus_key)=64

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -66,7 +66,7 @@ BEGIN
           pic.pool_hash_id,
           pic.tx_id DESC
       )
-    SELECT
+    SELECT DISTINCT ON (api.pool_id_bech32)
       api.pool_id_bech32::varchar,
       ENCODE(ph.hash_raw::bytea, 'hex') AS pool_id_hex,
       pu.active_epoch_no,

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -44,7 +44,7 @@ BEGIN
   RETURN QUERY
     WITH
       _all_pool_info AS (
-        SELECT DISTINCT ON (pic.pool_hash_id)
+        SELECT
           pic.pool_hash_id,
           pic.active_epoch_no,
           pic.update_id,
@@ -55,16 +55,9 @@ BEGIN
           ph.hash_raw
         FROM grest.pool_info_cache AS pic
         INNER JOIN public.pool_hash AS ph ON ph.id = pic.pool_hash_id
-        -- consider only activated updates or all updates if none were activated so far
-            AND ( (pic.active_epoch_no <= _epoch_no)
-            OR ( NOT EXISTS (SELECT 1 from grest.pool_info_cache AS pic2 where pic2.pool_hash_id = pic.pool_hash_id
-                AND pic2.active_epoch_no <= _epoch_no) ) )
         WHERE ph.hash_raw = ANY(
           SELECT cardano.bech32_decode_data(p)
           FROM UNNEST(_pool_bech32_ids) AS p)
-        ORDER BY
-          pic.pool_hash_id,
-          pic.tx_id DESC
       )
     SELECT DISTINCT ON (api.pool_id_bech32)
       api.pool_id_bech32::varchar,

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -63,7 +63,6 @@ AS $$
     LEFT JOIN public.off_chain_pool_data AS ocpd ON ocpd.pmr_id = pic.meta_id
   ORDER BY
     pic.pool_hash_id,
-    pic.tx_id DESC,
     pasc.epoch_no DESC
   ;
 $$;


### PR DESCRIPTION
## Description
This PR fixes a couple of different issues found around pool data.

1. Issue mentioned in #381 fixed by correct descending ordering of registered_tx_id column for pool_info_cache insertion.
2. pool_calidus_keys was missing an ordering on pool_info_cache, needs to grab latest entry from this cache table.
3. pool_info need a distinct select due to a DBSync bug not yet having a bug fix deployed. Can be removed later when fix is deployed but doesn't cause any negative impact even after fix is applied. https://github.com/IntersectMBO/cardano-db-sync/issues/1986

## Which issue it fixes?
#381
