### PR TITLE
Changes to endpoints to utilize pool_stat (now core) table instead of…

### DIFF
--- a/files/grest/rpc/00_cached_tables/active_stake_cache.sql
+++ b/files/grest/rpc/00_cached_tables/active_stake_cache.sql
@@ -1,9 +1,4 @@
-CREATE TABLE IF NOT EXISTS grest.pool_active_stake_cache (
-  pool_id bigint NOT NULL,
-  epoch_no bigint NOT NULL,
-  amount lovelace NOT NULL,
-  PRIMARY KEY (pool_id, epoch_no)
-);
+DELETE TABLE IF EXISTS grest.pool_active_stake_cache;
 
 CREATE TABLE IF NOT EXISTS grest.epoch_active_stake_cache (
   epoch_no bigint NOT NULL,
@@ -63,28 +58,6 @@ BEGIN
       (SELECT last_value::integer
         FROM grest.control_table
         WHERE key = 'last_active_stake_validated_epoch'), _epoch_no - 3) INTO _last_active_stake_validated_epoch;
-    -- POOL ACTIVE STAKE CACHE
-    INSERT INTO grest.pool_active_stake_cache
-      SELECT
-        epoch_stake.pool_id AS pool_id,
-        epoch_stake.epoch_no,
-        SUM(epoch_stake.amount) AS amount
-      FROM public.epoch_stake
-      WHERE epoch_stake.epoch_no >= _last_active_stake_validated_epoch
-        AND epoch_stake.epoch_no <= _epoch_no
-      GROUP BY
-        epoch_stake.pool_id,
-        epoch_stake.epoch_no
-    ON CONFLICT (
-      pool_id,
-      epoch_no
-    ) DO UPDATE
-      SET amount = excluded.amount
-      WHERE pool_active_stake_cache.amount IS DISTINCT FROM excluded.amount;
-    
-    -- Active stake older than active stake can already be captured from pool history cache
-    DELETE FROM grest.pool_active_stake_cache
-      WHERE epoch_no < _last_active_stake_validated_epoch;
 
     -- EPOCH ACTIVE STAKE CACHE
     INSERT INTO grest.epoch_active_stake_cache
@@ -107,4 +80,4 @@ BEGIN
   END;
 $$;
 
-COMMENT ON FUNCTION grest.active_stake_cache_update IS 'Internal function to update active stake cache (epoch, pool, and account tables).'; -- noqa: LT01
+COMMENT ON FUNCTION grest.active_stake_cache_update IS 'Internal function to update active stake cache (epoch).'; -- noqa: LT01

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -128,10 +128,10 @@ BEGIN
       LIMIT 1
     ) AS block_data ON TRUE
     LEFT JOIN LATERAL(
-      SELECT amount::lovelace AS as_sum
-      FROM grest.pool_active_stake_cache AS pasc
-      WHERE pasc.pool_id = api.pool_hash_id
-        AND pasc.epoch_no = _epoch_no
+      SELECT stake::lovelace AS as_sum
+      FROM pool_stat AS pstat
+      WHERE pstat.pool_hash_id = api.pool_hash_id
+        AND pstat.epoch_no = (_epoch_no - 1)
     ) AS active_stake ON TRUE
     LEFT JOIN LATERAL(
       SELECT amount::lovelace AS es_sum

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -51,18 +51,18 @@ AS $$
     pmr.url AS meta_url,
     pmr.hash AS meta_hash,
     pic.pool_status,
-    pasc.amount::text AS active_stake,
+    pstat.stake::text AS active_stake,
     pic.retiring_epoch
   FROM grest.pool_info_cache AS pic
     INNER JOIN public.pool_hash AS ph ON ph.id = pic.pool_hash_id
     LEFT JOIN grest.pool_groups AS pgrp ON pgrp.pool_id_bech32 = ph.view
-    LEFT JOIN grest.pool_active_stake_cache AS pasc ON pasc.pool_id = pic.pool_hash_id
+    LEFT JOIN pool_stat AS pstat ON pstat.pool_hash_id = pic.pool_hash_id AND pstat.epoch_no < (select max(no) from epoch) AND pstat.epoch_no > (select max(no) - 3 from epoch)
     LEFT JOIN public.pool_update AS pu ON pu.id = pic.update_id
     LEFT JOIN public.stake_address AS sa ON pu.reward_addr_id = sa.id
     LEFT JOIN public.pool_metadata_ref AS pmr ON pmr.id = pic.meta_id
     LEFT JOIN public.off_chain_pool_data AS ocpd ON ocpd.pmr_id = pic.meta_id
   ORDER BY
     pic.pool_hash_id,
-    pasc.epoch_no DESC
+    pstat.epoch_no DESC
   ;
 $$;

--- a/files/grest/rpc/pool/pool_stake_snapshot.sql
+++ b/files/grest/rpc/pool/pool_stake_snapshot.sql
@@ -22,22 +22,22 @@ BEGIN
   RETURN QUERY
   SELECT
     CASE
-      WHEN (pasc.epoch_no = _mark) THEN 'Mark'
-      WHEN (pasc.epoch_no = _set)  THEN 'Set'
+      WHEN (easc.epoch_no = _mark) THEN 'Mark'
+      WHEN (easc.epoch_no = _set)  THEN 'Set'
       ELSE 'Go'
     END AS snapshot,
-    pasc.epoch_no,
+    easc.epoch_no,
     eic.p_nonce,
-    pasc.amount::text,
+    pstat.stake::text,
     easc.amount::text
   FROM
-    grest.pool_active_stake_cache AS pasc
-    INNER JOIN grest.epoch_active_stake_cache AS easc ON easc.epoch_no = pasc.epoch_no
-    LEFT JOIN grest.epoch_info_cache AS eic ON eic.epoch_no = pasc.epoch_no
-  WHERE pasc.pool_id = (SELECT id FROM pool_hash AS ph WHERE ph.hash_raw = cardano.bech32_decode_data(_pool_bech32))
-    AND pasc.epoch_no BETWEEN _go AND _mark
+    grest.epoch_active_stake_cache AS easc
+    INNER JOIN pool_stat AS pstat on (easc.epoch_no - 1) = pstat.epoch_no
+    LEFT JOIN grest.epoch_info_cache AS eic ON eic.epoch_no = easc.epoch_no
+  WHERE pstat.pool_id = (SELECT id FROM pool_hash AS ph WHERE ph.hash_raw = cardano.bech32_decode_data(_pool_bech32))
+    AND easc.epoch_no BETWEEN _go AND _mark
   ORDER BY
-    pasc.epoch_no;
+    easc.epoch_no;
 END;
 $$;
 


### PR DESCRIPTION

## Description
First set of changes to make use of out-of-the-box pool_stat table instead of relying on grest.pool_active_stake_cache.
Once these are reviewed and tested we can have a go at disabling the logic associated with that cache population and anything that depends on it (e.g. currently it is responsible for keeping a control_table record updated that at least one other cron job/cache depends on)



## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
